### PR TITLE
Use source filename basename (not label) for PyMOL spin/MO/NCI file processing

### DIFF
--- a/chemsmart/cli/mol/mo.py
+++ b/chemsmart/cli/mol/mo.py
@@ -55,6 +55,7 @@ def mo(
 
     # get label for the job
     label = ctx.obj["label"]
+    source_basename = ctx.obj["source_basename"]
     if coordinates is not None:
         logger.debug(f"Coordinates for visualization: {coordinates}")
         try:
@@ -72,6 +73,7 @@ def mo(
     return PyMOLMOJob(
         molecule=molecules,
         label=label,
+        source_basename=source_basename,
         pymol_script=file,
         style=style,
         trace=trace,

--- a/chemsmart/cli/mol/mol.py
+++ b/chemsmart/cli/mol/mol.py
@@ -371,6 +371,7 @@ def mol(
     ctx.ensure_object(dict)
     # mark this pipeline as not QMMM by default
     ctx.obj.setdefault("qmmm", False)
+    ctx.obj.setdefault("source_basename", None)
     ctx.obj["label_provided"] = label is not None
     molecules = None
     source_basename = None

--- a/chemsmart/cli/mol/mol.py
+++ b/chemsmart/cli/mol/mol.py
@@ -371,6 +371,7 @@ def mol(
     ctx.ensure_object(dict)
     # mark this pipeline as not QMMM by default
     ctx.obj.setdefault("qmmm", False)
+    ctx.obj["label_provided"] = label is not None
     molecules = None
     source_basename = None
 

--- a/chemsmart/cli/mol/mol.py
+++ b/chemsmart/cli/mol/mol.py
@@ -372,6 +372,7 @@ def mol(
     # mark this pipeline as not QMMM by default
     ctx.obj.setdefault("qmmm", False)
     molecules = None
+    source_basename = None
 
     # Normalize empty tuple to None (click's
     # multiple=True returns () when no -f provided)
@@ -453,6 +454,9 @@ def mol(
         else:
             if len(filenames) == 1:
                 filenames = filenames[0]
+                source_basename = os.path.splitext(
+                    os.path.basename(filenames)
+                )[0]
                 molecules = Molecule.from_filepath(
                     filepath=filenames, index=":", return_list=True
                 )
@@ -516,6 +520,7 @@ def mol(
     ctx.obj["directory"] = directory
     ctx.obj["filetype"] = filetype
     ctx.obj["filenames"] = filenames
+    ctx.obj["source_basename"] = source_basename
     ctx.obj["qmmm"] = False
 
 

--- a/chemsmart/cli/mol/nci.py
+++ b/chemsmart/cli/mol/nci.py
@@ -53,6 +53,7 @@ def nci(
 
     # get label for the job
     label = ctx.obj["label"]
+    source_basename = ctx.obj["source_basename"]
     if coordinates is not None:
         logger.debug(f"Coordinates for visualization: {coordinates}")
         try:
@@ -70,6 +71,7 @@ def nci(
     return PyMOLNCIJob(
         molecule=molecules,
         label=label,
+        source_basename=source_basename,
         isosurface_value=isosurface_value,
         color_range=color_range,
         binary=binary,

--- a/chemsmart/cli/mol/spin.py
+++ b/chemsmart/cli/mol/spin.py
@@ -52,6 +52,7 @@ def spin(
 
     # get label for the job
     label = ctx.obj["label"]
+    source_basename = ctx.obj["source_basename"]
     if coordinates is not None:
         logger.debug(f"Coordinates for visualization: {coordinates}")
         try:
@@ -69,6 +70,7 @@ def spin(
     return PyMOLSpinJob(
         molecule=molecules,
         label=label,
+        source_basename=source_basename,
         pymol_script=file,
         style=style,
         trace=trace,

--- a/chemsmart/cli/mol/spin.py
+++ b/chemsmart/cli/mol/spin.py
@@ -53,6 +53,7 @@ def spin(
     # get label for the job
     label = ctx.obj["label"]
     source_basename = ctx.obj["source_basename"]
+    spin_basename = label if ctx.obj["label_provided"] else None
     if coordinates is not None:
         logger.debug(f"Coordinates for visualization: {coordinates}")
         try:
@@ -71,6 +72,7 @@ def spin(
         molecule=molecules,
         label=label,
         source_basename=source_basename,
+        spin_basename=spin_basename,
         pymol_script=file,
         style=style,
         trace=trace,

--- a/chemsmart/jobs/mol/job.py
+++ b/chemsmart/jobs/mol/job.py
@@ -46,6 +46,7 @@ class PyMOLJob(Job):
         self,
         molecule=None,
         label=None,
+        source_basename=None,
         jobrunner=None,
         pymol_script=None,
         style=None,
@@ -71,6 +72,8 @@ class PyMOLJob(Job):
         Args:
             molecule: Molecule or list[Molecule] to visualize.
             label: Job identifier string (default: None).
+            source_basename: Basename of source calculation/input files
+                used for processing steps like chk/fchk/cube handling.
             jobrunner: Runner for executing the job (default: None).
             pymol_script: Custom PyMOL script path (default: None).
             style: Visualization style settings (default: None).
@@ -91,6 +94,9 @@ class PyMOLJob(Job):
         super().__init__(
             molecule=molecule, label=label, jobrunner=jobrunner, **kwargs
         )
+        if source_basename is None:
+            source_basename = label
+        self.source_basename = source_basename
         self.pymol_script = pymol_script
         self.style = style
         self.trace = trace
@@ -280,7 +286,13 @@ class PyMOLJob(Job):
         if label is None:
             # by default, if no label is given and the job is read in
             # from a file, the label is set to the file basename
-            label = os.path.basename(filename).split(".")[0]
+            label = os.path.basename(filename).splitext(
+                os.path.basename(filename)
+            )[0]
+
+        source_basename = os.path.basename(filename).splitext(
+            os.path.basename(filename)
+        )[0]
 
         logger.info(f"Num of molecules read: {len(molecules)}.")
         molecules = molecules[string2index_1based(index)]
@@ -292,6 +304,7 @@ class PyMOLJob(Job):
                 cls(
                     molecule=molecules,
                     label=label,
+                    source_basename=source_basename,
                     pymol_script=pymol_script,
                     style=style,
                     vdw=vdw,
@@ -309,6 +322,7 @@ class PyMOLJob(Job):
         return cls(
             molecule=molecules,
             label=label,
+            source_basename=source_basename,
             jobrunner=jobrunner,
             pymol_script=pymol_script,
             style=style,

--- a/chemsmart/jobs/mol/job.py
+++ b/chemsmart/jobs/mol/job.py
@@ -290,7 +290,6 @@ class PyMOLJob(Job):
 
         source_basename = os.path.splitext(os.path.basename(filename))[0]
 
-        logger.info(f"Num of molecules read: {len(molecules)}.")
         molecules = molecules[string2index_1based(index)]
         logger.info(f"Num of molecules to use: {len(molecules)}.")
 

--- a/chemsmart/jobs/mol/job.py
+++ b/chemsmart/jobs/mol/job.py
@@ -286,13 +286,9 @@ class PyMOLJob(Job):
         if label is None:
             # by default, if no label is given and the job is read in
             # from a file, the label is set to the file basename
-            label = os.path.basename(filename).splitext(
-                os.path.basename(filename)
-            )[0]
+            label = os.path.splitext(os.path.basename(filename))[0]
 
-        source_basename = os.path.basename(filename).splitext(
-            os.path.basename(filename)
-        )[0]
+        source_basename = os.path.splitext(os.path.basename(filename))[0]
 
         logger.info(f"Num of molecules read: {len(molecules)}.")
         molecules = molecules[string2index_1based(index)]

--- a/chemsmart/jobs/mol/runner.py
+++ b/chemsmart/jobs/mol/runner.py
@@ -1588,7 +1588,7 @@ class PyMOLSpinJobRunner(PyMOLVisualizationJobRunner):
         """
         gaussian_exe = self._get_gaussian_executable(job)
 
-        cubegen_command = f"{gaussian_exe}/cubegen 0 spin {job.label}.fchk {job.job_basename}.cube {job.npts}"
+        cubegen_command = f"{gaussian_exe}/cubegen 0 spin {job.source_basename}.fchk {job.job_basename}.cube {job.npts}"
         run_command(cubegen_command)
 
     def _write_spin_density_pml(self, job):

--- a/chemsmart/jobs/mol/runner.py
+++ b/chemsmart/jobs/mol/runner.py
@@ -291,8 +291,10 @@ class PyMOLJobRunner(JobRunner):
         Raises:
             FileNotFoundError: If the required .chk file is not found.
         """
-        chk_file_path = os.path.join(job.folder, f"{job.label}.chk")
-        fchk_file_path = os.path.join(job.folder, f"{job.label}.fchk")
+        chk_file_path = os.path.join(job.folder, f"{job.source_basename}.chk")
+        fchk_file_path = os.path.join(
+            job.folder, f"{job.source_basename}.fchk"
+        )
         if not os.path.exists(chk_file_path) and not os.path.exists(
             fchk_file_path
         ):
@@ -303,14 +305,16 @@ class PyMOLJobRunner(JobRunner):
         gaussian_exe = self._get_gaussian_executable(job)
         if os.path.exists(fchk_file_path):
             logger.info(
-                f".fchk file {job.label}.fchk already exists.\n"
+                f".fchk file {job.source_basename}.fchk already exists.\n"
                 f"Skipping generation of .fchk file."
             )
             pass
         else:
             # generate .fchk file from .chk file
-            logger.info(f"Generating .fchk file from {job.label}.chk")
-            fchk_command = f"{gaussian_exe}/formchk {job.label}.chk"
+            logger.info(
+                f"Generating .fchk file from {job.source_basename}.chk"
+            )
+            fchk_command = f"{gaussian_exe}/formchk {job.source_basename}.chk"
             run_command(fchk_command)
 
     def _write_input(self, job):
@@ -1305,8 +1309,12 @@ class PyMOLNCIJobRunner(PyMOLVisualizationJobRunner):
         Raises:
             AssertionError: If required cube files are not found.
         """
-        dens_file = os.path.join(job.folder, f"{job.label}-dens.cube")
-        grad_file = os.path.join(job.folder, f"{job.label}-grad.cube")
+        dens_file = os.path.join(
+            job.folder, f"{job.source_basename}-dens.cube"
+        )
+        grad_file = os.path.join(
+            job.folder, f"{job.source_basename}-grad.cube"
+        )
         assert os.path.exists(
             dens_file
         ), f"Density cube file {dens_file} not found!"
@@ -1335,11 +1343,11 @@ class PyMOLNCIJobRunner(PyMOLVisualizationJobRunner):
             str: Command string with NCI visualization command.
         """
         if job.binary:
-            command += f"; nci_binary {job.label}"
+            command += f"; nci_binary {job.source_basename}"
         elif job.intermediate:
-            command += f"; nci_intermediate {job.label}"
+            command += f"; nci_intermediate {job.source_basename}"
         else:
-            command += f"; nci {job.label}"
+            command += f"; nci {job.source_basename}"
         return command
 
 
@@ -1389,7 +1397,7 @@ class PyMOLMOJobRunner(PyMOLVisualizationJobRunner):
             run cubegen_command and returns None
             cubegen_command generatess the appropriate .cube file
             based on the job type (job.job_basename; nci/spin etc)
-            from job.label.fchk file.
+            from job.source_basename.fchk file.
         """
         gaussian_exe = self._get_gaussian_executable(job)
 
@@ -1426,7 +1434,7 @@ class PyMOLMOJobRunner(PyMOLVisualizationJobRunner):
             )
 
         cubegen_command = (
-            f"{gaussian_exe}/cubegen 0 MO={mo_type} {job.label}.fchk "
+            f"{gaussian_exe}/cubegen 0 MO={mo_type} {job.source_basename}.fchk "
             f"{job.job_basename}.cube 0 h"
         )
 

--- a/docs/source/pymol-cli-options.rst
+++ b/docs/source/pymol-cli-options.rst
@@ -44,7 +44,8 @@ This page documents the CLI options for molecular visualization and analysis usi
 
    -  -  ``-l, --label``
       -  string
-      -  Custom output filename
+      -  Custom output filename. For ``mo``/``spin``/``nci``, this controls output naming only; processing input files
+         still use the source filename basename.
 
    -  -  ``-a, --append-label``
       -  string

--- a/docs/source/pymol-electronic-structure.rst
+++ b/docs/source/pymol-electronic-structure.rst
@@ -80,7 +80,9 @@ Generate spin density visualizations for open-shell systems.
 
 .. note::
 
-   Requires both ``.log`` and ``.chk`` files in the same folder.
+   Requires both ``.log`` and ``.chk`` files in the same folder. If ``-l/--label`` is provided, Chemsmart still
+   processes files from the source filename basename (for example, ``output.log`` -> ``output.chk``/``output.fchk``),
+   while the final spin output/session filename follows the custom label.
 
 Spin density jobs inherit all visualization options.
 
@@ -98,3 +100,12 @@ With ray tracing:
 .. code:: bash
 
    chemsmart run mol -f radical.log spin -t
+
+With custom output label while still processing source files:
+
+.. code:: bash
+
+   chemsmart run mol -f output.log -l new_name_new_spin_isovalue spin -i 0.1
+
+This command processes ``output.log`` (and related ``output.chk``/``output.fchk``) and writes the spin session as
+``new_name_new_spin_isovalue.pse``.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -333,6 +333,22 @@ def invoke_mol_with_visualize():
     return _invoke
 
 
+@pytest.fixture
+def invoke_mol_cli():
+    """Invoke ``mol`` CLI with provided args."""
+    from chemsmart.cli.mol.mol import mol as mol_group
+
+    def _invoke(cli_args, ctx_obj=None):
+        runner = CliRunner()
+        if ctx_obj is None:
+            ctx_obj = {}
+        return runner.invoke(
+            mol_group, cli_args, obj=ctx_obj, catch_exceptions=False
+        )
+
+    return _invoke
+
+
 @pytest.fixture()
 def chemsmart_templates_config(mocker):
     """

--- a/tests/test_PyMOLJobs.py
+++ b/tests/test_PyMOLJobs.py
@@ -10,6 +10,10 @@ from chemsmart.jobs.mol.irc import PyMOLIRCMovieJob
 from chemsmart.jobs.mol.mo import PyMOLMOJob
 from chemsmart.jobs.mol.movie import PyMOLMovieJob
 from chemsmart.jobs.mol.nci import PyMOLNCIJob
+from chemsmart.jobs.mol.runner import (
+    PyMOLNCIJobRunner,
+    PyMOLSpinJobRunner,
+)
 from chemsmart.jobs.mol.spin import PyMOLSpinJob
 from chemsmart.jobs.mol.visualize import PyMOLVisualizationJob
 from chemsmart.utils.cluster import (
@@ -751,3 +755,127 @@ class TestPyMOLCLIFolderOptions:
         assert "No such option" not in result.output, result.output
         label = ctx_obj.get("label", "")
         assert "gaussian" in label
+
+
+class TestPyMOLFileProcessingUsesSourceFilename:
+    def test_spin_cli_custom_label_uses_source_basename_and_exact_output_name(
+        self, gaussian_benzene_opt_outfile, invoke_mol_cli
+    ):
+        from unittest.mock import patch
+
+        custom_label = "new_name_new_spin_isovalue"
+        with patch("chemsmart.jobs.mol.spin.PyMOLSpinJob") as mock_spin_job:
+            result = invoke_mol_cli(
+                [
+                    "-f",
+                    gaussian_benzene_opt_outfile,
+                    "-l",
+                    custom_label,
+                    "spin",
+                    "-i",
+                    "0.1",
+                ]
+            )
+
+        assert result.exit_code == 0, result.output
+        _, kwargs = mock_spin_job.call_args
+        assert kwargs["source_basename"] == "benzene"
+        assert kwargs["label"] == custom_label
+        assert kwargs["spin_basename"] == custom_label
+
+    def test_generate_fchk_uses_source_basename_not_label(
+        self,
+        tmpdir,
+        gaussian_benzene_opt_outfile,
+        pymol_mo_jobrunner,
+        monkeypatch,
+    ):
+        molecules = Molecule.from_filepath(
+            gaussian_benzene_opt_outfile, index="-1", return_list=True
+        )
+        job = PyMOLMOJob(
+            molecules,
+            label="custom_label",
+            source_basename="benzene_opt",
+            homo=True,
+        )
+        job.set_folder(tmpdir)
+
+        with open(os.path.join(tmpdir, "benzene_opt.chk"), "w"):
+            pass
+
+        commands = []
+        monkeypatch.setattr(
+            pymol_mo_jobrunner,
+            "_get_gaussian_executable",
+            lambda _job: "/gaussian",
+        )
+        monkeypatch.setattr(
+            "chemsmart.jobs.mol.runner.run_command",
+            lambda cmd: commands.append(cmd),
+        )
+
+        pymol_mo_jobrunner._generate_fchk_file(job)
+
+        assert commands == ["/gaussian/formchk benzene_opt.chk"]
+
+    def test_spin_cubegen_uses_source_basename_fchk(
+        self, tmpdir, gaussian_benzene_opt_outfile, pbs_server, monkeypatch
+    ):
+        molecules = Molecule.from_filepath(
+            gaussian_benzene_opt_outfile, index="-1", return_list=True
+        )
+        job = PyMOLSpinJob(
+            molecules,
+            label="spin_label",
+            source_basename="benzene_opt",
+        )
+        job.set_folder(tmpdir)
+        runner = PyMOLSpinJobRunner(server=pbs_server, scratch=False)
+
+        commands = []
+        monkeypatch.setattr(
+            runner,
+            "_get_gaussian_executable",
+            lambda _job: "/gaussian",
+        )
+        monkeypatch.setattr(
+            "chemsmart.jobs.mol.runner.run_command",
+            lambda cmd: commands.append(cmd),
+        )
+
+        runner._generate_spin_cube_file(job)
+
+        assert commands == [
+            f"/gaussian/cubegen 0 spin benzene_opt.fchk spin_label_spin.cube {job.npts}"
+        ]
+
+    def test_nci_uses_source_basename_for_cube_loading_and_command(
+        self, tmpdir, gaussian_benzene_opt_outfile, pbs_server
+    ):
+        molecules = Molecule.from_filepath(
+            gaussian_benzene_opt_outfile, index="-1", return_list=True
+        )
+        job = PyMOLNCIJob(
+            molecules,
+            label="renamed_label",
+            source_basename="benzene_opt",
+            isosurface_value=0.5,
+            color_range=1.0,
+        )
+        job.set_folder(tmpdir)
+        runner = PyMOLNCIJobRunner(server=pbs_server, scratch=False)
+
+        dens_file = os.path.join(tmpdir, "benzene_opt-dens.cube")
+        grad_file = os.path.join(tmpdir, "benzene_opt-grad.cube")
+        with open(dens_file, "w"):
+            pass
+        with open(grad_file, "w"):
+            pass
+
+        command = runner._load_cube_files(job, "cmd")
+        command = runner._run_nci_command(job, command)
+
+        assert f"load {dens_file}" in command
+        assert f"load {grad_file}" in command
+        assert "; nci benzene_opt" in command

--- a/tests/test_PyMOLJobs.py
+++ b/tests/test_PyMOLJobs.py
@@ -4,6 +4,7 @@ import shutil
 import pytest
 
 from chemsmart.io.molecules.structure import Molecule
+from chemsmart.utils.utils import quote_path
 from chemsmart.jobs.mol import PyMOLHybridVisualizationJob
 from chemsmart.jobs.mol.align import PyMOLAlignJob
 from chemsmart.jobs.mol.irc import PyMOLIRCMovieJob
@@ -876,6 +877,6 @@ class TestPyMOLFileProcessingUsesSourceFilename:
         command = runner._load_cube_files(job, "cmd")
         command = runner._run_nci_command(job, command)
 
-        assert f"load {dens_file}" in command
-        assert f"load {grad_file}" in command
+        assert f"load {quote_path(dens_file)}" in command
+        assert f"load {quote_path(grad_file)}" in command
         assert "; nci benzene_opt" in command

--- a/tests/test_PyMOLJobs.py
+++ b/tests/test_PyMOLJobs.py
@@ -4,7 +4,6 @@ import shutil
 import pytest
 
 from chemsmart.io.molecules.structure import Molecule
-from chemsmart.utils.utils import quote_path
 from chemsmart.jobs.mol import PyMOLHybridVisualizationJob
 from chemsmart.jobs.mol.align import PyMOLAlignJob
 from chemsmart.jobs.mol.irc import PyMOLIRCMovieJob
@@ -21,6 +20,7 @@ from chemsmart.utils.cluster import (
     is_pubchem_api_available,
     is_pubchem_network_available,
 )
+from chemsmart.utils.utils import quote_path
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
This is useful when running and creating spin/mo/nci jobs that need to be relabelled for the output but requires the same input.chk or input.fchk files to generate the cube files.

For examples, both `chemsmart run mol -f input.log spin` and `chemsmart run mol -f input.log  -a spin_point_zerofive spin -i 0.05` will use input.chk / input.fchk instead of having the second one using input_spin_point_zerofive.chk (.fchk) which will not be found. This is useful when we want to process the same chk/fchk file to generate different output visualisation settings.