### PR TITLE
Update GROMACS job and runner structure

### DIFF
--- a/chemsmart/jobs/gromacs/job.py
+++ b/chemsmart/jobs/gromacs/job.py
@@ -29,7 +29,12 @@ class GromacsJob(Job):
         self.mdp_file = Path(mdp_file) if mdp_file else None
         self.structure_file = Path(structure_file) if structure_file else None
         self.top_file = Path(top_file) if top_file else None
-        self.tpr_file = Path(tpr_file) if tpr_file else Path(self.folder) / f"{self.label}.tpr"
+        self._use_default_tpr_file = tpr_file is None
+        self.tpr_file = (
+            Path(tpr_file)
+            if tpr_file is not None
+            else Path(self.folder) / f"{self.label}.tpr"
+)
         self.index_file = Path(index_file) if index_file else None
         self.itp_files = [Path(f) for f in itp_files] if itp_files else []
 
@@ -41,6 +46,27 @@ class GromacsJob(Job):
 
     def has_topology(self):
         return self.top_file is not None and self.top_file.exists()
+    def has_required_prepared_inputs(self):
+        """
+        Check whether the job has the minimum user-provided files
+        required to assemble a TPR file.
+        """
+        return (
+                self.mdp_file is not None
+                and self.structure_file is not None
+                and self.top_file is not None
+        )
+
+    def set_folder(self, folder):
+            """
+            Set the job folder and update the default TPR path if it was not
+            explicitly provided by the user.
+            """
+            super().set_folder(folder)
+
+            if self._use_default_tpr_file:
+                self.tpr_file = Path(self.folder) / f"{self.label}.tpr"
+
 class GromacsEMJob(GromacsJob):
     """
     Energy minimization job for GROMACS.

--- a/chemsmart/jobs/gromacs/runner.py
+++ b/chemsmart/jobs/gromacs/runner.py
@@ -6,6 +6,7 @@ import logging
 import os
 import shlex
 import subprocess
+from pathlib import Path
 
 from chemsmart.jobs.runner import JobRunner
 
@@ -41,14 +42,29 @@ class GromacsJobRunner(JobRunner):
             **kwargs,
         )
 
+    @property
+    def executable(self):
+        """
+        First version: directly use gmx in PATH.
+        Later this can be replaced by executable settings logic.
+        """
+        return None
+
     def _prerun(self, job):
         self._assign_variables(job)
+        self._validate_gromacs_inputs(job)
+
+        if not job.has_tpr():
+            self._assemble_tpr(job)
 
     def _assign_variables(self, job):
         self.running_directory = job.folder
-        self.job_inputfile = os.path.abspath(job.inputfile)
-        self.job_outputfile = os.path.abspath(job.outputfile)
-        self.job_errfile = os.path.abspath(job.errfile)
+        self.job_outputfile = os.path.abspath(
+            os.path.join(job.folder, f"{job.label}.out")
+        )
+        self.job_errfile = os.path.abspath(
+            os.path.join(job.folder, f"{job.label}.err")
+        )
 
     def _write_input(self, job):
         """
@@ -66,11 +82,14 @@ class GromacsJobRunner(JobRunner):
 
     def _get_command(self, job):
         """
-        First version: assume EM-style execution.
-        Later this should branch by job type.
+         Return the GROMACS mdrun command.
+
+         The TPR file should already be assembled in _prerun.
+         The -deffnm value should match the actual TPR file prefix.
         """
         exe = self._get_executable()
-        command = f"{exe} mdrun -deffnm {job.label}"
+        deffnm = Path(job.tpr_file).with_suffix("")
+        command = f"{exe} mdrun -deffnm {deffnm}"
         return command
 
     def _create_process(self, job, command, env):
@@ -89,3 +108,68 @@ class GromacsJobRunner(JobRunner):
 
     def _postrun(self, job):
         pass
+
+    def _assemble_tpr(self, job):
+        """
+        Assemble a GROMACS TPR file using gmx grompp.
+        """
+        exe = self._get_executable()
+
+        command = [
+            exe,
+            "grompp",
+            "-f",
+            str(job.mdp_file),
+            "-c",
+            str(job.structure_file),
+            "-p",
+            str(job.top_file),
+            "-o",
+            str(job.tpr_file),
+        ]
+
+        if job.index_file is not None:
+            command.extend(["-n", str(job.index_file)])
+
+        logger.info(f"Assembling TPR with command: {' '.join(command)}")
+
+        process = subprocess.Popen(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            cwd=self.running_directory,
+        )
+        stdout, stderr = process.communicate()
+
+        if process.returncode != 0:
+            raise RuntimeError(
+                "Failed to assemble GROMACS TPR file with gmx grompp.\n"
+                f"Command: {' '.join(command)}\n"
+                f"STDOUT:\n{stdout}\n"
+                f"STDERR:\n{stderr}"
+            )
+
+    def _validate_gromacs_inputs(self, job):
+        """
+        Validate required GROMACS input files.
+        The first implementation supports prepared inputs:
+        mdp_file, structure_file, and top_file.
+        """
+        required_files = {
+            "mdp_file": getattr(job,"mdp_file",None),
+            "structure_file": getattr(job,"structure_file",None),
+            "top_file": getattr(job,"top_file",None),
+        }
+
+        missing = [
+            name
+            for name, path in required_files.items()
+            if path is None or not Path(path).exists()
+        ]
+
+        if missing:
+            raise FileNotFoundError(
+                "Missing required GROMACS input files: "
+                + ", ".join(missing)
+            )

--- a/tests/test_gromacs_runner.py
+++ b/tests/test_gromacs_runner.py
@@ -1,0 +1,135 @@
+import pytest
+from pathlib import Path
+
+from chemsmart.jobs.gromacs.job import GromacsEMJob
+from chemsmart.jobs.gromacs.runner import GromacsJobRunner
+
+
+def test_gromacs_em_job_type_matches_runner_jobtypes():
+    assert GromacsEMJob.TYPE in GromacsJobRunner.JOBTYPES
+
+
+def test_gromacs_em_job_stores_file_attributes(tmp_path):
+    mdp_file = tmp_path / "em.mdp"
+    structure_file = tmp_path / "input.gro"
+    top_file = tmp_path / "topol.top"
+    tpr_file = tmp_path / "em.tpr"
+
+    mdp_file.write_text("integrator = steep\n", encoding="utf-8")
+    structure_file.write_text("dummy structure\n", encoding="utf-8")
+    top_file.write_text("dummy topology\n", encoding="utf-8")
+
+    job = GromacsEMJob(
+        molecule=None,
+        label="em",
+        jobrunner=None,
+        mdp_file=mdp_file,
+        structure_file=structure_file,
+        top_file=top_file,
+    )
+
+    job.set_folder(str(tmp_path))
+
+    assert job.mdp_file == mdp_file
+    assert job.structure_file == structure_file
+    assert job.top_file == top_file
+    assert job.tpr_file ==tpr_file
+    assert job.has_required_prepared_inputs()
+
+
+def test_gromacs_runner_get_command_uses_tpr_file(tmp_path):
+    mdp_file = tmp_path / "em.mdp"
+    structure_file = tmp_path / "input.gro"
+    top_file = tmp_path / "topol.top"
+    tpr_file = tmp_path / "em.tpr"
+
+    mdp_file.write_text("integrator = steep\n", encoding="utf-8")
+    structure_file.write_text("dummy structure\n", encoding="utf-8")
+    top_file.write_text("dummy topology\n", encoding="utf-8")
+    tpr_file.write_text("dummy tpr\n", encoding="utf-8")
+
+    job = GromacsEMJob(
+        molecule=None,
+        label="em",
+        jobrunner=None,
+        mdp_file=mdp_file,
+        structure_file=structure_file,
+        top_file=top_file,
+        tpr_file=tmp_path/"em.tpr",
+    )
+
+    job.set_folder(str(tmp_path))
+
+    runner = GromacsJobRunner.__new__(GromacsJobRunner)
+    command = runner._get_command(job)
+
+    assert command == f"gmx mdrun -deffnm {tmp_path / 'em'}"
+def test_gromacs_em_job_keeps_user_provided_tpr_file(tmp_path):
+    mdp_file = tmp_path / "em.mdp"
+    structure_file = tmp_path / "input.gro"
+    top_file = tmp_path / "topol.top"
+    custom_tpr_file = tmp_path / "custom_em.tpr"
+
+    mdp_file.write_text("integrator = steep\n", encoding="utf-8")
+    structure_file.write_text("dummy structure\n", encoding="utf-8")
+    top_file.write_text("dummy topology\n", encoding="utf-8")
+    custom_tpr_file.write_text("dummy tpr\n", encoding="utf-8")
+
+    job = GromacsEMJob(
+        molecule=None,
+        label="em",
+        jobrunner=None,
+        mdp_file=mdp_file,
+        structure_file=structure_file,
+        top_file=top_file,
+        tpr_file=custom_tpr_file,
+    )
+
+    new_folder = tmp_path / "new_folder"
+    new_folder.mkdir()
+    job.set_folder(str(new_folder))
+
+    assert job.tpr_file == custom_tpr_file
+def test_gromacs_runner_validate_inputs_passes_with_required_files(tmp_path):
+    mdp_file = tmp_path / "em.mdp"
+    structure_file = tmp_path / "input.gro"
+    top_file = tmp_path / "topol.top"
+
+    mdp_file.write_text("integrator = steep\n", encoding="utf-8")
+    structure_file.write_text("dummy structure\n", encoding="utf-8")
+    top_file.write_text("dummy topology\n", encoding="utf-8")
+
+    job = GromacsEMJob(
+        molecule=None,
+        label="em",
+        jobrunner=None,
+        mdp_file=mdp_file,
+        structure_file=structure_file,
+        top_file=top_file,
+    )
+
+    runner = GromacsJobRunner.__new__(GromacsJobRunner)
+
+    runner._validate_gromacs_inputs(job)
+
+
+def test_gromacs_runner_validate_inputs_raises_for_missing_files(tmp_path):
+    mdp_file = tmp_path / "em.mdp"
+    structure_file = tmp_path / "input.gro"
+
+    mdp_file.write_text("integrator = steep\n", encoding="utf-8")
+    structure_file.write_text("dummy structure\n", encoding="utf-8")
+
+    job = GromacsEMJob(
+        molecule=None,
+        label="em",
+        jobrunner=None,
+        mdp_file=mdp_file,
+        structure_file=structure_file,
+        top_file=None,
+    )
+
+    runner = GromacsJobRunner.__new__(GromacsJobRunner)
+
+    with pytest.raises(FileNotFoundError, match="top_file"):
+        runner._validate_gromacs_inputs(job)


### PR DESCRIPTION
This PR updates the initial GROMACS job and runner structure based on the shared `gromacs` branch.

Current scope:
- keeps `GromacsJob` inherited from the base `Job` class
- keeps `GromacsEMJob` inherited from `GromacsJob`
- adds GROMACS-specific file attributes, including `mdp_file`, `structure_file`, `top_file`, `tpr_file`, `itp_files`, and `index_file`
- updates `GromacsJobRunner` to inherit from the base `JobRunner`
- uses the existing runner lifecycle instead of defining a separate run flow
- adds pre-run validation for required GROMACS input files
- adds initial TPR assembly logic using `gmx grompp`
- updates `mdrun` command generation to use the actual TPR file prefix
- adds smoke tests for job type matching, file attributes, TPR path handling, runner command generation, and input validation

Notes:
- this is still an initial structural implementation
- the first supported path is user-provided/prepared GROMACS input files
- automatic force-field generation is not implemented yet
- settings/YAML integration, writer logic, executable settings, and full end-to-end EM execution remain next steps