### PR TITLE
downgrade rdkit from 2024.9.5 to 2024.3.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "pytest~=8.3.4",
     "pyyaml",
     "pymatgen==2025.1.24",
-    "rdkit==2024.9.5",
+    "rdkit==2024.3.2",
     "scipy==1.15.1",
     "setuptools>=70.1.1",
     "tomlkit==0.13.2",


### PR DESCRIPTION
RDKit 2024.9.5 causes following error when running `make install`:

> ERROR: Could not find a version that satisfies the requirement rdkit==2024.9.5 (from chemsmart) (from versions: 2022.3.3, 2022.3.4, 2022.3.5, 2022.9.1, 2022.9.2, 2022.9.3, 2022.9.4, 2022.9.5, 2023.3.1, 2023.3.2, 2023.3.3, 2023.9.1, 2023.9.2, 2023.9.3, 2023.9.4, 2023.9.5, 2023.9.6, 2024.3.1, 2024.3.2)
> ERROR: No matching distribution found for rdkit==2024.9.5
> 
> ERROR conda.cli.main_run:execute(125): `conda run pip install -e .[test]` failed. (See above for error)

This may be due to that rdkit module is still not available at this version via pip, thus we will use 2024.3.2 at the moment, to make sure that `make install` runs correctly to install all dependencies of `chemsmart`.