### PR TITLE
remove --cov=chemsmart in Makefile   

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ lint:             ## Run pep8, black linters.
 
 .PHONY: test
 test: lint        ## Run tests and generate coverage report.
-	$(ENV_PREFIX)pytest -v --cov-config .coveragerc --cov=chemsmart -l --tb=short --maxfail=1 tests/
+	$(ENV_PREFIX)pytest -v --cov-config .coveragerc -l --tb=short --maxfail=1 tests/
 	$(ENV_PREFIX)coverage xml
 	$(ENV_PREFIX)coverage html
 


### PR DESCRIPTION
`  --cov=[SOURCE]` specifies Path or package name to measure during execution (multi-allowed). Use --cov= to not do any source filtering and record everything.