### PR TITLE
fail safely with raised error message if the filetype/program type for thermochemistry calculation was wrongly specified

### DIFF
--- a/chemsmart/cli/thermochemistry/thermochemistry.py
+++ b/chemsmart/cli/thermochemistry/thermochemistry.py
@@ -226,13 +226,13 @@ def thermochemistry(
     files = []
 
     if directory:
-        if filetype.lower() not in ["gaussian", "orca"]:
+        if filetype.lower() not in {"gaussian", "orca"}:
             raise ValueError(
-                f"Unsupported filetype {filetype} for thermochemistry.\n "
+                f"Unsupported filetype {filetype} for thermochemistry.\n"
                 f"Please choose one of ['gaussian', 'orca']."
             )
         files = find_output_files_in_directory(
-            directory=directory, program=filetype
+            directory=directory, program=filetype.lower()
         )
         for file in files:
             job = ThermochemistryJob.from_filename(


### PR DESCRIPTION
Currently if -t log will raise a NoneType error without further specification of why the error occurs.