### PR TITLE
fix to self.check_imaginary_frequencies flag which is not activated correctly if set to False

### DIFF
--- a/chemsmart/analysis/thermochemistry.py
+++ b/chemsmart/analysis/thermochemistry.py
@@ -71,6 +71,11 @@ class Thermochemistry:
     ):
         self.filename = filename
         self.molecule = Molecule.from_filepath(filename)
+        self.energy_units = energy_units
+        self.check_imaginary_frequencies = check_imaginary_frequencies
+        # Keep original cm^-1 values for replacing imaginary frequencies
+        self.s_freq_cutoff_cm = s_freq_cutoff
+        self.h_freq_cutoff_cm = h_freq_cutoff
         self.temperature = temperature
         self.pressure = pressure
         self.use_weighted_mass = use_weighted_mass
@@ -115,11 +120,12 @@ class Thermochemistry:
             else None
         )
 
-        # convert the unit of vibrational frequencies
-        # from cm^-1 to Hz
+        # convert the unit of vibrational frequencies from cm^-1 to Hz
+        # avoid calling self.cleaned_frequencies twice
+        cleaned_frequencies = self.cleaned_frequencies
         self.v = (
-            [k * units._c * 1e2 for k in self.cleaned_frequencies]
-            if self.cleaned_frequencies is not None
+            [k * units._c * 1e2 for k in cleaned_frequencies]
+            if cleaned_frequencies is not None
             else None
         )
 
@@ -130,9 +136,6 @@ class Thermochemistry:
             if self.v is not None
             else None
         )
-
-        self.energy_units = energy_units
-        self.check_imaginary_frequencies = check_imaginary_frequencies
 
     @cached_property
     def file_object(self):
@@ -220,37 +223,87 @@ class Thermochemistry:
     def cleaned_frequencies(self):
         """Clean up vibrational frequencies for thermochemical calculations.
 
-        For transition states (jobtype == "ts"), the first imaginary
-        frequency is assumed to correspond to the reaction coordinate and is
-        excluded from thermochemical calculation.
-        For optimization, only geometries without imaginary frequencies are
-        parsed for thermochemical calculations.
+        Frequencies returned by this property remain in cm^-1.
+
+        If self.check_imaginary_frequencies is True:
+            - TS jobs must have exactly one imaginary frequency.
+            - Non-TS jobs must have no imaginary frequencies.
+
+        If self.check_imaginary_frequencies is False:
+            - TS jobs remove the first imaginary frequency as the reaction coordinate.
+            - Extra imaginary frequencies are replaced by a positive cutoff.
+            - Non-TS jobs replace all imaginary frequencies by a positive cutoff.
+
+        The replacement cutoff is:
+            - s_freq_cutoff if provided
+            - otherwise h_freq_cutoff if provided
+            - otherwise 100.0 cm^-1
         """
         if self.vibrational_frequencies is None:
             return None
-        if self.imaginary_frequencies:
-            if self.jobtype == "ts":
-                if (
-                    len(self.imaginary_frequencies) == 1
-                    and self.vibrational_frequencies[0] < 0.0
-                ):
-                    return self.vibrational_frequencies[1:]
-                else:
-                    raise ValueError(
-                        f"!! ERROR: Detected multiple imaginary frequencies in "
-                        f"TS calculation for {self.filename}. Only one "
-                        f"imaginary frequency is allowed for a valid TS. "
-                        f"Please re-optimize the geometry to locate a true TS."
-                    )
-            else:
+
+        frequencies = list(self.vibrational_frequencies)
+        imaginary_indices = [
+            i for i, freq in enumerate(frequencies) if freq < 0.0
+        ]
+
+        if not imaginary_indices:
+            return frequencies
+
+        # IMPORTANT:
+        # cleaned_frequencies is still in cm^-1.
+        # Do not use self.s_freq_cutoff/self.h_freq_cutoff here because those
+        # have already been converted to Hz.
+        if self.s_freq_cutoff_cm is not None:
+            freq_cutoff = self.s_freq_cutoff_cm
+        elif self.h_freq_cutoff_cm is not None:
+            freq_cutoff = self.h_freq_cutoff_cm
+        else:
+            freq_cutoff = 100.0
+
+        if self.jobtype == "ts":
+            # Valid TS: exactly one imaginary frequency.
+            # Remove it from thermochemistry.
+            if len(imaginary_indices) == 1:
+                reaction_coordinate_index = imaginary_indices[0]
+                return [
+                    freq
+                    for i, freq in enumerate(frequencies)
+                    if i != reaction_coordinate_index
+                ]
+
+            # Invalid TS: more than one imaginary frequency.
+            if self.check_imaginary_frequencies:
                 raise ValueError(
-                    f"!! ERROR: Detected imaginary frequencies in geometry "
-                    f"optimization for {self.filename}. A valid optimized "
-                    f"geometry should not contain imaginary frequencies. "
-                    f"Please re-optimize the geometry to locate a true "
-                    f"minimum."
+                    f"!! ERROR: Detected multiple imaginary frequencies in "
+                    f"TS calculation for {self.filename}. Only one "
+                    f"imaginary frequency is allowed for a valid TS. "
+                    f"Please re-optimize the geometry to locate a true TS."
                 )
-        return self.vibrational_frequencies
+
+            # Permissive mode:
+            # remove first imaginary frequency as reaction coordinate;
+            # replace all remaining imaginary frequencies by cutoff.
+            reaction_coordinate_index = imaginary_indices[0]
+
+            return [
+                freq_cutoff if freq < 0.0 else freq
+                for i, freq in enumerate(frequencies)
+                if i != reaction_coordinate_index
+            ]
+
+        # Non-TS jobs: any imaginary frequency is invalid in strict mode.
+        if self.check_imaginary_frequencies:
+            raise ValueError(
+                f"!! ERROR: Detected imaginary frequencies in geometry "
+                f"optimization for {self.filename}. A valid optimized "
+                f"geometry should not contain imaginary frequencies. "
+                f"Please re-optimize the geometry to locate a true minimum."
+            )
+
+        # Permissive mode:
+        # replace all imaginary frequencies by cutoff.
+        return [freq_cutoff if freq < 0.0 else freq for freq in frequencies]
 
     @property
     def electronic_energy(self):

--- a/chemsmart/analysis/thermochemistry.py
+++ b/chemsmart/analysis/thermochemistry.py
@@ -261,6 +261,14 @@ class Thermochemistry:
         else:
             freq_cutoff = 100.0
 
+        # check against non-positive cutoff value
+        # before using it to replace imaginary frequencies
+        if freq_cutoff <= 0.0:
+            raise ValueError(
+                f"Imaginary-frequency replacement cutoff must be positive. "
+                f"Got {freq_cutoff} cm^-1."
+            )
+
         if self.jobtype == "ts":
             # Valid TS: exactly one imaginary frequency.
             # Remove it from thermochemistry.

--- a/chemsmart/cli/thermochemistry/thermochemistry.py
+++ b/chemsmart/cli/thermochemistry/thermochemistry.py
@@ -122,9 +122,8 @@ def click_thermochemistry_options(f):
         help="Overwrite existing output files if they already exist.",
     )
     @click.option(
-        "-i",
-        "--check-imaginary-frequencies",
-        is_flag=True,
+        "-i/",
+        "--check-imaginary-frequencies/--no-check-imaginary-frequencies",
         default=True,
         show_default=True,
         help="Check for imaginary frequencies in the calculations.",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,6 +39,47 @@ thermochemistry_cli_module = importlib.import_module(
 mol_cli_module = importlib.import_module("chemsmart.cli.mol.mol")
 
 
+############ Thermochemistry Mock Fixtures ##################
+@pytest.fixture()
+def make_thermochemistry_mock():
+    """Factory fixture that creates a MagicMock mimicking a Thermochemistry instance.
+
+    Returns a callable that accepts the attributes accessed by
+    ``Thermochemistry.cleaned_frequencies`` and returns a properly configured
+    mock, so test methods stay free of direct ``MagicMock`` construction.
+
+    Usage::
+
+        def test_something(make_thermochemistry_mock):
+            mock = make_thermochemistry_mock(
+                vibrational_frequencies=[-50.0, 100.0],
+                jobtype="opt",
+                check_imaginary_frequencies=False,
+            )
+            result = Thermochemistry.cleaned_frequencies.fget(mock)
+            assert result == [100.0, 100.0]
+    """
+    from chemsmart.analysis.thermochemistry import Thermochemistry
+
+    def _factory(
+        vibrational_frequencies,
+        jobtype="opt",
+        check_imaginary_frequencies=True,
+        s_freq_cutoff_cm=None,
+        h_freq_cutoff_cm=None,
+    ):
+        mock = MagicMock(spec=Thermochemistry)
+        mock.vibrational_frequencies = vibrational_frequencies
+        mock.jobtype = jobtype
+        mock.check_imaginary_frequencies = check_imaginary_frequencies
+        mock.s_freq_cutoff_cm = s_freq_cutoff_cm
+        mock.h_freq_cutoff_cm = h_freq_cutoff_cm
+        mock.filename = "dummy.log"
+        return mock
+
+    return _factory
+
+
 ############ CLI Fixtures ##################
 @pytest.fixture()
 def make_cli_ctx_obj():

--- a/tests/test_thermochemistry.py
+++ b/tests/test_thermochemistry.py
@@ -3361,7 +3361,6 @@ class TestThermochemistryBatchMode:
         assert f"{gibbs_free_energy4:.6f}" in data_lines4[0]
 
 
-
 class TestCleanedFrequencies:
     """Unit tests for Thermochemistry.cleaned_frequencies.
 

--- a/tests/test_thermochemistry.py
+++ b/tests/test_thermochemistry.py
@@ -1,6 +1,5 @@
 import os.path
 from shutil import copyfile
-from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
@@ -3362,6 +3361,7 @@ class TestThermochemistryBatchMode:
         assert f"{gibbs_free_energy4:.6f}" in data_lines4[0]
 
 
+
 class TestCleanedFrequencies:
     """Unit tests for Thermochemistry.cleaned_frequencies.
 
@@ -3370,36 +3370,22 @@ class TestCleanedFrequencies:
     single vs multiple imaginary frequencies, and cutoff value validation.
     """
 
-    def _make_mock(
-        self,
-        vibrational_frequencies,
-        jobtype="opt",
-        check_imaginary_frequencies=True,
-        s_freq_cutoff_cm=None,
-        h_freq_cutoff_cm=None,
-    ):
-        """Return a mock with the attributes accessed by cleaned_frequencies."""
-        mock = MagicMock(spec=Thermochemistry)
-        mock.vibrational_frequencies = vibrational_frequencies
-        mock.jobtype = jobtype
-        mock.check_imaginary_frequencies = check_imaginary_frequencies
-        mock.s_freq_cutoff_cm = s_freq_cutoff_cm
-        mock.h_freq_cutoff_cm = h_freq_cutoff_cm
-        mock.filename = "dummy.log"
-        return mock
-
     # ------------------------------------------------------------------
     # Shared: None / no imaginary
     # ------------------------------------------------------------------
 
-    def test_none_vibrational_frequencies_returns_none(self):
-        mock = self._make_mock(vibrational_frequencies=None)
+    def test_none_vibrational_frequencies_returns_none(
+        self, make_thermochemistry_mock
+    ):
+        mock = make_thermochemistry_mock(vibrational_frequencies=None)
         result = Thermochemistry.cleaned_frequencies.fget(mock)
         assert result is None
 
-    def test_no_imaginary_frequencies_returns_unchanged(self):
+    def test_no_imaginary_frequencies_returns_unchanged(
+        self, make_thermochemistry_mock
+    ):
         freqs = [100.0, 200.0, 300.0]
-        mock = self._make_mock(vibrational_frequencies=freqs)
+        mock = make_thermochemistry_mock(vibrational_frequencies=freqs)
         result = Thermochemistry.cleaned_frequencies.fget(mock)
         assert result == freqs
 
@@ -3407,8 +3393,10 @@ class TestCleanedFrequencies:
     # Non-TS strict mode
     # ------------------------------------------------------------------
 
-    def test_non_ts_strict_raises_on_imaginary(self):
-        mock = self._make_mock(
+    def test_non_ts_strict_raises_on_imaginary(
+        self, make_thermochemistry_mock
+    ):
+        mock = make_thermochemistry_mock(
             vibrational_frequencies=[-50.0, 100.0, 200.0],
             jobtype="opt",
             check_imaginary_frequencies=True,
@@ -3421,9 +3409,9 @@ class TestCleanedFrequencies:
     # ------------------------------------------------------------------
 
     def test_non_ts_permissive_replaces_single_imaginary_with_default_cutoff(
-        self,
+        self, make_thermochemistry_mock
     ):
-        mock = self._make_mock(
+        mock = make_thermochemistry_mock(
             vibrational_frequencies=[-50.0, 100.0, 200.0],
             jobtype="opt",
             check_imaginary_frequencies=False,
@@ -3432,9 +3420,9 @@ class TestCleanedFrequencies:
         assert result == [100.0, 100.0, 200.0]
 
     def test_non_ts_permissive_replaces_multiple_imaginary_with_default_cutoff(
-        self,
+        self, make_thermochemistry_mock
     ):
-        mock = self._make_mock(
+        mock = make_thermochemistry_mock(
             vibrational_frequencies=[-80.0, 100.0, -30.0, 200.0],
             jobtype="opt",
             check_imaginary_frequencies=False,
@@ -3442,8 +3430,10 @@ class TestCleanedFrequencies:
         result = Thermochemistry.cleaned_frequencies.fget(mock)
         assert result == [100.0, 100.0, 100.0, 200.0]
 
-    def test_non_ts_permissive_uses_s_freq_cutoff(self):
-        mock = self._make_mock(
+    def test_non_ts_permissive_uses_s_freq_cutoff(
+        self, make_thermochemistry_mock
+    ):
+        mock = make_thermochemistry_mock(
             vibrational_frequencies=[-80.0, 100.0, 200.0],
             jobtype="opt",
             check_imaginary_frequencies=False,
@@ -3452,8 +3442,10 @@ class TestCleanedFrequencies:
         result = Thermochemistry.cleaned_frequencies.fget(mock)
         assert result == [50.0, 100.0, 200.0]
 
-    def test_non_ts_permissive_uses_h_freq_cutoff_when_no_s_cutoff(self):
-        mock = self._make_mock(
+    def test_non_ts_permissive_uses_h_freq_cutoff_when_no_s_cutoff(
+        self, make_thermochemistry_mock
+    ):
+        mock = make_thermochemistry_mock(
             vibrational_frequencies=[-80.0, 100.0, 200.0],
             jobtype="opt",
             check_imaginary_frequencies=False,
@@ -3467,8 +3459,10 @@ class TestCleanedFrequencies:
     # TS strict mode
     # ------------------------------------------------------------------
 
-    def test_ts_single_imaginary_strict_removes_it(self):
-        mock = self._make_mock(
+    def test_ts_single_imaginary_strict_removes_it(
+        self, make_thermochemistry_mock
+    ):
+        mock = make_thermochemistry_mock(
             vibrational_frequencies=[-300.0, 100.0, 200.0],
             jobtype="ts",
             check_imaginary_frequencies=True,
@@ -3476,8 +3470,10 @@ class TestCleanedFrequencies:
         result = Thermochemistry.cleaned_frequencies.fget(mock)
         assert result == [100.0, 200.0]
 
-    def test_ts_multiple_imaginary_strict_raises(self):
-        mock = self._make_mock(
+    def test_ts_multiple_imaginary_strict_raises(
+        self, make_thermochemistry_mock
+    ):
+        mock = make_thermochemistry_mock(
             vibrational_frequencies=[-300.0, -50.0, 100.0, 200.0],
             jobtype="ts",
             check_imaginary_frequencies=True,
@@ -3489,8 +3485,10 @@ class TestCleanedFrequencies:
     # TS permissive mode
     # ------------------------------------------------------------------
 
-    def test_ts_single_imaginary_permissive_removes_it(self):
-        mock = self._make_mock(
+    def test_ts_single_imaginary_permissive_removes_it(
+        self, make_thermochemistry_mock
+    ):
+        mock = make_thermochemistry_mock(
             vibrational_frequencies=[-300.0, 100.0, 200.0],
             jobtype="ts",
             check_imaginary_frequencies=False,
@@ -3499,9 +3497,9 @@ class TestCleanedFrequencies:
         assert result == [100.0, 200.0]
 
     def test_ts_multiple_imaginary_permissive_removes_first_replaces_rest(
-        self,
+        self, make_thermochemistry_mock
     ):
-        mock = self._make_mock(
+        mock = make_thermochemistry_mock(
             vibrational_frequencies=[-300.0, -50.0, 100.0, 200.0],
             jobtype="ts",
             check_imaginary_frequencies=False,
@@ -3510,8 +3508,10 @@ class TestCleanedFrequencies:
         # -300.0 removed as reaction coordinate; -50.0 replaced by 100.0
         assert result == [100.0, 100.0, 200.0]
 
-    def test_ts_multiple_imaginary_permissive_uses_custom_cutoff(self):
-        mock = self._make_mock(
+    def test_ts_multiple_imaginary_permissive_uses_custom_cutoff(
+        self, make_thermochemistry_mock
+    ):
+        mock = make_thermochemistry_mock(
             vibrational_frequencies=[-300.0, -50.0, -20.0, 100.0],
             jobtype="ts",
             check_imaginary_frequencies=False,
@@ -3525,8 +3525,8 @@ class TestCleanedFrequencies:
     # Cutoff validation
     # ------------------------------------------------------------------
 
-    def test_zero_cutoff_raises_value_error(self):
-        mock = self._make_mock(
+    def test_zero_cutoff_raises_value_error(self, make_thermochemistry_mock):
+        mock = make_thermochemistry_mock(
             vibrational_frequencies=[-50.0, 100.0],
             jobtype="opt",
             check_imaginary_frequencies=False,
@@ -3535,8 +3535,10 @@ class TestCleanedFrequencies:
         with pytest.raises(ValueError, match="must be positive"):
             Thermochemistry.cleaned_frequencies.fget(mock)
 
-    def test_negative_cutoff_raises_value_error(self):
-        mock = self._make_mock(
+    def test_negative_cutoff_raises_value_error(
+        self, make_thermochemistry_mock
+    ):
+        mock = make_thermochemistry_mock(
             vibrational_frequencies=[-50.0, 100.0],
             jobtype="opt",
             check_imaginary_frequencies=False,

--- a/tests/test_thermochemistry.py
+++ b/tests/test_thermochemistry.py
@@ -1,7 +1,9 @@
 import os.path
 from shutil import copyfile
+from unittest.mock import MagicMock
 
 import numpy as np
+import pytest
 from ase import units
 
 from chemsmart.analysis.thermochemistry import (
@@ -3360,6 +3362,190 @@ class TestThermochemistryBatchMode:
         assert f"{gibbs_free_energy4:.6f}" in data_lines4[0]
 
 
+class TestCleanedFrequencies:
+    """Unit tests for Thermochemistry.cleaned_frequencies.
+
+    Tests cover both the strict (check_imaginary_frequencies=True) and
+    permissive (check_imaginary_frequencies=False) modes, TS vs non-TS jobs,
+    single vs multiple imaginary frequencies, and cutoff value validation.
+    """
+
+    def _make_mock(
+        self,
+        vibrational_frequencies,
+        jobtype="opt",
+        check_imaginary_frequencies=True,
+        s_freq_cutoff_cm=None,
+        h_freq_cutoff_cm=None,
+    ):
+        """Return a mock with the attributes accessed by cleaned_frequencies."""
+        mock = MagicMock(spec=Thermochemistry)
+        mock.vibrational_frequencies = vibrational_frequencies
+        mock.jobtype = jobtype
+        mock.check_imaginary_frequencies = check_imaginary_frequencies
+        mock.s_freq_cutoff_cm = s_freq_cutoff_cm
+        mock.h_freq_cutoff_cm = h_freq_cutoff_cm
+        mock.filename = "dummy.log"
+        return mock
+
+    # ------------------------------------------------------------------
+    # Shared: None / no imaginary
+    # ------------------------------------------------------------------
+
+    def test_none_vibrational_frequencies_returns_none(self):
+        mock = self._make_mock(vibrational_frequencies=None)
+        result = Thermochemistry.cleaned_frequencies.fget(mock)
+        assert result is None
+
+    def test_no_imaginary_frequencies_returns_unchanged(self):
+        freqs = [100.0, 200.0, 300.0]
+        mock = self._make_mock(vibrational_frequencies=freqs)
+        result = Thermochemistry.cleaned_frequencies.fget(mock)
+        assert result == freqs
+
+    # ------------------------------------------------------------------
+    # Non-TS strict mode
+    # ------------------------------------------------------------------
+
+    def test_non_ts_strict_raises_on_imaginary(self):
+        mock = self._make_mock(
+            vibrational_frequencies=[-50.0, 100.0, 200.0],
+            jobtype="opt",
+            check_imaginary_frequencies=True,
+        )
+        with pytest.raises(ValueError, match="imaginary frequencies"):
+            Thermochemistry.cleaned_frequencies.fget(mock)
+
+    # ------------------------------------------------------------------
+    # Non-TS permissive mode
+    # ------------------------------------------------------------------
+
+    def test_non_ts_permissive_replaces_single_imaginary_with_default_cutoff(
+        self,
+    ):
+        mock = self._make_mock(
+            vibrational_frequencies=[-50.0, 100.0, 200.0],
+            jobtype="opt",
+            check_imaginary_frequencies=False,
+        )
+        result = Thermochemistry.cleaned_frequencies.fget(mock)
+        assert result == [100.0, 100.0, 200.0]
+
+    def test_non_ts_permissive_replaces_multiple_imaginary_with_default_cutoff(
+        self,
+    ):
+        mock = self._make_mock(
+            vibrational_frequencies=[-80.0, 100.0, -30.0, 200.0],
+            jobtype="opt",
+            check_imaginary_frequencies=False,
+        )
+        result = Thermochemistry.cleaned_frequencies.fget(mock)
+        assert result == [100.0, 100.0, 100.0, 200.0]
+
+    def test_non_ts_permissive_uses_s_freq_cutoff(self):
+        mock = self._make_mock(
+            vibrational_frequencies=[-80.0, 100.0, 200.0],
+            jobtype="opt",
+            check_imaginary_frequencies=False,
+            s_freq_cutoff_cm=50.0,
+        )
+        result = Thermochemistry.cleaned_frequencies.fget(mock)
+        assert result == [50.0, 100.0, 200.0]
+
+    def test_non_ts_permissive_uses_h_freq_cutoff_when_no_s_cutoff(self):
+        mock = self._make_mock(
+            vibrational_frequencies=[-80.0, 100.0, 200.0],
+            jobtype="opt",
+            check_imaginary_frequencies=False,
+            s_freq_cutoff_cm=None,
+            h_freq_cutoff_cm=75.0,
+        )
+        result = Thermochemistry.cleaned_frequencies.fget(mock)
+        assert result == [75.0, 100.0, 200.0]
+
+    # ------------------------------------------------------------------
+    # TS strict mode
+    # ------------------------------------------------------------------
+
+    def test_ts_single_imaginary_strict_removes_it(self):
+        mock = self._make_mock(
+            vibrational_frequencies=[-300.0, 100.0, 200.0],
+            jobtype="ts",
+            check_imaginary_frequencies=True,
+        )
+        result = Thermochemistry.cleaned_frequencies.fget(mock)
+        assert result == [100.0, 200.0]
+
+    def test_ts_multiple_imaginary_strict_raises(self):
+        mock = self._make_mock(
+            vibrational_frequencies=[-300.0, -50.0, 100.0, 200.0],
+            jobtype="ts",
+            check_imaginary_frequencies=True,
+        )
+        with pytest.raises(ValueError, match="multiple imaginary frequencies"):
+            Thermochemistry.cleaned_frequencies.fget(mock)
+
+    # ------------------------------------------------------------------
+    # TS permissive mode
+    # ------------------------------------------------------------------
+
+    def test_ts_single_imaginary_permissive_removes_it(self):
+        mock = self._make_mock(
+            vibrational_frequencies=[-300.0, 100.0, 200.0],
+            jobtype="ts",
+            check_imaginary_frequencies=False,
+        )
+        result = Thermochemistry.cleaned_frequencies.fget(mock)
+        assert result == [100.0, 200.0]
+
+    def test_ts_multiple_imaginary_permissive_removes_first_replaces_rest(
+        self,
+    ):
+        mock = self._make_mock(
+            vibrational_frequencies=[-300.0, -50.0, 100.0, 200.0],
+            jobtype="ts",
+            check_imaginary_frequencies=False,
+        )
+        result = Thermochemistry.cleaned_frequencies.fget(mock)
+        # -300.0 removed as reaction coordinate; -50.0 replaced by 100.0
+        assert result == [100.0, 100.0, 200.0]
+
+    def test_ts_multiple_imaginary_permissive_uses_custom_cutoff(self):
+        mock = self._make_mock(
+            vibrational_frequencies=[-300.0, -50.0, -20.0, 100.0],
+            jobtype="ts",
+            check_imaginary_frequencies=False,
+            s_freq_cutoff_cm=60.0,
+        )
+        result = Thermochemistry.cleaned_frequencies.fget(mock)
+        # -300.0 removed; -50.0 and -20.0 replaced by 60.0
+        assert result == [60.0, 60.0, 100.0]
+
+    # ------------------------------------------------------------------
+    # Cutoff validation
+    # ------------------------------------------------------------------
+
+    def test_zero_cutoff_raises_value_error(self):
+        mock = self._make_mock(
+            vibrational_frequencies=[-50.0, 100.0],
+            jobtype="opt",
+            check_imaginary_frequencies=False,
+            s_freq_cutoff_cm=0.0,
+        )
+        with pytest.raises(ValueError, match="must be positive"):
+            Thermochemistry.cleaned_frequencies.fget(mock)
+
+    def test_negative_cutoff_raises_value_error(self):
+        mock = self._make_mock(
+            vibrational_frequencies=[-50.0, 100.0],
+            jobtype="opt",
+            check_imaginary_frequencies=False,
+            s_freq_cutoff_cm=-10.0,
+        )
+        with pytest.raises(ValueError, match="must be positive"):
+            Thermochemistry.cleaned_frequencies.fget(mock)
+
+
 class TestThermochemistryCLI:
     """CLI option-propagation tests for the thermochemistry command."""
 
@@ -3386,6 +3572,30 @@ class TestThermochemistryCLI:
         assert result.exit_code == 0, result.output
         assert settings is not None
         assert settings.use_weighted_mass is False
+
+    def test_check_imaginary_frequencies_flag_propagated(
+        self,
+        run_thermochemistry_and_capture_settings,
+    ):
+        result, settings = run_thermochemistry_and_capture_settings(
+            extra_args=["--check-imaginary-frequencies"]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert settings is not None
+        assert settings.check_imaginary_frequencies is True
+
+    def test_no_check_imaginary_frequencies_flag_propagated(
+        self,
+        run_thermochemistry_and_capture_settings,
+    ):
+        result, settings = run_thermochemistry_and_capture_settings(
+            extra_args=["--no-check-imaginary-frequencies"]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert settings is not None
+        assert settings.check_imaginary_frequencies is False
 
 
 class TestThermochemistryCLIFolderOptions:


### PR DESCRIPTION
useful when estimating thermochemistry for approximating TS with modred calcs when no TS can be found but modred is okay