### PR TITLE
enhancement: MO plots to use fchk if available

### DIFF
--- a/chemsmart/jobs/mol/runner.py
+++ b/chemsmart/jobs/mol/runner.py
@@ -294,7 +294,7 @@ class PyMOLJobRunner(JobRunner):
         chk_file_path = os.path.join(job.folder, f"{job.label}.chk")
         fchk_file_path = os.path.join(job.folder, f"{job.label}.fchk")
         if not os.path.exists(chk_file_path) and not os.path.exists(
-            chk_file_path
+            fchk_file_path
         ):
             raise FileNotFoundError(
                 f".chk or .fchk file is required but not found at {chk_file_path} or {fchk_file_path}!"

--- a/chemsmart/jobs/mol/runner.py
+++ b/chemsmart/jobs/mol/runner.py
@@ -293,7 +293,7 @@ class PyMOLJobRunner(JobRunner):
         """
         chk_file_path = os.path.join(job.folder, f"{job.label}.chk")
         fchk_file_path = os.path.join(job.folder, f"{job.label}.fchk")
-        if not os.path.exists(chk_file_path) and not os.path.isfile(
+        if not os.path.exists(chk_file_path) and not os.path.exists(
             chk_file_path
         ):
             raise FileNotFoundError(

--- a/chemsmart/jobs/mol/runner.py
+++ b/chemsmart/jobs/mol/runner.py
@@ -292,13 +292,16 @@ class PyMOLJobRunner(JobRunner):
             FileNotFoundError: If the required .chk file is not found.
         """
         chk_file_path = os.path.join(job.folder, f"{job.label}.chk")
-        if not os.path.exists(chk_file_path):
+        fchk_file_path = os.path.join(job.folder, f"{job.label}.fchk")
+        if not os.path.exists(chk_file_path) and not os.path.isfile(
+            chk_file_path
+        ):
             raise FileNotFoundError(
-                f".chk file is required but not found at {chk_file_path}!"
+                f".chk or .fchk file is required but not found at {chk_file_path} or {fchk_file_path}!"
             )
 
         gaussian_exe = self._get_gaussian_executable(job)
-        if os.path.exists(os.path.join(job.folder, f"{job.label}.fchk")):
+        if os.path.exists(fchk_file_path):
             logger.info(
                 f".fchk file {job.label}.fchk already exists.\n"
                 f"Skipping generation of .fchk file."


### PR DESCRIPTION
Requires `job.log` and `job.fchk` (or `job.chk` as before) when running MO plots via `chemsmart run mol -f job.log mo --homo` for e.g., HOMO generation.

`job.log` is used as input, as Molecule object need to be created from it.