### PR TITLE
fix: fix basis set with - 

### DIFF
--- a/chemsmart/jobs/gaussian/writer.py
+++ b/chemsmart/jobs/gaussian/writer.py
@@ -81,9 +81,18 @@ class GaussianInputWriter(InputWriter):
                 # returns empty list if no heavy elements found in structure
                 # (heavy elements specified in settings)
             ):
+                # first remove any '-' in light_elements_basis
+                # this is because '-' is needed by bse package to get the right
+                # basis set from https://www.basissetexchange.org/, eg, def2-SVP
+                # but this is not needed in Gaussian input file
+                # (will cause error when run), eg, def2svp
+                light_elements_basis = (
+                    self.settings.light_elements_basis.replace("-", "").lower()
+                )
+
                 route_string = route_string.replace(
                     self.settings.basis,
-                    self.settings.light_elements_basis,
+                    light_elements_basis,
                 )
         f.write(route_string + "\n")
         f.write("\n")


### PR DESCRIPTION
when project settings has heavy elements but molecule has not, e.g, using mixed basis set for DFT simulation for systems containing heavy elements, (eg, Pd, Ag etc), but also need to use the same project settings to run molecules without heavy elements, eg, olefin substrate for the system