### PR TITLE
added  cmp_with_ignore() function to utils.utils.py

### DIFF
--- a/chemsmart/utils/utils.py
+++ b/chemsmart/utils/utils.py
@@ -2,6 +2,7 @@ import copy
 import hashlib
 import os
 import re
+import stat
 import time
 from functools import lru_cache, wraps
 from itertools import groupby
@@ -430,3 +431,51 @@ def check_charge_and_multiplicity(settings):
         raise ValueError(
             "Charge and multiplicity must be set for Gaussian jobs."
         )
+
+
+def cmp_with_ignore(f1, f2, shallow=True, ignore_string=None):
+    """
+    Compare two files with an option to ignore lines containing a specific string.
+
+    Arguments:
+    f1 -- First file name
+    f2 -- Second file name
+    shallow -- Treat files as identical if their stat signatures are identical. [default: True]
+    ignore_string -- Ignore lines containing this string during content comparison. [default: None]
+                  -- If None, defaults to original filecmp.cmp() behavior.
+
+    Returns:
+    True if the files are the same, False otherwise.
+    """
+
+    def _sig(st):
+        return (stat.S_IFMT(st.st_mode), st.st_size, st.st_mtime)
+
+    def _do_cmp_with_ignore(f1, f2, ignore_string):
+        with open(f1, "r") as fp1, open(f2, "r") as fp2:
+            for line1, line2 in zip(fp1, fp2):
+                # Skip lines containing the ignore_string
+                if ignore_string and (
+                    ignore_string in line1 and ignore_string in line2
+                ):
+                    continue
+                # Compare the current lines
+                if line1 != line2:
+                    return False
+            # Ensure both files have reached EOF (no extra lines in one file)
+            return fp1.read() == fp2.read()
+
+    # Perform the shallow comparison
+    # Uses file stats (os.stat()) to quickly determine if the files can be treated
+    # as identical without reading their contents.
+    s1 = _sig(os.stat(f1))
+    s2 = _sig(os.stat(f2))
+    if s1[0] != stat.S_IFREG or s2[0] != stat.S_IFREG:
+        return False
+    if shallow and s1 == s2:
+        return True
+    if s1[1] != s2[1]:
+        return False
+
+    # Perform deep comparison with line filtering
+    return _do_cmp_with_ignore(f1, f2, ignore_string)

--- a/tests/test_GaussianWriter.py
+++ b/tests/test_GaussianWriter.py
@@ -1,4 +1,3 @@
-import filecmp
 import os
 from filecmp import cmp
 from shutil import copy
@@ -15,6 +14,7 @@ from chemsmart.jobs.gaussian import (
 from chemsmart.jobs.gaussian.settings import GaussianJobSettings
 from chemsmart.jobs.gaussian.writer import GaussianInputWriter
 from chemsmart.settings.gaussian import GaussianProjectSettings
+from chemsmart.utils.utils import cmp_with_ignore
 
 
 class TestGaussianInputWriter:
@@ -400,13 +400,14 @@ class TestGaussianInputWriter:
         g16_file = os.path.join(
             tmpdir, "gaussian_sp_from_log_with_custom_basis_from_api.com"
         )
-        assert os.path.isfile(g16_file)
-        # somehow the cmp function fails on Github action
-        filecmp.clear_cache()
-        assert cmp(
+
+        # compare the written input file with the expected input file, except
+        # the line containing the version number (basis set exchange api may be different)
+        assert cmp_with_ignore(
             g16_file,
             gaussian_written_sp_from_nhc_singlet_log_with_custom_basis_from_api_file,
             shallow=False,
+            ignore_string="Version",
         )
 
     def test_write_modred_with_custom_basis_for_all_elements_in_structure_using_api(
@@ -462,12 +463,14 @@ class TestGaussianInputWriter:
             "gaussian_modred_with_custom_basis_for_all_atoms_from_api.com",
         )
         assert os.path.isfile(g16_file)
-        # somehow the cmp function fails on Github action
-        filecmp.clear_cache()
-        assert cmp(
+
+        # compare the written input file with the expected input file, except
+        # the line containing the version number (basis set exchange api may be different)
+        assert cmp_with_ignore(
             g16_file,
             gaussian_modred_with_custom_basis_for_all_atoms_from_api,
             shallow=False,
+            ignore_string="Version",
         )
 
     def test_write_gaussian_input_from_pbc_logfile(


### PR DESCRIPTION
Compare two files with an option to ignore lines containing a specific string, e.g., different basis set exchange api version used to get basis set from [basis set exchange](https://www.basissetexchange.org/)