### PR TITLE
fix: use -N flag for num conformers for crest job as -n is used for num st…

### DIFF
--- a/chemsmart/cli/gaussian/crest.py
+++ b/chemsmart/cli/gaussian/crest.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 @click_job_options
 @click_gaussian_jobtype_options
 @click.option(
-    "-n",
+    "-N",
     "--num-confs-to-run",
     type=int,
     default=None,


### PR DESCRIPTION
…eps if scan job is required