### PR TITLE
Add initial GROMACS EM scaffold

### DIFF
--- a/chemsmart/cli/gromacs/__init__.py
+++ b/chemsmart/cli/gromacs/__init__.py
@@ -3,8 +3,9 @@ GROMACS command-line interface subcommands.
 
 This module provides CLI subcommands for GROMACS workflows.
 """
-from .em import em
 from .gromacs import gromacs
+from .em import em
+
 
 __all__ = [
     "gromacs",

--- a/chemsmart/cli/gromacs/em.py
+++ b/chemsmart/cli/gromacs/em.py
@@ -13,28 +13,75 @@ logger = logging.getLogger(__name__)
 
 @gromacs.group("em", cls=MyGroup, invoke_without_command=True)
 @click_job_options
+@click.option(
+    "--mdp",
+    "mdp_file",
+    type=click.Path(exists=True, dir_okay=False, resolve_path=True),
+    default=None,
+    help="GROMACS .mdp file for energy minimization",
+)
+@click.option(
+    "--structure",
+    "-s",
+    "structure_file",
+    type=click.Path(exists=True, dir_okay=False, resolve_path=True),
+    default=None,
+    help="Input structure file,such as .gro or .pdb.",
+)
+@click.option(
+    "--top",
+    "top_file",
+    type=click.Path(exists=True, dir_okay=False, resolve_path=True),
+    default=None,
+    help="GROMACS topology .top file.",
+)
+@click.option(
+    "--index",
+    "index_file",
+    type=click.Path(exists=True, dir_okay=False, resolve_path=True),
+    default=None,
+    help="Optional GROMACS index .ndx file.",
+)
 @click.pass_context
-def em(ctx, skip_completed, **kwargs):
+def em(
+    ctx,
+    skip_completed,
+    mdp_file,
+    structure_file,
+    top_file,
+    itp_files,
+    index_file,
+    **kwargs
+):
     """CLI subcommand for running GROMACS energy minimization."""
 
     jobrunner = ctx.obj.get("jobrunner", None)
     project = ctx.obj.get("project", None)
     filename = ctx.obj.get("filename", None)
+    if structure_file is None:
+        structure_file = filename
+    label = "gromacs_em"
+    if structure_file is not None:
+        label = os.path.splitext(os.path.basename(structure_file))[0] + "_em"
+
 
     logger.info(f"GROMACS EM project: {project}")
-    logger.info(f"GROMACS EM filename: {filename}")
-
-    label = "gromacs_em"
-    if filename is not None:
-        import os
-        label = os.path.splitext(os.path.basename(filename))[0] + "_em"
+    logger.info(f"GROMACS EM structure file: {structure_file}")
+    logger.info(f"GROMACS EM mdp file: {mdp_file}")
+    logger.info(f"GROMACS EM topology file: {top_file}")
+    logger.info(f"GROMACS EM itp files: {itp_files}")
+    logger.info(f"GROMACS EM index file: {index_file}")
 
     if ctx.invoked_subcommand is None:
         return GromacsEMJob(
             molecule=None,
-            settings=None,
             label=label,
             jobrunner=jobrunner,
+            mdp_file=mdp_file,
+            structure_file=structure_file,
+            top_file=top_file,
+            itp_files=itp_files,
+            index_file=index_file,
             skip_completed=skip_completed,
             **kwargs,
-        )
+         )

--- a/chemsmart/cli/gromacs/gromacs.py
+++ b/chemsmart/cli/gromacs/gromacs.py
@@ -60,4 +60,3 @@ def gromacs_process_pipeline(ctx, *args, **kwargs):
         f"Pipeline completed for subcommand: {ctx.invoked_subcommand}"
     )
     return args[0] if args else None
-from chemsmart.cli.gromacs.em import em

--- a/chemsmart/jobs/gromacs/__init__.py
+++ b/chemsmart/jobs/gromacs/__init__.py
@@ -1,5 +1,10 @@
 from .job import GromacsJob, GromacsEMJob
 from .runner import GromacsJobRunner
+from chemsmart.jobs.gromacs import (
+    GromacsJob,
+    GromacsEMJob,
+    GromacsJobRunner,
+)
 
 __all__ = [
     "GromacsJob",

--- a/chemsmart/jobs/gromacs/job.py
+++ b/chemsmart/jobs/gromacs/job.py
@@ -1,58 +1,46 @@
-"""
-GROMACS job definitions.
-"""
-
-import logging
-import os
+from pathlib import Path
 
 from chemsmart.jobs.job import Job
 
-logger = logging.getLogger(__name__)
-
-
 class GromacsJob(Job):
-    """
-    Base class for GROMACS jobs.
-    """
-
     PROGRAM = "gromacs"
-    TYPE = "gmx"
+    TYPE = "gromacs"
 
-    def __init__(self, molecule=None, settings=None, label=None, jobrunner=None, **kwargs):
+    def __init__(
+        self,
+        molecule,
+        label,
+        jobrunner,
+        mdp_file=None,
+        structure_file=None,
+        top_file=None,
+        tpr_file=None,
+        itp_files=None,
+        index_file=None,
+        **kwargs,
+    ):
         super().__init__(
             molecule=molecule,
             label=label,
             jobrunner=jobrunner,
             **kwargs,
         )
-        self.molecule = molecule
-        self.settings = settings
 
-        if label is None:
-            label = "gromacs_job"
-        self.label = label
-
-    @property
-    def inputfile(self):
-        """
-        First version: use .gro as the main structure input placeholder.
-        Later this may be generalized.
-        """
-        return os.path.join(self.folder, f"{self.label}.gro")
-
-    @property
-    def outputfile(self):
-        return os.path.join(self.folder, f"{self.label}.out")
-
-    @property
-    def errfile(self):
-        return os.path.join(self.folder, f"{self.label}.err")
+        self.mdp_file = Path(mdp_file) if mdp_file else None
+        self.structure_file = Path(structure_file) if structure_file else None
+        self.top_file = Path(top_file) if top_file else None
+        self.tpr_file = Path(tpr_file) if tpr_file else Path(self.folder) / f"{self.label}.tpr"
+        self.index_file = Path(index_file) if index_file else None
+        self.itp_files = [Path(f) for f in itp_files] if itp_files else []
 
     def _run(self, **kwargs):
-        logger.info(f"Running GromacsJob {self} with jobrunner {self.jobrunner}")
         self.jobrunner.run(self, **kwargs)
 
+    def has_tpr(self):
+        return self.tpr_file is not None and self.tpr_file.exists()
 
+    def has_topology(self):
+        return self.top_file is not None and self.top_file.exists()
 class GromacsEMJob(GromacsJob):
     """
     Energy minimization job for GROMACS.
@@ -60,11 +48,28 @@ class GromacsEMJob(GromacsJob):
 
     TYPE = "gmxem"
 
-    def __init__(self, molecule=None, settings=None, label=None, jobrunner=None, **kwargs):
+    def __init__(
+        self,
+        molecule=None,
+        label="gromacs_em",
+        jobrunner=None,
+        mdp_file=None,
+        structure_file=None,
+        top_file=None,
+        tpr_file=None,
+        itp_files=None,
+        index_file=None,
+        **kwargs,
+    ):
         super().__init__(
             molecule=molecule,
-            settings=settings,
             label=label,
             jobrunner=jobrunner,
+            mdp_file=mdp_file,
+            structure_file=structure_file,
+            top_file=top_file,
+            tpr_file=tpr_file,
+            itp_files=itp_files,
+            index_file=index_file,
             **kwargs,
         )


### PR DESCRIPTION
 This PR adds the initial GROMACS integration scaffold.

Current scope:
- registers `gromacs` in ChemSmart CLI subcommands
- adds `chemsmart/cli/gromacs` package
- adds base GROMACS CLI group
- adds initial `em` subcommand scaffold
- adds `GromacsJob` and `GromacsEMJob`
- adds initial `GromacsJobRunner`
- verifies that the CLI/job/runner imports and subcommand registration work locally

Notes:
- this is still a structural scaffold
- full GROMACS execution has not been validated end-to-end yet
- settings, writer, executable integration, and complete EM run logic remain next steps