### PR TITLE
feat: added features to allow specification of values for .pml files via CLI options

### DIFF
--- a/chemsmart/cli/mol/mo.py
+++ b/chemsmart/cli/mol/mo.py
@@ -35,6 +35,7 @@ def mo(
     lumo,
     isosurface_value,
     transparency_value,
+    surface_quality,
     antialias_value,
     ray_trace_mode,
     skip_completed,
@@ -67,18 +68,6 @@ def mo(
             )
     from chemsmart.jobs.mol.mo import PyMOLMOJob
 
-    # get jobrunner for running Gaussian IRC jobs
-    jobrunner = ctx.obj["jobrunner"]
-    logger.debug(f"Jobrunner for MO job: {jobrunner}")
-    if isosurface_value is not None:
-        jobrunner.isosurface_value = isosurface_value
-    if transparency_value is not None:
-        jobrunner.transparency_value = transparency_value
-    if antialias_value is not None:
-        jobrunner.antialias_value = antialias_value
-    if ray_trace_mode is not None:
-        jobrunner.ray_trace_mode = ray_trace_mode
-
     return PyMOLMOJob(
         molecule=molecules,
         label=label,
@@ -92,7 +81,11 @@ def mo(
         number=number,
         homo=homo,
         lumo=lumo,
-        jobrunner=jobrunner,
+        isosurface_value=isosurface_value,
+        transparency_value=transparency_value,
+        surface_quality=surface_quality,
+        antialias_value=antialias_value,
+        ray_trace_mode=ray_trace_mode,
         skip_completed=skip_completed,
         **kwargs,
     )

--- a/chemsmart/cli/mol/mo.py
+++ b/chemsmart/cli/mol/mo.py
@@ -6,6 +6,7 @@ import click
 from chemsmart.cli.job import click_job_options
 from chemsmart.cli.mol.mol import (
     click_pymol_mo_options,
+    click_pymol_pml_options,
     click_pymol_visualization_options,
     mol,
 )
@@ -18,6 +19,7 @@ logger = logging.getLogger(__name__)
 @click_job_options
 @click_pymol_visualization_options
 @click_pymol_mo_options
+@click_pymol_pml_options
 @click.pass_context
 def mo(
     ctx,
@@ -31,6 +33,10 @@ def mo(
     number,
     homo,
     lumo,
+    isosurface_value,
+    transparency_value,
+    antialias_value,
+    ray_trace_mode,
     skip_completed,
     **kwargs,
 ):
@@ -61,6 +67,18 @@ def mo(
             )
     from chemsmart.jobs.mol.mo import PyMOLMOJob
 
+    # get jobrunner for running Gaussian IRC jobs
+    jobrunner = ctx.obj["jobrunner"]
+    logger.debug(f"Jobrunner for MO job: {jobrunner}")
+    if isosurface_value is not None:
+        jobrunner.isosurface_value = isosurface_value
+    if transparency_value is not None:
+        jobrunner.transparency_value = transparency_value
+    if antialias_value is not None:
+        jobrunner.antialias_value = antialias_value
+    if ray_trace_mode is not None:
+        jobrunner.ray_trace_mode = ray_trace_mode
+
     return PyMOLMOJob(
         molecule=molecules,
         label=label,
@@ -74,6 +92,7 @@ def mo(
         number=number,
         homo=homo,
         lumo=lumo,
+        jobrunner=jobrunner,
         skip_completed=skip_completed,
         **kwargs,
     )

--- a/chemsmart/cli/mol/mol.py
+++ b/chemsmart/cli/mol/mol.py
@@ -116,7 +116,7 @@ def click_pymol_nci_options(f):
 
     @click.option(
         "-i",
-        "--isosurface",
+        "--isosurface-value",
         type=float,
         default=0.5,
         help="Isosurface value for NCI plot. Default=0.5",
@@ -130,13 +130,13 @@ def click_pymol_nci_options(f):
     )
     @click.option(
         "-b",
-        "--binary",
+        "--binary/--no-binary",
         is_flag=True,
         default=False,
         help="Plot NCI plots with two colors only. Default to False.",
     )
     @click.option(
-        "--intermediate",
+        "--intermediate/--no-intermediate",
         is_flag=True,
         default=False,
         help="Plot NCI plots with intermediate range colors. Default to "
@@ -184,19 +184,17 @@ def click_pymol_mo_options(f):
 
 
 def click_pymol_pml_options(f):
-    """Common click options for PyMOL .pml files.
-    Note that all single-letter flags here use
-    capital letter, to distinguish from other options."""
+    """Common click options for PyMOL .pml files."""
 
     @click.option(
-        "-I",
+        "-i",
         "--isosurface-value",
         type=float,
         default=None,
         help="Set isosurface value to be used in PyMOL .pml file.",
     )
     @click.option(
-        "-T",
+        "-tv",
         "--transparency-value",
         type=float,
         default=None,
@@ -204,7 +202,7 @@ def click_pymol_pml_options(f):
         "Value range: 0.0 – 1.0; 0.0 = fully opaque; 1.0 = fully transparent",
     )
     @click.option(
-        "-Q",
+        "-sq",
         "--surface-quality",
         type=int,
         default=None,
@@ -217,7 +215,7 @@ def click_pymol_pml_options(f):
         " 4 → Ultra quality (maximum smoothness, may be very slow)",
     )
     @click.option(
-        "-A",
+        "-a",
         "--antialias-value",
         type=int,
         default=None,
@@ -228,7 +226,7 @@ def click_pymol_pml_options(f):
         "Some builds allow up to 4.",
     )
     @click.option(
-        "-M",
+        "-m",
         "--ray-trace-mode",
         type=int,
         default=None,

--- a/chemsmart/cli/mol/mol.py
+++ b/chemsmart/cli/mol/mol.py
@@ -118,7 +118,7 @@ def click_pymol_nci_options(f):
         "-i",
         "--isosurface-value",
         type=float,
-        default=0.5,
+        default=None,
         help="Isosurface value for NCI plot. Default=0.5",
     )
     @click.option(

--- a/chemsmart/cli/mol/mol.py
+++ b/chemsmart/cli/mol/mol.py
@@ -204,6 +204,19 @@ def click_pymol_pml_options(f):
         "Value range: 0.0 – 1.0; 0.0 = fully opaque; 1.0 = fully transparent",
     )
     @click.option(
+        "-Q",
+        "--surface-quality",
+        type=int,
+        default=None,
+        help="Set surface quality in PyMOL .pml file. Controls the "
+        "quality of molecular surfaces. Higher values yield smoother "
+        "surfaces but may increase rendering time. 0 → Low quality "
+        "(fast, faceted surfaces); 1 → Medium quality (balanced); "
+        "2 → High quality (smooth surfaces, slower rendering); "
+        "3 → Very high quality (very smooth, longest rendering time);"
+        " 4 → Ultra quality (maximum smoothness, may be very slow)",
+    )
+    @click.option(
         "-A",
         "--antialias-value",
         type=int,

--- a/chemsmart/cli/mol/mol.py
+++ b/chemsmart/cli/mol/mol.py
@@ -183,6 +183,55 @@ def click_pymol_mo_options(f):
     return wrapper_common_options
 
 
+def click_pymol_pml_options(f):
+    """Common click options for PyMOL .pml files."""
+
+    @click.option(
+        "-i",
+        "--isosurface-value",
+        type=float,
+        default=None,
+        help="Set isosurface value to be used in PyMOL .pml file.",
+    )
+    @click.option(
+        "-t",
+        "--transparency-value",
+        type=int,
+        default=None,
+        help="Set transparency value to be used in PyMOL .pml file."
+        "Value range: 0.0 – 1.0; 0.0 = fully opaque; 1.0 = fully transparent",
+    )
+    @click.option(
+        "-a",
+        "--antialias-value",
+        type=int,
+        default=None,
+        help="Set antialias value in PyMOL .pml file. Controls smoothing of edges "
+        "in the 3D rendering (anti-aliasing). Helps remove jagged edges, "
+        "especially useful for high-quality figures. 0 → Off (fast, jagged edges);"
+        "1 → On (basic anti-aliasing); 2 → Higher quality anti-aliasing."
+        "Some builds allow up to 4.",
+    )
+    @click.option(
+        "-m",
+        "--ray-trace-mode",
+        type=int,
+        default=None,
+        help="Set ray trace mode in PyMOL .pml file. Controls quality "
+        "of ray-traced images. Higher values yield better quality "
+        "but take longer to render. 0 → Normal shading (standard "
+        "photorealistic render); 1 → Cartoon/line outlines (black "
+        "outlines around objects, like cell-shading); 2 → Black "
+        "outline only (no shading, wireframe-like appearance); "
+        "3 → White outline mode (for figures on dark backgrounds)",
+    )
+    @functools.wraps(f)
+    def wrapper_common_options(*args, **kwargs):
+        return f(*args, **kwargs)
+
+    return wrapper_common_options
+
+
 def click_pymol_save_options(f):
     """Common click options for PyMOL save options."""
 

--- a/chemsmart/cli/mol/mol.py
+++ b/chemsmart/cli/mol/mol.py
@@ -184,17 +184,19 @@ def click_pymol_mo_options(f):
 
 
 def click_pymol_pml_options(f):
-    """Common click options for PyMOL .pml files."""
+    """Common click options for PyMOL .pml files.
+    Note that all single-letter flags here use
+    capital letter, to distinguish from other options."""
 
     @click.option(
-        "-i",
+        "-I",
         "--isosurface-value",
         type=float,
         default=None,
         help="Set isosurface value to be used in PyMOL .pml file.",
     )
     @click.option(
-        "-t",
+        "-T",
         "--transparency-value",
         type=int,
         default=None,
@@ -202,7 +204,7 @@ def click_pymol_pml_options(f):
         "Value range: 0.0 – 1.0; 0.0 = fully opaque; 1.0 = fully transparent",
     )
     @click.option(
-        "-a",
+        "-A",
         "--antialias-value",
         type=int,
         default=None,
@@ -213,7 +215,7 @@ def click_pymol_pml_options(f):
         "Some builds allow up to 4.",
     )
     @click.option(
-        "-m",
+        "-M",
         "--ray-trace-mode",
         type=int,
         default=None,

--- a/chemsmart/cli/mol/mol.py
+++ b/chemsmart/cli/mol/mol.py
@@ -198,7 +198,7 @@ def click_pymol_pml_options(f):
     @click.option(
         "-T",
         "--transparency-value",
-        type=int,
+        type=float,
         default=None,
         help="Set transparency value to be used in PyMOL .pml file."
         "Value range: 0.0 – 1.0; 0.0 = fully opaque; 1.0 = fully transparent",

--- a/chemsmart/cli/mol/nci.py
+++ b/chemsmart/cli/mol/nci.py
@@ -28,7 +28,7 @@ def nci(
     quiet,
     command_line_only,
     coordinates,
-    isosurface,
+    isosurface_value,
     color_range,
     binary,
     intermediate,
@@ -68,7 +68,7 @@ def nci(
     return PyMOLNCIJob(
         molecule=molecules,
         label=label,
-        isosurface=isosurface,
+        isosurface_value=isosurface_value,
         color_range=color_range,
         binary=binary,
         intermediate=intermediate,

--- a/chemsmart/cli/mol/spin.py
+++ b/chemsmart/cli/mol/spin.py
@@ -4,7 +4,11 @@ import logging
 import click
 
 from chemsmart.cli.job import click_job_options
-from chemsmart.cli.mol.mol import click_pymol_visualization_options, mol
+from chemsmart.cli.mol.mol import (
+    click_pymol_pml_options,
+    click_pymol_visualization_options,
+    mol,
+)
 from chemsmart.utils.cli import MyCommand
 
 logger = logging.getLogger(__name__)
@@ -13,6 +17,7 @@ logger = logging.getLogger(__name__)
 @mol.command("spin", cls=MyCommand)
 @click_job_options
 @click_pymol_visualization_options
+@click_pymol_pml_options
 @click.pass_context
 def spin(
     ctx,
@@ -23,6 +28,11 @@ def spin(
     quiet,
     command_line_only,
     coordinates,
+    isosurface_value,
+    transparency_value,
+    surface_quality,
+    antialias_value,
+    ray_trace_mode,
     skip_completed,
     **kwargs,
 ):
@@ -65,6 +75,11 @@ def spin(
         quiet_mode=quiet,
         command_line_only=command_line_only,
         coordinates=coordinates,
+        isosurface_value=isosurface_value,
+        transparency_value=transparency_value,
+        surface_quality=surface_quality,
+        antialias_value=antialias_value,
+        ray_trace_mode=ray_trace_mode,
         skip_completed=skip_completed,
         **kwargs,
     )

--- a/chemsmart/jobs/mol/job.py
+++ b/chemsmart/jobs/mol/job.py
@@ -54,6 +54,10 @@ class PyMOLJob(Job):
         quiet_mode=True,
         command_line_only=True,
         coordinates=None,
+        isosurface_value=None,
+        transparency_value=None,
+        antialias_value=None,
+        ray_trace_mode=None,
         **kwargs,
     ):
         """
@@ -73,6 +77,10 @@ class PyMOLJob(Job):
             quiet_mode: Run PyMOL in quiet mode (default: True).
             command_line_only: Use command line interface only (default: True).
             coordinates: Coordinates for atom labeling (default: None).
+            isosurface_value: Isosurface value for NCI visualization (optional).
+            transparency_value: Transparency value for surfaces (optional).
+            antialias_value: Antialiasing level for rendering (optional).
+            ray_trace_mode: Ray tracing mode for rendering (optional).
             **kwargs: Additional arguments passed to parent Job class.
         """
         super().__init__(
@@ -85,6 +93,26 @@ class PyMOLJob(Job):
         self.quiet_mode = quiet_mode
         self.command_line_only = command_line_only
         self.coordinates = coordinates  # coordinates for labelling
+
+        # Set defaults for pml files
+        if isosurface_value is None:
+            isosurface_value = 0.05
+        if transparency_value is None:
+            transparency_value = 0.02
+        if antialias_value is None:
+            antialias_value = 2
+        if ray_trace_mode is None:
+            ray_trace_mode = 3
+
+        self.isosurface_value = isosurface_value
+        self.transparency_value = transparency_value
+        self.antialias_value = antialias_value
+        self.ray_trace_mode = ray_trace_mode
+
+        logger.debug(f"Isosurface value: {self.isosurface_value}")
+        logger.debug(f"Transparency value: {self.transparency_value}")
+        logger.debug(f"Antialias value: {self.antialias_value}")
+        logger.debug(f"Ray trace mode: {self.ray_trace_mode}")
 
     @property
     def inputfile(self):

--- a/chemsmart/jobs/mol/job.py
+++ b/chemsmart/jobs/mol/job.py
@@ -56,6 +56,7 @@ class PyMOLJob(Job):
         coordinates=None,
         isosurface_value=None,
         transparency_value=None,
+        surface_quality=None,
         antialias_value=None,
         ray_trace_mode=None,
         **kwargs,
@@ -79,6 +80,7 @@ class PyMOLJob(Job):
             coordinates: Coordinates for atom labeling (default: None).
             isosurface_value: Isosurface value for NCI visualization (optional).
             transparency_value: Transparency value for surfaces (optional).
+            surface_quality: Surface quality setting (optional).
             antialias_value: Antialiasing level for rendering (optional).
             ray_trace_mode: Ray tracing mode for rendering (optional).
             **kwargs: Additional arguments passed to parent Job class.
@@ -98,19 +100,23 @@ class PyMOLJob(Job):
         if isosurface_value is None:
             isosurface_value = 0.05
         if transparency_value is None:
-            transparency_value = 0.02
+            transparency_value = 0.2
+        if surface_quality is None:
+            surface_quality = 3
         if antialias_value is None:
-            antialias_value = 2
+            antialias_value = 3
         if ray_trace_mode is None:
-            ray_trace_mode = 3
+            ray_trace_mode = 1
 
         self.isosurface_value = isosurface_value
         self.transparency_value = transparency_value
+        self.surface_quality = surface_quality
         self.antialias_value = antialias_value
         self.ray_trace_mode = ray_trace_mode
 
         logger.debug(f"Isosurface value: {self.isosurface_value}")
         logger.debug(f"Transparency value: {self.transparency_value}")
+        logger.debug(f"Surface quality: {self.surface_quality}")
         logger.debug(f"Antialias value: {self.antialias_value}")
         logger.debug(f"Ray trace mode: {self.ray_trace_mode}")
 

--- a/chemsmart/jobs/mol/nci.py
+++ b/chemsmart/jobs/mol/nci.py
@@ -38,8 +38,8 @@ class PyMOLNCIJob(PyMOLJob):
         self,
         molecule,
         label,
-        isosurface_value=0.5,
-        color_range=1.0,
+        isosurface_value,
+        color_range,
         binary=False,
         intermediate=False,
         nci_basename=None,
@@ -67,6 +67,11 @@ class PyMOLNCIJob(PyMOLJob):
             label=label,
             **kwargs,
         )
+        # set defaults
+        if isosurface_value is None:
+            isosurface_value = 0.5
+        if color_range is None:
+            color_range = 1.0
         self.isosurface_value = isosurface_value
         self.color_range = color_range
         self.binary = binary

--- a/chemsmart/jobs/mol/nci.py
+++ b/chemsmart/jobs/mol/nci.py
@@ -23,7 +23,7 @@ class PyMOLNCIJob(PyMOLJob):
         TYPE (str): Job type identifier ('pymol_nci').
         molecule: Molecule object to analyze.
         label (str): Job identifier used for file naming and outputs.
-        isosurface (float): Isosurface value for NCI visualization.
+        isosurface_value (float): Isosurface value for NCI visualization.
         color_range (float): Range used for coloring the interaction map.
         binary (bool): Whether to use binary NCI analysis mode.
         intermediate (bool): Whether to use intermediate NCI mode.
@@ -38,7 +38,7 @@ class PyMOLNCIJob(PyMOLJob):
         self,
         molecule,
         label,
-        isosurface=0.5,
+        isosurface_value=0.5,
         color_range=1.0,
         binary=False,
         intermediate=False,
@@ -55,7 +55,7 @@ class PyMOLNCIJob(PyMOLJob):
         Args:
             molecule: Molecule object to analyze.
             label (str): Job identifier string.
-            isosurface (float): Isosurface level for NCI visualization (default 0.5).
+            isosurface_value (float): Isosurface level for NCI visualization (default 0.5).
             color_range (float): Color range for interaction mapping (default 1.0).
             binary (bool): Use binary NCI analysis mode (default False).
             intermediate (bool): Use intermediate NCI analysis mode (default False).
@@ -67,7 +67,7 @@ class PyMOLNCIJob(PyMOLJob):
             label=label,
             **kwargs,
         )
-        self.isosurface = isosurface
+        self.isosurface_value = isosurface_value
         self.color_range = color_range
         self.binary = binary
         self.intermediate = intermediate

--- a/chemsmart/jobs/mol/runner.py
+++ b/chemsmart/jobs/mol/runner.py
@@ -63,10 +63,6 @@ class PyMOLJobRunner(JobRunner):
     def __init__(
         self,
         server,
-        isosurface_value=None,
-        transparency_value=None,
-        antialias_value=None,
-        ray_trace_mode=None,
         scratch=None,
         fake=False,
         **kwargs,
@@ -80,10 +76,6 @@ class PyMOLJobRunner(JobRunner):
 
         Args:
             server: Server configuration for job execution.
-            isosurface_value: Isosurface value for NCI visualization (optional).
-            transparency_value: Transparency value for surfaces (optional).
-            antialias_value: Antialiasing level for rendering (optional).
-            ray_trace_mode: Ray tracing mode for rendering (optional).
             scratch: Whether to use scratch directories (default: None).
             fake: Whether this is a fake runner for testing (default: False).
             **kwargs: Additional arguments passed to parent JobRunner.
@@ -99,11 +91,6 @@ class PyMOLJobRunner(JobRunner):
         logger.debug(f"Jobrunner mem gb: {self.mem_gb}")
         logger.debug(f"Jobrunner num threads: {self.num_threads}")
         logger.debug(f"Jobrunner scratch: {self.scratch}")
-
-        self.isosurface_value = isosurface_value
-        self.transparency_value = transparency_value
-        self.antialias_value = antialias_value
-        self.ray_trace_mode = ray_trace_mode
 
     @property
     def executable(self):

--- a/chemsmart/jobs/mol/runner.py
+++ b/chemsmart/jobs/mol/runner.py
@@ -201,6 +201,8 @@ class PyMOLJobRunner(JobRunner):
         if job.isosurface_value is None and job.color_range is None:
             return dest_style_file
         else:
+            logger.debug(f"Job isosurface_value: {job.isosurface_value}")
+            logger.debug(f"Job color_range: {job.color_range}")
             return self._modify_job_pymol_script(job, dest_style_file)
 
     def _modify_job_pymol_script(self, job, style_file_path=None):

--- a/chemsmart/jobs/mol/runner.py
+++ b/chemsmart/jobs/mol/runner.py
@@ -1132,7 +1132,8 @@ class PyMOLMOJobRunner(PyMOLVisualizationJobRunner):
                 run_command(cubegen_command)
 
     def _write_molecular_orbital_pml(
-        self, job, isosurface=0.05, transparency=0.2
+        self,
+        job,
     ):
         """
         Write a PML script to visualize the MO isosurfaces.
@@ -1143,8 +1144,6 @@ class PyMOLMOJobRunner(PyMOLVisualizationJobRunner):
 
         Args:
             job: PyMOL MO job object.
-            isosurface (float): Isosurface value in a.u. (default 0.05).
-            transparency (float): Surface transparency (0–1, default 0.2).
         """
 
         pml_file = os.path.join(job.folder, f"{job.mo_basename}.pml")
@@ -1152,16 +1151,18 @@ class PyMOLMOJobRunner(PyMOLVisualizationJobRunner):
             with open(pml_file, "w") as f:
                 f.write(f"load {job.mo_basename}.cube\n")
                 f.write(
-                    f"isosurface pos_iso, {job.mo_basename}, {isosurface}\n"
+                    f"isosurface pos_iso, {job.mo_basename}, {job.isosurface}\n"
                 )
                 f.write(
-                    f"isosurface neg_iso, {job.mo_basename}, {-isosurface}\n"
+                    f"isosurface neg_iso, {job.mo_basename}, {-job.isosurface}\n"
                 )
                 f.write("print(pos_iso)\n")
                 f.write("print(neg_iso)\n")
                 f.write("set surface_color, blue, pos_iso\n")
                 f.write("set surface_color, red, neg_iso\n")
-                f.write(f"set transparency, {transparency}\n")
+                f.write(f"set transparency, {job.transparency}\n")
+                f.write(f"set surface_quality, {job.surface_quality}\n")
+                f.write(f"set antialias, {job.antialias_value}\n")
             logger.info(f"Wrote PML file: {pml_file}")
 
     def _job_specific_commands(self, job, command):
@@ -1295,7 +1296,7 @@ class PyMOLSpinJobRunner(PyMOLVisualizationJobRunner):
         cubegen_command = f"{gaussian_exe}/cubegen 0 spin {self.job_basename}.fchk {self.job_basename}_spin.cube {job.npts}"
         run_command(cubegen_command)
 
-    def _write_spin_density_pml(self, job, isosurface=0.05, transparency=0.2):
+    def _write_spin_density_pml(self, job):
         """
         Write the .pml file based on the .cube file.
 
@@ -1305,8 +1306,6 @@ class PyMOLSpinJobRunner(PyMOLVisualizationJobRunner):
 
         Args:
             job: PyMOL spin job instance.
-            isosurface: Isosurface level for visualization (default: 0.05).
-            transparency: Surface transparency level (default: 0.2).
         """
 
         pml_file = os.path.join(job.folder, f"{job.spin_basename}.pml")
@@ -1314,20 +1313,20 @@ class PyMOLSpinJobRunner(PyMOLVisualizationJobRunner):
             with open(pml_file, "w") as f:
                 f.write(f"load {job.spin_basename}.cube\n")
                 f.write(
-                    f"isosurface pos_iso_spin, {job.spin_basename}, {isosurface}\n"
+                    f"isosurface pos_iso_spin, {job.spin_basename}, {job.isosurface}\n"
                 )
                 f.write(
-                    f"isosurface neg_iso_spin, {job.spin_basename}, {-isosurface}\n"
+                    f"isosurface neg_iso_spin, {job.spin_basename}, {-job.isosurface}\n"
                 )
                 f.write(
-                    f"ramp_new ramp, {job.spin_basename}, [{-isosurface},{isosurface}], [red, blue]\n"
+                    f"ramp_new ramp, {job.spin_basename}, [{-job.isosurface},{job.isosurface}], [red, blue]\n"
                 )
                 f.write("set surface_color, ramp, pos_iso_spin\n")
                 f.write("set surface_color, ramp, neg_iso_spin\n")
-                f.write(f"set transparency, {transparency}\n")
-                f.write("set surface_quality, 3\n")
-                f.write("set antialias, 3\n")
-                f.write("set ray_trace_mode, 1\n")
+                f.write(f"set transparency, {job.transparency}\n")
+                f.write(f"set surface_quality, {job.surface_quality}\n")
+                f.write(f"set antialias, {job.antialias_value}\n")
+                f.write(f"set ray_trace_mode, {job.ray_trace_mode}\n")
             logger.info(f"Wrote PML file: {pml_file}")
 
     def _job_specific_commands(self, job, command):

--- a/chemsmart/jobs/mol/runner.py
+++ b/chemsmart/jobs/mol/runner.py
@@ -199,6 +199,7 @@ class PyMOLJobRunner(JobRunner):
         shutil.copy(source_style_file, dest_style_file)
 
         if job.isosurface_value is None and job.color_range is None:
+            print(job.isosurface_value, job.color_range)
             return dest_style_file
         else:
             logger.debug(f"Job isosurface_value: {job.isosurface_value}")

--- a/chemsmart/jobs/mol/runner.py
+++ b/chemsmart/jobs/mol/runner.py
@@ -1151,16 +1151,16 @@ class PyMOLMOJobRunner(PyMOLVisualizationJobRunner):
             with open(pml_file, "w") as f:
                 f.write(f"load {job.mo_basename}.cube\n")
                 f.write(
-                    f"isosurface pos_iso, {job.mo_basename}, {job.isosurface}\n"
+                    f"isosurface pos_iso, {job.mo_basename}, {job.isosurface_value}\n"
                 )
                 f.write(
-                    f"isosurface neg_iso, {job.mo_basename}, {-job.isosurface}\n"
+                    f"isosurface neg_iso, {job.mo_basename}, {-job.isosurface_value}\n"
                 )
                 f.write("print(pos_iso)\n")
                 f.write("print(neg_iso)\n")
                 f.write("set surface_color, blue, pos_iso\n")
                 f.write("set surface_color, red, neg_iso\n")
-                f.write(f"set transparency, {job.transparency}\n")
+                f.write(f"set transparency, {job.transparency_value}\n")
                 f.write(f"set surface_quality, {job.surface_quality}\n")
                 f.write(f"set antialias, {job.antialias_value}\n")
             logger.info(f"Wrote PML file: {pml_file}")
@@ -1313,17 +1313,17 @@ class PyMOLSpinJobRunner(PyMOLVisualizationJobRunner):
             with open(pml_file, "w") as f:
                 f.write(f"load {job.spin_basename}.cube\n")
                 f.write(
-                    f"isosurface pos_iso_spin, {job.spin_basename}, {job.isosurface}\n"
+                    f"isosurface pos_iso_spin, {job.spin_basename}, {job.isosurface_value}\n"
                 )
                 f.write(
-                    f"isosurface neg_iso_spin, {job.spin_basename}, {-job.isosurface}\n"
+                    f"isosurface neg_iso_spin, {job.spin_basename}, {-job.isosurface_value}\n"
                 )
                 f.write(
-                    f"ramp_new ramp, {job.spin_basename}, [{-job.isosurface},{job.isosurface}], [red, blue]\n"
+                    f"ramp_new ramp, {job.spin_basename}, [{-job.isosurface_value},{job.isosurface_value}], [red, blue]\n"
                 )
                 f.write("set surface_color, ramp, pos_iso_spin\n")
                 f.write("set surface_color, ramp, neg_iso_spin\n")
-                f.write(f"set transparency, {job.transparency}\n")
+                f.write(f"set transparency, {job.transparency_value}\n")
                 f.write(f"set surface_quality, {job.surface_quality}\n")
                 f.write(f"set antialias, {job.antialias_value}\n")
                 f.write(f"set ray_trace_mode, {job.ray_trace_mode}\n")

--- a/chemsmart/jobs/mol/runner.py
+++ b/chemsmart/jobs/mol/runner.py
@@ -60,7 +60,17 @@ class PyMOLJobRunner(JobRunner):
     FAKE = False
     SCRATCH = False
 
-    def __init__(self, server, scratch=None, fake=False, **kwargs):
+    def __init__(
+        self,
+        server,
+        isosurface_value=None,
+        transparency_value=None,
+        antialias_value=None,
+        ray_trace_mode=None,
+        scratch=None,
+        fake=False,
+        **kwargs,
+    ):
         """
         Initialize the PyMOL job runner.
 
@@ -70,6 +80,10 @@ class PyMOLJobRunner(JobRunner):
 
         Args:
             server: Server configuration for job execution.
+            isosurface_value: Isosurface value for NCI visualization (optional).
+            transparency_value: Transparency value for surfaces (optional).
+            antialias_value: Antialiasing level for rendering (optional).
+            ray_trace_mode: Ray tracing mode for rendering (optional).
             scratch: Whether to use scratch directories (default: None).
             fake: Whether this is a fake runner for testing (default: False).
             **kwargs: Additional arguments passed to parent JobRunner.
@@ -85,6 +99,11 @@ class PyMOLJobRunner(JobRunner):
         logger.debug(f"Jobrunner mem gb: {self.mem_gb}")
         logger.debug(f"Jobrunner num threads: {self.num_threads}")
         logger.debug(f"Jobrunner scratch: {self.scratch}")
+
+        self.isosurface_value = isosurface_value
+        self.transparency_value = transparency_value
+        self.antialias_value = antialias_value
+        self.ray_trace_mode = ray_trace_mode
 
     @property
     def executable(self):

--- a/chemsmart/jobs/mol/runner.py
+++ b/chemsmart/jobs/mol/runner.py
@@ -1147,22 +1147,23 @@ class PyMOLMOJobRunner(PyMOLVisualizationJobRunner):
         """
 
         pml_file = os.path.join(job.folder, f"{job.mo_basename}.pml")
-        if not os.path.exists(pml_file):
-            with open(pml_file, "w") as f:
-                f.write(f"load {job.mo_basename}.cube\n")
-                f.write(
-                    f"isosurface pos_iso, {job.mo_basename}, {job.isosurface_value}\n"
-                )
-                f.write(
-                    f"isosurface neg_iso, {job.mo_basename}, {-job.isosurface_value}\n"
-                )
-                f.write("print(pos_iso)\n")
-                f.write("print(neg_iso)\n")
-                f.write("set surface_color, blue, pos_iso\n")
-                f.write("set surface_color, red, neg_iso\n")
-                f.write(f"set transparency, {job.transparency_value}\n")
-                f.write(f"set surface_quality, {job.surface_quality}\n")
-                f.write(f"set antialias, {job.antialias_value}\n")
+        if os.path.exists(pml_file):
+            logger.warning(f"PML file {pml_file} already exists! Overwriting.")
+        with open(pml_file, "w") as f:
+            f.write(f"load {job.mo_basename}.cube\n")
+            f.write(
+                f"isosurface pos_iso, {job.mo_basename}, {job.isosurface_value}\n"
+            )
+            f.write(
+                f"isosurface neg_iso, {job.mo_basename}, {-job.isosurface_value}\n"
+            )
+            f.write("print(pos_iso)\n")
+            f.write("print(neg_iso)\n")
+            f.write("set surface_color, blue, pos_iso\n")
+            f.write("set surface_color, red, neg_iso\n")
+            f.write(f"set transparency, {job.transparency_value}\n")
+            f.write(f"set surface_quality, {job.surface_quality}\n")
+            f.write(f"set antialias, {job.antialias_value}\n")
             logger.info(f"Wrote PML file: {pml_file}")
 
     def _job_specific_commands(self, job, command):
@@ -1309,24 +1310,25 @@ class PyMOLSpinJobRunner(PyMOLVisualizationJobRunner):
         """
 
         pml_file = os.path.join(job.folder, f"{job.spin_basename}.pml")
-        if not os.path.exists(pml_file):
-            with open(pml_file, "w") as f:
-                f.write(f"load {job.spin_basename}.cube\n")
-                f.write(
-                    f"isosurface pos_iso_spin, {job.spin_basename}, {job.isosurface_value}\n"
-                )
-                f.write(
-                    f"isosurface neg_iso_spin, {job.spin_basename}, {-job.isosurface_value}\n"
-                )
-                f.write(
-                    f"ramp_new ramp, {job.spin_basename}, [{-job.isosurface_value},{job.isosurface_value}], [red, blue]\n"
-                )
-                f.write("set surface_color, ramp, pos_iso_spin\n")
-                f.write("set surface_color, ramp, neg_iso_spin\n")
-                f.write(f"set transparency, {job.transparency_value}\n")
-                f.write(f"set surface_quality, {job.surface_quality}\n")
-                f.write(f"set antialias, {job.antialias_value}\n")
-                f.write(f"set ray_trace_mode, {job.ray_trace_mode}\n")
+        if os.path.exists(pml_file):
+            logger.warning(f"PML file {pml_file} already exists. Overwriting.")
+        with open(pml_file, "w") as f:
+            f.write(f"load {job.spin_basename}.cube\n")
+            f.write(
+                f"isosurface pos_iso_spin, {job.spin_basename}, {job.isosurface_value}\n"
+            )
+            f.write(
+                f"isosurface neg_iso_spin, {job.spin_basename}, {-job.isosurface_value}\n"
+            )
+            f.write(
+                f"ramp_new ramp, {job.spin_basename}, [{-job.isosurface_value},{job.isosurface_value}], [red, blue]\n"
+            )
+            f.write("set surface_color, ramp, pos_iso_spin\n")
+            f.write("set surface_color, ramp, neg_iso_spin\n")
+            f.write(f"set transparency, {job.transparency_value}\n")
+            f.write(f"set surface_quality, {job.surface_quality}\n")
+            f.write(f"set antialias, {job.antialias_value}\n")
+            f.write(f"set ray_trace_mode, {job.ray_trace_mode}\n")
             logger.info(f"Wrote PML file: {pml_file}")
 
     def _job_specific_commands(self, job, command):

--- a/chemsmart/jobs/mol/runner.py
+++ b/chemsmart/jobs/mol/runner.py
@@ -223,6 +223,10 @@ class PyMOLJobRunner(JobRunner):
         if os.path.exists(
             os.path.join(job.folder, f"{self.job_basename}.fchk")
         ):
+            logger.info(
+                f".fchk file {self.job_basename}.fchk already exists."
+                f"Skipping generation of .fchk file."
+            )
             pass
         else:
             # generate .fchk file from .chk file

--- a/chemsmart/jobs/mol/runner.py
+++ b/chemsmart/jobs/mol/runner.py
@@ -198,12 +198,12 @@ class PyMOLJobRunner(JobRunner):
         )
         shutil.copy(source_style_file, dest_style_file)
 
+        logger.debug(f"Job isosurface_value: {job.isosurface_value}")
+        logger.debug(f"Job color_range: {job.color_range}")
+
         if job.isosurface_value is None and job.color_range is None:
-            print(job.isosurface_value, job.color_range)
             return dest_style_file
         else:
-            logger.debug(f"Job isosurface_value: {job.isosurface_value}")
-            logger.debug(f"Job color_range: {job.color_range}")
             return self._modify_job_pymol_script(job, dest_style_file)
 
     def _modify_job_pymol_script(self, job, style_file_path=None):
@@ -368,18 +368,11 @@ class PyMOLJobRunner(JobRunner):
 
         # Get style file
         if job.pymol_script is None:
-            style_file_path = os.path.join(
-                job.folder, "zhang_group_pymol_style.py"
+            logger.info(
+                f"No style file supplied for job {job.label}."
+                f"Using default zhang_group_pymol_style.py."
             )
-            if os.path.exists(style_file_path):
-                job_pymol_script = style_file_path
-            else:
-                logger.info(
-                    "Using default zhang_group_pymol_style for rendering."
-                )
-                job_pymol_script = self._generate_visualization_style_script(
-                    job
-                )
+            job_pymol_script = self._generate_visualization_style_script(job)
             if os.path.exists(job_pymol_script):
                 command += f" -r {quote_path(job_pymol_script)}"
         else:

--- a/chemsmart/jobs/mol/templates/zhang_group_pymol_style.py
+++ b/chemsmart/jobs/mol/templates/zhang_group_pymol_style.py
@@ -163,7 +163,7 @@ def movie_render():
     cmd.set("spec_reflect", 0.5)
     cmd.util.ray_shadows("none")
 
-    cmd.set("antialias", 1)
+    cmd.set("antialias", 3)
     cmd.set("orthoscopic", 0)
     cmd.set("field_of_view", 45)
     cmd.set("transparency", 0)

--- a/chemsmart/utils/repattern.py
+++ b/chemsmart/utils/repattern.py
@@ -111,3 +111,8 @@ gaussian_dias_filename_point_with_fragment2 = r".*_p(\d+)_(f2)(?:_(.+)?)?\.log"
 
 # filename matches with reactant r1 or r2
 gaussian_dias_filename_with_reactant = r".*_r([12])(?:_(.+)?)?\.log"
+
+
+# PyMOL strings
+pymol_isosurface_pattern = r"isosurface\s*=\s*[\d\.]+"
+pymol_color_range_pattern = r"range\s*=\s*[\d\.]+"


### PR DESCRIPTION
E.g., one may be able to specify pymol nci isosurface value and color range via
`chemsmart run mol -f file.log nci -i 0.7 -r 1.2` 
to give isosurface value of 0.7 and color range of 1.2

and specify MO/spin density .pml options via
`chemsmart run mol -f file.log mo --homo -i 0.7 --transparency-value 0.3 --surface-quality 3 --antialias-value 3 --ray-trace-mode 3` 
 `chemsmart run mol -f file.log spin -i 0.7 --transparency-value 0.3 --surface-quality 3 --antialias-value 3 --ray-trace-mode 3` etc