### PR TITLE
Add CLI and Job unit tests for GROMACS integration

### DIFF
--- a/chemsmart/cli/gromacs/__init__.py
+++ b/chemsmart/cli/gromacs/__init__.py
@@ -1,14 +1,13 @@
-from .factory import GromacsJobFactory
-from .job import GromacsEMJob, GromacsJob
-from .runner import GromacsJobRunner
-from .state import GromacsWorkflowState
-from .writer import GromacsInputWriter
+"""
+GROMACS command-line interface subcommands.
+
+This module provides CLI subcommands for GROMACS workflows.
+"""
+
+from .em import em
+from .gromacs import gromacs
 
 __all__ = [
-    "GromacsJob",
-    "GromacsEMJob",
-    "GromacsJobRunner",
-    "GromacsJobFactory",
-    "GromacsWorkflowState",
-    "GromacsInputWriter",
+    "gromacs",
+    "em",
 ]

--- a/chemsmart/cli/gromacs/__init__.py
+++ b/chemsmart/cli/gromacs/__init__.py
@@ -1,13 +1,14 @@
-"""
-GROMACS command-line interface subcommands.
-
-This module provides CLI subcommands for GROMACS workflows.
-"""
-
-from .em import em
-from .gromacs import gromacs
+from .factory import GromacsJobFactory
+from .job import GromacsEMJob, GromacsJob
+from .runner import GromacsJobRunner
+from .state import GromacsWorkflowState
+from .writer import GromacsInputWriter
 
 __all__ = [
-    "gromacs",
-    "em",
+    "GromacsJob",
+    "GromacsEMJob",
+    "GromacsJobRunner",
+    "GromacsJobFactory",
+    "GromacsWorkflowState",
+    "GromacsInputWriter",
 ]

--- a/chemsmart/cli/gromacs/em.py
+++ b/chemsmart/cli/gromacs/em.py
@@ -1,27 +1,21 @@
+
+from __future__ import annotations
 """
 GROMACS energy minimization CLI command.
 
 This command supports two creation modes:
-
-1. YAML-driven mode:
-       chemsmart run gromacs -p project.yaml em
-
-2. Direct CLI mode:
-       chemsmart run gromacs em --mdp em.mdp --structure input.gro --top topol.top
-
-YAML-driven mode is preferred for ChemSmart integration because it follows the
-settings -> job -> runner architecture.
+1. YAML-driven mode: chemsmart run gromacs -p project.yaml em
+2. Direct CLI mode: chemsmart run gromacs em --mdp em.mdp --structure input.gro --top topol.top
 """
 
 import logging
-import os
 from pathlib import Path
-
 import click
 
 from chemsmart.cli.gromacs.gromacs import gromacs
 from chemsmart.cli.job import click_job_options
 from chemsmart.jobs.gromacs.job import GromacsEMJob
+from chemsmart.settings.gromacs import GromacsProjectSettings
 from chemsmart.utils.cli import MyGroup
 
 logger = logging.getLogger(__name__)
@@ -36,6 +30,7 @@ logger = logging.getLogger(__name__)
         exists=True,
         dir_okay=False,
         resolve_path=True,
+        path_type=Path,
     ),
     default=None,
     help="GROMACS .mdp file for energy minimization.",
@@ -47,6 +42,7 @@ logger = logging.getLogger(__name__)
         exists=True,
         dir_okay=False,
         resolve_path=True,
+        path_type=Path,
     ),
     default=None,
     help="Optional .mdp file used to generate ions.tpr in full_setup workflow.",
@@ -59,6 +55,7 @@ logger = logging.getLogger(__name__)
         exists=True,
         dir_okay=False,
         resolve_path=True,
+        path_type=Path,
     ),
     default=None,
     help="Input structure file, such as .gro or .pdb.",
@@ -70,6 +67,7 @@ logger = logging.getLogger(__name__)
         exists=True,
         dir_okay=False,
         resolve_path=True,
+        path_type=Path,
     ),
     default=None,
     help="Raw PDB file used by the full_setup workflow.",
@@ -81,6 +79,7 @@ logger = logging.getLogger(__name__)
         exists=True,
         dir_okay=False,
         resolve_path=True,
+        path_type=Path,
     ),
     default=None,
     help="GROMACS topology .top file.",
@@ -92,9 +91,22 @@ logger = logging.getLogger(__name__)
         exists=True,
         dir_okay=False,
         resolve_path=True,
+        path_type=Path,
     ),
     default=None,
     help="Optional GROMACS index .ndx file.",
+)
+@click.option(
+    "--itp",
+    "itp_files",
+    multiple=True,
+    type=click.Path(
+        exists=True,
+        dir_okay=False,
+        resolve_path=True,
+        path_type=Path,
+    ),
+    help="Optional GROMACS .itp include file. Can be used multiple times.",
 )
 @click.option(
     "--workflow",
@@ -111,9 +123,10 @@ def em(
     structure_file,
     input_pdb,
     top_file,
-    itp_files,
     index_file,
+    itp_files,
     workflow,
+    molecule=None,
     **kwargs,
 ):
     """
@@ -144,47 +157,39 @@ def em(
         settings.validate()
 
         logger.info(
-            "Creating GROMACS EM job from project settings: project=%s, "
-            "project_yaml=%s",
-            project,
-            project_yaml,
+            "Creating GROMACS EM job from project YAML: %s",
+            project_yaml
         )
 
         if ctx.invoked_subcommand is None:
             return GromacsEMJob.from_project_settings(
                 settings=settings,
-                molecule=None,
+                molecule=molecule,
                 jobrunner=jobrunner,
                 skip_completed=skip_completed,
                 **kwargs,
             )
-
         return None
 
+    # direct CLI mode
     label = "gromacs_em"
-
     if structure_file is not None:
         label = (
-            os.path.splitext(os.path.basename(str(structure_file)))[0]
-            + "_em"
+            Path(structure_file).stem + "_em"
         )
 
     workflow = workflow or "prepared"
 
     logger.info("Creating GROMACS EM job from direct CLI options.")
-    logger.info("GROMACS EM project: %s", project)
     logger.info("GROMACS EM structure file: %s", structure_file)
-    logger.info("GROMACS EM input PDB file: %s", input_pdb)
     logger.info("GROMACS EM mdp file: %s", mdp_file)
-    logger.info("GROMACS EM ions mdp file: %s", ions_mdp_file)
     logger.info("GROMACS EM topology file: %s", top_file)
     logger.info("GROMACS EM itp files: %s", itp_files)
-    logger.info("GROMACS EM index file: %s", index_file)
     logger.info("GROMACS EM workflow: %s", workflow)
 
     if ctx.invoked_subcommand is None:
         return GromacsEMJob(
-            molecule=None,
+            molecule=molecule,
             label=label,
             jobrunner=jobrunner,
             mdp_file=Path(mdp_file) if mdp_file else None,
@@ -198,5 +203,3 @@ def em(
             skip_completed=skip_completed,
             **kwargs,
         )
-
-    return None

--- a/chemsmart/cli/gromacs/em.py
+++ b/chemsmart/cli/gromacs/em.py
@@ -1,5 +1,21 @@
+"""
+GROMACS energy minimization CLI command.
+
+This command supports two creation modes:
+
+1. YAML-driven mode:
+       chemsmart run gromacs -p project.yaml em
+
+2. Direct CLI mode:
+       chemsmart run gromacs em --mdp em.mdp --structure input.gro --top topol.top
+
+YAML-driven mode is preferred for ChemSmart integration because it follows the
+settings -> job -> runner architecture.
+"""
+
 import logging
 import os
+from pathlib import Path
 
 import click
 
@@ -16,71 +32,171 @@ logger = logging.getLogger(__name__)
 @click.option(
     "--mdp",
     "mdp_file",
-    type=click.Path(exists=True, dir_okay=False, resolve_path=True),
+    type=click.Path(
+        exists=True,
+        dir_okay=False,
+        resolve_path=True,
+    ),
     default=None,
-    help="GROMACS .mdp file for energy minimization",
+    help="GROMACS .mdp file for energy minimization.",
+)
+@click.option(
+    "--ions-mdp",
+    "ions_mdp_file",
+    type=click.Path(
+        exists=True,
+        dir_okay=False,
+        resolve_path=True,
+    ),
+    default=None,
+    help="Optional .mdp file used to generate ions.tpr in full_setup workflow.",
 )
 @click.option(
     "--structure",
     "-s",
     "structure_file",
-    type=click.Path(exists=True, dir_okay=False, resolve_path=True),
+    type=click.Path(
+        exists=True,
+        dir_okay=False,
+        resolve_path=True,
+    ),
     default=None,
-    help="Input structure file,such as .gro or .pdb.",
+    help="Input structure file, such as .gro or .pdb.",
+)
+@click.option(
+    "--input-pdb",
+    "input_pdb",
+    type=click.Path(
+        exists=True,
+        dir_okay=False,
+        resolve_path=True,
+    ),
+    default=None,
+    help="Raw PDB file used by the full_setup workflow.",
 )
 @click.option(
     "--top",
     "top_file",
-    type=click.Path(exists=True, dir_okay=False, resolve_path=True),
+    type=click.Path(
+        exists=True,
+        dir_okay=False,
+        resolve_path=True,
+    ),
     default=None,
     help="GROMACS topology .top file.",
 )
 @click.option(
     "--index",
     "index_file",
-    type=click.Path(exists=True, dir_okay=False, resolve_path=True),
+    type=click.Path(
+        exists=True,
+        dir_okay=False,
+        resolve_path=True,
+    ),
     default=None,
     help="Optional GROMACS index .ndx file.",
+)
+@click.option(
+    "--workflow",
+    type=click.Choice(["prepared", "full_setup"]),
+    default=None,
+    help="GROMACS workflow mode.",
 )
 @click.pass_context
 def em(
     ctx,
     skip_completed,
     mdp_file,
+    ions_mdp_file,
     structure_file,
+    input_pdb,
     top_file,
     itp_files,
     index_file,
+    workflow,
     **kwargs,
 ):
-    """CLI subcommand for running GROMACS energy minimization."""
+    """
+    CLI subcommand for running GROMACS energy minimization.
+    """
 
     jobrunner = ctx.obj.get("jobrunner", None)
     project = ctx.obj.get("project", None)
+    project_yaml = ctx.obj.get("project_yaml", None)
+    project_settings = ctx.obj.get("project_settings", None)
     filename = ctx.obj.get("filename", None)
+
     if structure_file is None:
         structure_file = filename
-    label = "gromacs_em"
-    if structure_file is not None:
-        label = os.path.splitext(os.path.basename(structure_file))[0] + "_em"
 
-    logger.info(f"GROMACS EM project: {project}")
-    logger.info(f"GROMACS EM structure file: {structure_file}")
-    logger.info(f"GROMACS EM mdp file: {mdp_file}")
-    logger.info(f"GROMACS EM topology file: {top_file}")
-    logger.info(f"GROMACS EM itp files: {itp_files}")
-    logger.info(f"GROMACS EM index file: {index_file}")
+    if project_settings is not None:
+        settings = project_settings.with_overrides(
+            mdp_file=Path(mdp_file) if mdp_file else None,
+            ions_mdp_file=Path(ions_mdp_file) if ions_mdp_file else None,
+            structure_file=Path(structure_file) if structure_file else None,
+            input_pdb=Path(input_pdb) if input_pdb else None,
+            top_file=Path(top_file) if top_file else None,
+            index_file=Path(index_file) if index_file else None,
+            workflow=workflow,
+            itp_files=list(itp_files) if itp_files else None,
+        )
+
+        settings.validate()
+
+        logger.info(
+            "Creating GROMACS EM job from project settings: project=%s, "
+            "project_yaml=%s",
+            project,
+            project_yaml,
+        )
+
+        if ctx.invoked_subcommand is None:
+            return GromacsEMJob.from_project_settings(
+                settings=settings,
+                molecule=None,
+                jobrunner=jobrunner,
+                skip_completed=skip_completed,
+                **kwargs,
+            )
+
+        return None
+
+    label = "gromacs_em"
+
+    if structure_file is not None:
+        label = (
+            os.path.splitext(os.path.basename(str(structure_file)))[0]
+            + "_em"
+        )
+
+    workflow = workflow or "prepared"
+
+    logger.info("Creating GROMACS EM job from direct CLI options.")
+    logger.info("GROMACS EM project: %s", project)
+    logger.info("GROMACS EM structure file: %s", structure_file)
+    logger.info("GROMACS EM input PDB file: %s", input_pdb)
+    logger.info("GROMACS EM mdp file: %s", mdp_file)
+    logger.info("GROMACS EM ions mdp file: %s", ions_mdp_file)
+    logger.info("GROMACS EM topology file: %s", top_file)
+    logger.info("GROMACS EM itp files: %s", itp_files)
+    logger.info("GROMACS EM index file: %s", index_file)
+    logger.info("GROMACS EM workflow: %s", workflow)
 
     if ctx.invoked_subcommand is None:
         return GromacsEMJob(
             molecule=None,
             label=label,
             jobrunner=jobrunner,
-            mdp_file=mdp_file,
-            structure_file=structure_file,
-            top_file=top_file,
-            itp_files=itp_files,
-            index_file=index_file,
+            mdp_file=Path(mdp_file) if mdp_file else None,
+            ions_mdp_file=Path(ions_mdp_file) if ions_mdp_file else None,
+            structure_file=Path(structure_file) if structure_file else None,
+            input_pdb=Path(input_pdb) if input_pdb else None,
+            top_file=Path(top_file) if top_file else None,
+            itp_files=list(itp_files) if itp_files else [],
+            index_file=Path(index_file) if index_file else None,
+            workflow=workflow,
             skip_completed=skip_completed,
             **kwargs,
         )
+
+    return None

--- a/chemsmart/cli/gromacs/factory.py
+++ b/chemsmart/cli/gromacs/factory.py
@@ -1,0 +1,26 @@
+
+
+from chemsmart.jobs.gromacs.job import GromacsEMJob
+from chemsmart.settings.gromacs import GromacsProjectSettings
+
+class GromacsJobFactory:
+    """
+    Factory for creating GROMACS jobs from project YAML or settings
+    """
+
+    JOB_TYPE_MAP = {
+        "em": GromacsEMJob,
+    }
+
+    @classmethod
+    def create_from_project_yaml(cls, project_yaml, molecule=None, label=None, jobrunner=None, **kwargs):
+        settings = GromacsProjectSettings.from_yaml(project_yaml)
+        return cls.create_from_settings(settings, molecule=molecule, label=label, jobrunner=jobrunner, **kwargs)
+
+    @classmethod
+    def create_from_settings(cls, settings, molecule=None, label=None, jobrunner=None, **kwargs):
+        settings.validate()
+        job_cls = cls.JOB_TYPE_MAP.get(settings.job_type)
+        if job_cls is None:
+            raise ValueError(f"Unsupported GROMACS job type: {settings.job_type}")
+        return job_cls.from_project_settings(settings=settings, molecule=molecule, label=label, jobrunner=jobrunner, **kwargs)

--- a/chemsmart/cli/gromacs/gromacs.py
+++ b/chemsmart/cli/gromacs/gromacs.py
@@ -1,15 +1,22 @@
 """
-GROMACS Command Line Interface
+GROMACS Command Line Interface.
 
-This module provides the main CLI interface for GROMACS workflows.
+This module provides the main CLI group for GROMACS workflows.
+
+The group-level responsibility is intentionally small:
+1. collect project / input options;
+2. load GromacsProjectSettings when a project YAML is provided;
+3. store shared values in ctx.obj for leaf commands such as em.
 """
 
 import functools
 import logging
+from pathlib import Path
 
 import click
 
 from chemsmart.cli.job import click_filename_options
+from chemsmart.settings.gromacs import GromacsProjectSettings
 from chemsmart.utils.cli import MyGroup
 
 logger = logging.getLogger(__name__)
@@ -21,7 +28,29 @@ def click_gromacs_options(f):
     """
 
     @click.option(
-        "--project", "-p", type=str, default=None, help="Project settings."
+        "--project",
+        "-p",
+        type=str,
+        default=None,
+        help=(
+            "GROMACS project YAML file or project name. "
+            "For now, if this value points to an existing file, "
+            "it will be treated as a YAML file path."
+        ),
+    )
+    @click.option(
+        "--project-yaml",
+        "project_yaml",
+        type=click.Path(
+            exists=True,
+            dir_okay=False,
+            resolve_path=True,
+        ),
+        default=None,
+        help=(
+            "Explicit GROMACS project YAML file. "
+            "This has priority over --project."
+        ),
     )
     @functools.wraps(f)
     def wrapper_common_options(*args, **kwargs):
@@ -30,20 +59,52 @@ def click_gromacs_options(f):
     return wrapper_common_options
 
 
+def _load_project_settings(project=None, project_yaml=None):
+    """
+    Load GROMACS project settings from CLI project options.
+
+    project_yaml has priority because click already validates that it exists.
+    project is kept for compatibility with ChemSmart-style -p/--project usage.
+    """
+    if project_yaml is not None:
+        return GromacsProjectSettings.from_yaml(project_yaml)
+
+    if project is not None:
+        project_path = Path(project)
+
+        if project_path.exists() and project_path.is_file():
+            return GromacsProjectSettings.from_yaml(project_path)
+
+        raise FileNotFoundError(
+            "GROMACS --project currently expects a project YAML file path. "
+            f"Received: {project}"
+        )
+
+    return None
+
+
 @click.group(cls=MyGroup)
 @click_gromacs_options
 @click_filename_options
 @click.pass_context
-def gromacs(ctx, project, filename):
+def gromacs(ctx, project, project_yaml, filename):
     """
     Main CLI command group for running GROMACS jobs.
     """
 
-    logger.debug(f"GROMACS project: {project}")
-    logger.debug(f"GROMACS filename: {filename}")
+    logger.debug("GROMACS project: %s", project)
+    logger.debug("GROMACS project YAML: %s", project_yaml)
+    logger.debug("GROMACS filename: %s", filename)
+
+    project_settings = _load_project_settings(
+        project=project,
+        project_yaml=project_yaml,
+    )
 
     ctx.ensure_object(dict)
     ctx.obj["project"] = project
+    ctx.obj["project_yaml"] = project_yaml
+    ctx.obj["project_settings"] = project_settings
     ctx.obj["filename"] = filename
     ctx.obj["jobrunner"] = None
 
@@ -56,7 +117,10 @@ def gromacs_process_pipeline(ctx, *args, **kwargs):
     """
     kwargs.update({"subcommand": ctx.invoked_subcommand})
     ctx.obj[ctx.info_name] = kwargs
+
     logger.debug(
-        f"Pipeline completed for subcommand: {ctx.invoked_subcommand}"
+        "Pipeline completed for subcommand: %s",
+        ctx.invoked_subcommand,
     )
+
     return args[0] if args else None

--- a/chemsmart/jobs/gromacs/factory.py
+++ b/chemsmart/jobs/gromacs/factory.py
@@ -1,0 +1,66 @@
+from pathlib import Path
+from typing import Any, Optional
+
+from chemsmart.jobs.gromacs.job import GromacsEMJob
+from chemsmart.settings.gromacs import GromacsProjectSettings
+
+
+class GromacsJobFactory:
+    """
+    Create concrete GROMACS job objects from settings or project YAML files.
+    """
+
+    JOB_TYPE_MAP = {
+        "em": GromacsEMJob,
+    }
+
+    @classmethod
+    def create_from_project_yaml(
+        cls,
+        project_yaml,
+        molecule=None,
+        label=None,
+        jobrunner=None,
+        **kwargs,
+    ):
+        """
+        Create a GROMACS job from a project YAML file.
+        """
+        settings = GromacsProjectSettings.from_yaml(project_yaml)
+
+        return cls.create_from_settings(
+            settings=settings,
+            molecule=molecule,
+            label=label,
+            jobrunner=jobrunner,
+            **kwargs,
+        )
+
+    @classmethod
+    def create_from_settings(
+        cls,
+        settings,
+        molecule=None,
+        label=None,
+        jobrunner=None,
+        **kwargs,
+    ):
+        """
+        Create a GROMACS job from GromacsProjectSettings.
+        """
+        settings.validate()
+
+        job_cls = cls.JOB_TYPE_MAP.get(settings.job_type)
+
+        if job_cls is None:
+            raise ValueError(
+                f"Unsupported GROMACS job type: {settings.job_type}"
+            )
+
+        return job_cls.from_project_settings(
+            settings=settings,
+            molecule=molecule,
+            label=label,
+            jobrunner=jobrunner,
+            **kwargs,
+        )

--- a/chemsmart/jobs/gromacs/job.py
+++ b/chemsmart/jobs/gromacs/job.py
@@ -1,9 +1,23 @@
+from __future__ import annotations
+
+"""
+GROMACS job definitions.
+"""
+
 from pathlib import Path
 
 from chemsmart.jobs.job import Job
 
 
 class GromacsJob(Job):
+    """
+    Base GROMACS job.
+
+    This class stores concrete input files and workflow options used by the
+    runner. Reusable project-level settings should be stored in
+    GromacsProjectSettings.
+    """
+
     PROGRAM = "gromacs"
     TYPE = "gromacs"
 
@@ -13,12 +27,40 @@ class GromacsJob(Job):
         label,
         jobrunner,
         mdp_file=None,
+        ions_mdp_file=None,
         structure_file=None,
+        input_pdb=None,
         top_file=None,
         tpr_file=None,
         itp_files=None,
         index_file=None,
         workflow="prepared",
+        processed_structure_file=None,
+        boxed_structure_file=None,
+        solvated_structure_file=None,
+        ions_tpr_file=None,
+        ionized_structure_file=None,
+        force_field=None,
+        water_model=None,
+        timestep=None,
+        temperature=None,
+        pressure=None,
+        thermostat=None,
+        barostat=None,
+        constraints=None,
+        constraint_algorithm=None,
+        box_type="cubic",
+        box_distance=1.0,
+        solvent_file=None,
+        positive_ion="NA",
+        negative_ion="CL",
+        neutral=True,
+        genion_group="SOL",
+        grompp_maxwarn=None,
+        mdrun_threads=None,
+        mdrun_ntmpi=None,
+        mdrun_ntomp=None,
+        mdrun_extra_args=None,
         **kwargs,
     ):
         super().__init__(
@@ -29,8 +71,16 @@ class GromacsJob(Job):
         )
 
         self.mdp_file = Path(mdp_file) if mdp_file else None
+        self.ions_mdp_file = Path(ions_mdp_file) if ions_mdp_file else None
+
         self.structure_file = Path(structure_file) if structure_file else None
+        self.input_pdb = Path(input_pdb) if input_pdb else None
+
         self.top_file = Path(top_file) if top_file else None
+        self.index_file = Path(index_file) if index_file else None
+        self.itp_files = [Path(f) for f in itp_files] if itp_files else []
+
+        self.workflow = workflow
 
         self._use_default_tpr_file = tpr_file is None
         self.tpr_file = (
@@ -38,9 +88,54 @@ class GromacsJob(Job):
             if tpr_file is not None
             else Path(self.folder) / f"{self.label}.tpr"
         )
-        self.index_file = Path(index_file) if index_file else None
-        self.itp_files = [Path(f) for f in itp_files] if itp_files else []
-        self.workflow = workflow
+
+        self.processed_structure_file = (
+            Path(processed_structure_file)
+            if processed_structure_file
+            else None
+        )
+        self.boxed_structure_file = (
+            Path(boxed_structure_file)
+            if boxed_structure_file
+            else None
+        )
+        self.solvated_structure_file = (
+            Path(solvated_structure_file)
+            if solvated_structure_file
+            else None
+        )
+        self.ions_tpr_file = Path(ions_tpr_file) if ions_tpr_file else None
+        self.ionized_structure_file = (
+            Path(ionized_structure_file)
+            if ionized_structure_file
+            else None
+        )
+
+        self.force_field = force_field
+        self.water_model = water_model
+
+        self.timestep = timestep
+        self.temperature = temperature
+        self.pressure = pressure
+        self.thermostat = thermostat
+        self.barostat = barostat
+        self.constraints = constraints
+        self.constraint_algorithm = constraint_algorithm
+
+        self.box_type = box_type
+        self.box_distance = box_distance
+        self.solvent_file = Path(solvent_file) if solvent_file else None
+
+        self.positive_ion = positive_ion
+        self.negative_ion = negative_ion
+        self.neutral = neutral
+        self.genion_group = genion_group
+
+        self.grompp_maxwarn = grompp_maxwarn
+        self.mdrun_threads = mdrun_threads
+        self.mdrun_ntmpi = mdrun_ntmpi
+        self.mdrun_ntomp = mdrun_ntomp
+        self.mdrun_extra_args = list(mdrun_extra_args or [])
 
     @classmethod
     def from_project_settings(
@@ -53,9 +148,6 @@ class GromacsJob(Job):
     ):
         """
         Create a GROMACS job from GromacsProjectSettings.
-
-        Project settings store reusable project-level information, while the
-        job object stores the concrete inputs needed by the runner.
         """
         job_kwargs = settings.to_job_kwargs()
 
@@ -75,15 +167,20 @@ class GromacsJob(Job):
         self.jobrunner.run(self, **kwargs)
 
     def has_tpr(self):
+        """
+        Return True if the job already has an existing TPR file.
+        """
         return self.tpr_file is not None and self.tpr_file.exists()
 
     def has_topology(self):
+        """
+        Return True if the job already has an existing topology file.
+        """
         return self.top_file is not None and self.top_file.exists()
 
     def has_required_prepared_inputs(self):
         """
-        Check whether the job has the minimum user-provided files
-        required to assemble a TPR file.
+        Check whether the job has the minimum files for prepared workflow.
         """
         required_files = [
             self.mdp_file,
@@ -96,15 +193,30 @@ class GromacsJob(Job):
             for path in required_files
         )
 
+    def has_required_full_setup_inputs(self):
+        """
+        Check whether the job has the minimum inputs for full setup workflow.
+        """
+        input_file = self.input_pdb or self.structure_file
+
+        return (
+            input_file is not None
+            and Path(input_file).exists()
+            and self.mdp_file is not None
+            and Path(self.mdp_file).exists()
+            and self.force_field is not None
+            and self.water_model is not None
+        )
+
     def set_folder(self, folder):
         """
-        Set the job folder and update the default TPR path if it was not
-         explicitly provided by the user.
+        Set the job folder and update default TPR path if needed.
         """
         super().set_folder(folder)
 
         if self._use_default_tpr_file:
-             self.tpr_file = Path(self.folder) / f"{self.label}.tpr"
+            self.tpr_file = Path(self.folder) / f"{self.label}.tpr"
+
 
 class GromacsEMJob(GromacsJob):
     """
@@ -119,7 +231,9 @@ class GromacsEMJob(GromacsJob):
         label="gromacs_em",
         jobrunner=None,
         mdp_file=None,
+        ions_mdp_file=None,
         structure_file=None,
+        input_pdb=None,
         top_file=None,
         tpr_file=None,
         itp_files=None,
@@ -132,7 +246,9 @@ class GromacsEMJob(GromacsJob):
             label=label,
             jobrunner=jobrunner,
             mdp_file=mdp_file,
+            ions_mdp_file=ions_mdp_file,
             structure_file=structure_file,
+            input_pdb=input_pdb,
             top_file=top_file,
             tpr_file=tpr_file,
             itp_files=itp_files,

--- a/chemsmart/jobs/gromacs/runner.py
+++ b/chemsmart/jobs/gromacs/runner.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """
 GROMACS job runner for executing molecular dynamics workflows.
 """
@@ -8,6 +10,7 @@ import shlex
 import subprocess
 from pathlib import Path
 
+from chemsmart.jobs.gromacs.state import GromacsWorkflowState
 from chemsmart.jobs.runner import JobRunner
 from chemsmart.settings.executable import GromacsExecutable
 
@@ -17,6 +20,15 @@ logger = logging.getLogger(__name__)
 class GromacsJobRunner(JobRunner):
     """
     Job runner for executing GROMACS jobs.
+
+    The stable prepared workflow is:
+
+        grompp -> mdrun
+
+    The first full setup workflow is:
+
+        pdb2gmx -> editconf -> solvate -> grompp(ions)
+        -> genion -> grompp(em) -> mdrun
     """
 
     JOBTYPES = [
@@ -37,7 +49,10 @@ class GromacsJobRunner(JobRunner):
         fake=False,
         scratch_dir=None,
         gmx_executable=None,
-        **kwargs
+        gmx_modules=None,
+        gmx_env=None,
+        gmx_source_scripts=None,
+        **kwargs,
     ):
         if scratch is None:
             scratch = self.SCRATCH
@@ -49,27 +64,49 @@ class GromacsJobRunner(JobRunner):
             fake=fake,
             **kwargs,
         )
-        # Default to "gmx" so the runner works when GROMACS is available in PATH.
-        # Later this can be replaced by YAML/global settings logic.
+
         self.gmx_executable = gmx_executable
+        self.gmx_modules = list(gmx_modules or [])
+        self.gmx_env = dict(gmx_env or {})
+        self.gmx_source_scripts = list(gmx_source_scripts or [])
 
     @property
     def executable(self):
         """
-        First version: directly use gmx in PATH.
-        Later this can be replaced by executable settings logic.
+        Return the configured GROMACS executable.
         """
         return self._get_executable()
 
     def _prerun(self, job):
+        """
+        Prepare inputs before the main mdrun command is launched.
+        """
         self._assign_variables(job)
-        self._validate_gromacs_inputs(job)
 
-        if not job.has_tpr():
-            self._assemble_tpr(job)
+        workflow = getattr(job, "workflow", "prepared")
+
+        if workflow == "prepared":
+            self._validate_gromacs_inputs(job)
+
+            if not job.has_tpr():
+                self._assemble_tpr(job)
+
+            return
+
+        if workflow == "full_setup":
+            self._validate_full_setup_inputs(job)
+            self._run_full_setup(job)
+            return
+
+        raise ValueError(f"Unsupported GROMACS workflow: {workflow}")
 
     def _assign_variables(self, job):
-        self.running_directory = job.folder
+        """
+        Assign paths used by the parent runner and subprocess layer.
+        """
+        Path(job.folder).mkdir(parents=True, exist_ok=True)
+
+        self.running_directory = str(Path(job.folder).resolve())
         self.job_outputfile = os.path.abspath(
             os.path.join(job.folder, f"{job.label}.out")
         )
@@ -79,44 +116,52 @@ class GromacsJobRunner(JobRunner):
 
     def _write_input(self, job):
         """
-        First version: skip actual writer implementation for now.
-        Later this should call a GROMACS input writer.
+        GROMACS input writing is not required for prepared workflows.
+
+        MDP auto-writing can be added later through chemsmart.jobs.gromacs.writer.
         """
         pass
 
     def _get_executable(self):
         """
-           Return the GROMACS executable.
+        Return the GROMACS executable.
 
-           The executable can be provided directly through gmx_executable.
-           If not provided, it falls back to the default GromacsExecutable.
-           """
+        The direct runner option has the highest priority. If it is not given,
+        fall back to GromacsExecutable.
+        """
         if getattr(self, "gmx_executable", None) is not None:
             return self.gmx_executable
 
         return GromacsExecutable().get_executable()
 
-    def _get_grompp_command(self, job):
+    def _get_grompp_command(
+        self,
+        job,
+        structure_file=None,
+        tpr_file=None,
+        mdp_file=None,
+    ):
         """
         Build the GROMACS grompp command for assembling a TPR file.
         """
-        exe = self._get_executable()
-
         command = [
-            exe,
+            self._get_executable(),
             "grompp",
             "-f",
-            str(job.mdp_file),
+            str(mdp_file or job.mdp_file),
             "-c",
-            str(job.structure_file),
+            str(structure_file or job.structure_file),
             "-p",
             str(job.top_file),
             "-o",
-            str(job.tpr_file),
+            str(tpr_file or job.tpr_file),
         ]
 
         if job.index_file is not None:
             command.extend(["-n", str(job.index_file)])
+
+        if getattr(job, "grompp_maxwarn", None) is not None:
+            command.extend(["-maxwarn", str(job.grompp_maxwarn)])
 
         return command
 
@@ -124,35 +169,42 @@ class GromacsJobRunner(JobRunner):
         """
         Build the GROMACS mdrun command.
         """
-        exe = self._get_executable()
-        deffnm = Path(job.tpr_file).with_suffix("")
-
-        return [
-            exe,
+        command = [
+            self._get_executable(),
             "mdrun",
             "-deffnm",
-            str(deffnm),
+            str(Path(job.tpr_file).with_suffix("")),
         ]
+
+        if getattr(job, "mdrun_threads", None) is not None:
+            command.extend(["-nt", str(job.mdrun_threads)])
+
+        if getattr(job, "mdrun_ntmpi", None) is not None:
+            command.extend(["-ntmpi", str(job.mdrun_ntmpi)])
+
+        if getattr(job, "mdrun_ntomp", None) is not None:
+            command.extend(["-ntomp", str(job.mdrun_ntomp)])
+
+        command.extend(getattr(job, "mdrun_extra_args", []) or [])
+
+        return command
 
     def _get_pdb2gmx_command(self, job):
         """
         Build the GROMACS pdb2gmx command.
-
-        This command is used to generate topology files from an input PDB file.
-        It is only needed for workflows that start from a raw structure.
         """
-        exe = self._get_executable()
-
         input_pdb = getattr(job, "input_pdb", None)
         if input_pdb is None:
             input_pdb = getattr(job, "structure_file", None)
 
-        output_gro = getattr(job, "output_gro", None)
+        output_gro = getattr(job, "processed_structure_file", None)
+        if output_gro is None:
+            output_gro = getattr(job, "output_gro", None)
         if output_gro is None:
             output_gro = getattr(job, "structure_file", None)
 
         command = [
-            exe,
+            self._get_executable(),
             "pdb2gmx",
             "-f",
             str(input_pdb),
@@ -162,25 +214,21 @@ class GromacsJobRunner(JobRunner):
             str(job.top_file),
         ]
 
-        force_field = getattr(job, "force_field", None)
-        if force_field is not None:
-            command.extend(["-ff", str(force_field)])
+        if getattr(job, "force_field", None) is not None:
+            command.extend(["-ff", str(job.force_field)])
 
-        water_model = getattr(job, "water_model", None)
-        if water_model is not None:
-            command.extend(["-water", str(water_model)])
+        if getattr(job, "water_model", None) is not None:
+            command.extend(["-water", str(job.water_model)])
 
         return command
 
     def _get_editconf_command(self, job):
         """
         Build the GROMACS editconf command.
-
-        This command is commonly used to define the simulation box.
         """
-        exe = self._get_executable()
-
         input_structure = getattr(job, "editconf_input_file", None)
+        if input_structure is None:
+            input_structure = getattr(job, "processed_structure_file", None)
         if input_structure is None:
             input_structure = getattr(job, "structure_file", None)
 
@@ -189,7 +237,7 @@ class GromacsJobRunner(JobRunner):
             output_structure = getattr(job, "boxed_structure_file", None)
 
         command = [
-            exe,
+            self._get_executable(),
             "editconf",
             "-f",
             str(input_structure),
@@ -197,24 +245,18 @@ class GromacsJobRunner(JobRunner):
             str(output_structure),
         ]
 
-        box_type = getattr(job, "box_type", None)
-        if box_type is not None:
-            command.extend(["-bt", str(box_type)])
+        if getattr(job, "box_type", None) is not None:
+            command.extend(["-bt", str(job.box_type)])
 
-        distance = getattr(job, "box_distance", None)
-        if distance is not None:
-            command.extend(["-d", str(distance)])
+        if getattr(job, "box_distance", None) is not None:
+            command.extend(["-d", str(job.box_distance)])
 
         return command
 
     def _get_solvate_command(self, job):
         """
         Build the GROMACS solvate command.
-
-        This command is used to add solvent molecules to the simulation box.
         """
-        exe = self._get_executable()
-
         input_structure = getattr(job, "solvate_input_file", None)
         if input_structure is None:
             input_structure = getattr(job, "boxed_structure_file", None)
@@ -224,7 +266,7 @@ class GromacsJobRunner(JobRunner):
             output_structure = getattr(job, "solvated_structure_file", None)
 
         command = [
-            exe,
+            self._get_executable(),
             "solvate",
             "-cp",
             str(input_structure),
@@ -234,21 +276,15 @@ class GromacsJobRunner(JobRunner):
             str(job.top_file),
         ]
 
-        solvent_file = getattr(job, "solvent_file", None)
-        if solvent_file is not None:
-            command.extend(["-cs", str(solvent_file)])
+        if getattr(job, "solvent_file", None) is not None:
+            command.extend(["-cs", str(job.solvent_file)])
 
         return command
 
     def _get_genion_command(self, job):
         """
         Build the GROMACS genion command.
-
-        This command is used to add ions to the solvated system.
-        It usually requires a TPR file generated by grompp.
         """
-        exe = self._get_executable()
-
         input_tpr = getattr(job, "ions_tpr_file", None)
         if input_tpr is None:
             input_tpr = getattr(job, "tpr_file", None)
@@ -258,7 +294,7 @@ class GromacsJobRunner(JobRunner):
             output_structure = getattr(job, "ionized_structure_file", None)
 
         command = [
-            exe,
+            self._get_executable(),
             "genion",
             "-s",
             str(input_tpr),
@@ -268,25 +304,44 @@ class GromacsJobRunner(JobRunner):
             str(job.top_file),
         ]
 
-        positive_ion = getattr(job, "positive_ion", None)
-        if positive_ion is not None:
-            command.extend(["-pname", str(positive_ion)])
+        if getattr(job, "index_file", None) is not None:
+            command.extend(["-n", str(job.index_file)])
 
-        negative_ion = getattr(job, "negative_ion", None)
-        if negative_ion is not None:
-            command.extend(["-nname", str(negative_ion)])
+        if getattr(job, "positive_ion", None) is not None:
+            command.extend(["-pname", str(job.positive_ion)])
 
-        neutral = getattr(job, "neutral", None)
-        if neutral:
+        if getattr(job, "negative_ion", None) is not None:
+            command.extend(["-nname", str(job.negative_ion)])
+
+        if getattr(job, "neutral", None):
             command.append("-neutral")
 
         return command
+
+    def _bind_workflow_state(self, job):
+        """
+        Bind full setup intermediate file names to the job.
+        """
+        state = GromacsWorkflowState.from_job(job)
+
+        job.processed_structure_file = state.processed_structure_file
+        job.boxed_structure_file = state.boxed_structure_file
+        job.solvated_structure_file = state.solvated_structure_file
+        job.ions_tpr_file = state.ions_tpr_file
+        job.ionized_structure_file = state.ionized_structure_file
+        job.tpr_file = state.em_tpr_file
+
+        if job.top_file is None:
+            job.top_file = Path(job.folder) / "topol.top"
+
+        return state
 
     def _get_commands(self, job):
         """
         Return the command sequence for a GROMACS workflow.
 
-        Different GROMACS workflows may require different command combinations.
+        This is mainly useful for unit tests and dry structural validation.
+        Real execution is handled through _prerun and _get_command.
         """
         workflow = getattr(job, "workflow", "prepared")
 
@@ -304,70 +359,167 @@ class GromacsJobRunner(JobRunner):
             ]
 
         if workflow == "full_setup":
-            raise NotImplementedError(
-                "The full_setup workflow is not fully implemented yet. "
-                "Current stable workflow is prepared: grompp -> mdrun."
-            )
+            self._bind_workflow_state(job)
+
+            ions_mdp_file = getattr(job, "ions_mdp_file", None) or job.mdp_file
+
+            return [
+                self._get_pdb2gmx_command(job),
+                self._get_editconf_command(job),
+                self._get_solvate_command(job),
+                self._get_grompp_command(
+                    job,
+                    structure_file=job.solvated_structure_file,
+                    tpr_file=job.ions_tpr_file,
+                    mdp_file=ions_mdp_file,
+                ),
+                self._get_genion_command(job),
+                self._get_grompp_command(
+                    job,
+                    structure_file=job.ionized_structure_file,
+                    tpr_file=job.tpr_file,
+                    mdp_file=job.mdp_file,
+                ),
+                self._get_mdrun_command(job),
+            ]
+
         raise ValueError(f"Unsupported GROMACS workflow: {workflow}")
 
     def _get_command(self, job):
         """
-        Return the GROMACS mdrun command.
+        Return the final GROMACS mdrun command.
 
         The TPR file should already be assembled in _prerun.
-        The -deffnm value should match the actual TPR file prefix.
         """
-
         return " ".join(self._get_mdrun_command(job))
 
-    def _run_command(self, command, cwd=None, env=None, check=True):
+    def _format_command_for_log(self, command):
+        """
+        Format a command list for logging.
+        """
+        return " ".join(shlex.quote(str(part)) for part in command)
+
+    def _prepare_environment(self, env=None):
+        """
+        Prepare environment variables for subprocess execution.
+        """
+        run_env = os.environ.copy()
+        run_env.update(getattr(self, "gmx_env", {}) or {})
+
+        if env is not None:
+            run_env.update(env)
+
+        return run_env
+
+    def _wrap_command_if_needed(self, command):
+        """
+        Wrap command with bash when modules or source scripts are required.
+        """
+        modules = getattr(self, "gmx_modules", []) or []
+        source_scripts = getattr(self, "gmx_source_scripts", []) or []
+
+        if not modules and not source_scripts:
+            return list(command)
+
+        shell_steps = [
+            "source /etc/profile >/dev/null 2>&1 || true",
+        ]
+
+        for script in source_scripts:
+            shell_steps.append(f"source {shlex.quote(str(script))}")
+
+        for module in modules:
+            shell_steps.append(f"module load {shlex.quote(str(module))}")
+
+        shell_steps.append(self._format_command_for_log(command))
+
+        return [
+            "bash",
+            "-lc",
+            " && ".join(shell_steps),
+        ]
+
+    def _append_log(self, path, content):
+        """
+        Append content to a log file.
+        """
+        if path is None:
+            return
+
+        with open(path, "a", encoding="utf-8") as handle:
+            handle.write(content)
+
+            if not content.endswith("\n"):
+                handle.write("\n")
+
+    def _run_command(
+        self,
+        command,
+        cwd=None,
+        env=None,
+        check=True,
+        input_text=None,
+        stage=None,
+    ):
         """
         Run a GROMACS command and return the completed process.
-
-        Parameters
-        ----------
-        command : list[str]
-            Command represented as a list of arguments.
-        cwd : str or Path, optional
-            Working directory for the command.
-        env : dict, optional
-            Environment variables used to run the command.
-        check : bool
-            If True, raise RuntimeError when the command fails.
         """
         if cwd is None:
             cwd = self.running_directory
 
-        logger.info(f"Running GROMACS command: {' '.join(command)}")
+        logger.info(
+            "Running GROMACS command: %s",
+            self._format_command_for_log(command),
+        )
 
-        process = subprocess.Popen(
-            command,
+        if getattr(self, "fake", False):
+            return subprocess.CompletedProcess(
+                args=command,
+                returncode=0,
+                stdout="",
+                stderr="",
+            )
+
+        prepared_command = self._wrap_command_if_needed(command)
+        run_env = self._prepare_environment(env)
+
+        result = subprocess.run(
+            prepared_command,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
             cwd=cwd,
-            env=env,
+            env=run_env,
+            input=input_text,
+            check=False,
         )
-        stdout, stderr = process.communicate()
 
-        if check and process.returncode != 0:
+        stage_name = stage or (command[1] if len(command) > 1 else "command")
+
+        self._append_log(
+            self.job_outputfile,
+            f"\n===== {stage_name} STDOUT =====\n{result.stdout}\n",
+        )
+        self._append_log(
+            self.job_errfile,
+            f"\n===== {stage_name} STDERR =====\n{result.stderr}\n",
+        )
+
+        if check and result.returncode != 0:
             raise RuntimeError(
                 "GROMACS command failed.\n"
-                f"Command: {' '.join(command)}\n"
-                f"Return code: {process.returncode}\n"
-                f"STDOUT:\n{stdout}\n"
-                f"STDERR:\n{stderr}"
+                f"Stage: {stage_name}\n"
+                f"Command: {self._format_command_for_log(command)}\n"
+                f"Return code: {result.returncode}\n"
+                f"STDOUT:\n{result.stdout}\n"
+                f"STDERR:\n{result.stderr}"
             )
 
-        return process
+        return result
 
     def _run_commands(self, commands, cwd=None, env=None, check=True):
         """
         Run a sequence of GROMACS commands in order.
-
-        This helper prepares the runner for multi-step workflows, while the
-        current stable workflow still uses grompp in _prerun and mdrun as the
-        main command.
         """
         processes = []
 
@@ -386,23 +538,27 @@ class GromacsJobRunner(JobRunner):
         """
         Create the main GROMACS process.
 
-        This method keeps compatibility with the parent runner. It accepts both
-        string commands and list commands.
+        This method keeps compatibility with the parent runner.
         """
         if isinstance(command, str):
             command = shlex.split(command)
 
+        prepared_command = self._wrap_command_if_needed(command)
+        run_env = self._prepare_environment(env)
+
         with (
-            open(self.job_outputfile, "w") as out,
-            open(self.job_errfile, "w") as err,
+            open(self.job_outputfile, "a", encoding="utf-8") as out,
+            open(self.job_errfile, "a", encoding="utf-8") as err,
         ):
-            logger.info(f"Command executed: {command}")
+            logger.info("Command executed: %s", prepared_command)
+
             return subprocess.Popen(
-                command,
+                prepared_command,
                 stdout=out,
                 stderr=err,
-                env=env,
+                env=run_env,
                 cwd=self.running_directory,
+                text=True,
             )
 
     def _postrun(self, job):
@@ -413,13 +569,71 @@ class GromacsJobRunner(JobRunner):
         Assemble a GROMACS TPR file using gmx grompp.
         """
         command = self._get_grompp_command(job)
-        self._run_command(command, cwd=self.running_directory, check=True)
+
+        self._run_command(
+            command,
+            cwd=self.running_directory,
+            check=True,
+            stage="grompp",
+        )
+
+    def _run_full_setup(self, job):
+        """
+        Run the first full setup workflow.
+
+        This first implementation intentionally covers the common non-interactive
+        happy path only.
+        """
+        self._bind_workflow_state(job)
+
+        self._run_command(
+            self._get_pdb2gmx_command(job),
+            stage="pdb2gmx",
+        )
+
+        self._run_command(
+            self._get_editconf_command(job),
+            stage="editconf",
+        )
+
+        self._run_command(
+            self._get_solvate_command(job),
+            stage="solvate",
+        )
+
+        ions_mdp_file = getattr(job, "ions_mdp_file", None) or job.mdp_file
+
+        self._run_command(
+            self._get_grompp_command(
+                job,
+                structure_file=job.solvated_structure_file,
+                tpr_file=job.ions_tpr_file,
+                mdp_file=ions_mdp_file,
+            ),
+            stage="grompp_ions",
+        )
+
+        self._run_command(
+            self._get_genion_command(job),
+            stage="genion",
+            input_text=f"{job.genion_group}\n",
+        )
+
+        self._run_command(
+            self._get_grompp_command(
+                job,
+                structure_file=job.ionized_structure_file,
+                tpr_file=job.tpr_file,
+                mdp_file=job.mdp_file,
+            ),
+            stage="grompp_em",
+        )
+
+        job.structure_file = job.ionized_structure_file
 
     def _validate_gromacs_inputs(self, job):
         """
-        Validate required GROMACS input files.
-        The first implementation supports prepared inputs:
-        mdp_file, structure_file, and top_file.
+        Validate required GROMACS input files for prepared workflow.
         """
         required_files = {
             "mdp_file": getattr(job, "mdp_file", None),
@@ -435,5 +649,39 @@ class GromacsJobRunner(JobRunner):
 
         if missing:
             raise FileNotFoundError(
-                "Missing required GROMACS input files: " + ", ".join(missing)
+                "Missing required GROMACS input files: "
+                + ", ".join(missing)
+            )
+
+    def _validate_full_setup_inputs(self, job):
+        """
+        Validate required inputs for full setup workflow.
+        """
+        input_file = getattr(job, "input_pdb", None) or getattr(
+            job,
+            "structure_file",
+            None,
+        )
+
+        required_files = {
+            "input_pdb|structure_file": input_file,
+            "mdp_file": getattr(job, "mdp_file", None),
+        }
+
+        missing = [
+            name
+            for name, path in required_files.items()
+            if path is None or not Path(path).exists()
+        ]
+
+        if getattr(job, "force_field", None) is None:
+            missing.append("force_field")
+
+        if getattr(job, "water_model", None) is None:
+            missing.append("water_model")
+
+        if missing:
+            raise FileNotFoundError(
+                "Missing required GROMACS full_setup inputs: "
+                + ", ".join(missing)
             )

--- a/chemsmart/jobs/gromacs/state.py
+++ b/chemsmart/jobs/gromacs/state.py
@@ -1,0 +1,64 @@
+# chemsmart/jobs/gromacs/state.py
+from __future__ import annotations
+
+"""
+Workflow state for GROMACS multi-step setup jobs.
+"""
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(slots=True)
+class GromacsWorkflowState:
+    """
+    Store intermediate file names for a GROMACS full setup workflow.
+
+    Keeping these files in one state object avoids spreading intermediate file
+    names across job, runner and CLI layers.
+    """
+    working_dir: Path
+    label: str
+
+    processed_structure_file: Path
+    boxed_structure_file: Path
+    solvated_structure_file: Path
+    ions_tpr_file: Path
+    ionized_structure_file: Path
+    em_tpr_file: Path
+
+    @classmethod
+    def from_job(cls, job) -> "GromacsWorkflowState":
+        """
+         Build workflow state from a GROMACS job.
+         """
+        working_dir = Path(job.folder).resolve()
+        label = job.label
+
+        return cls(
+            working_dir=working_dir,
+            label=label,
+            processed_structure_file=Path(
+                getattr(job, "processed_structure_file", None)
+                or working_dir / "processed.gro"
+            ),
+            boxed_structure_file=Path(
+                getattr(job, "boxed_structure_file", None)
+                or working_dir / "boxed.gro"
+            ),
+            solvated_structure_file=Path(
+                getattr(job, "solvated_structure_file", None)
+                or working_dir / "solvated.gro"
+            ),
+            ions_tpr_file=Path(
+                getattr(job, "ions_tpr_file", None)
+                or working_dir / "ions.tpr"
+            ),
+            ionized_structure_file=Path(
+                getattr(job, "ionized_structure_file", None)
+                or working_dir / "ionized.gro"
+            ),
+            em_tpr_file=Path(
+                getattr(job, "tpr_file", None)
+                or working_dir / f"{label}.tpr"
+            ),
+        )

--- a/chemsmart/jobs/gromacs/writer.py
+++ b/chemsmart/jobs/gromacs/writer.py
@@ -1,3 +1,37 @@
+from __future__ import annotations
+
 """
 GROMACS input writer.
+
+At this stage, prepared workflows use user-provided MDP, structure and topology
+files directly. This writer is kept as a small extension point for future MDP
+generation.
 """
+
+from pathlib import Path
+
+
+class GromacsInputWriter:
+    """
+    Minimal writer interface for future GROMACS input generation.
+    """
+
+    def __init__(self, job):
+        self.job = job
+
+    def write(self):
+        """
+        Write generated GROMACS input files.
+
+        The current implementation does not generate files automatically because
+        prepared workflows rely on user-provided files.
+        """
+        return []
+
+    def write_text_file(self, filename, content):
+        """
+        Utility method for writing a text file into the job folder.
+        """
+        path = Path(self.job.folder) / filename
+        path.write_text(content, encoding="utf-8")
+        return path

--- a/chemsmart/settings/executable.py
+++ b/chemsmart/settings/executable.py
@@ -238,6 +238,7 @@ class ORCAExecutable(Executable):
             executable_path = os.path.join(self.executable_folder, "orca")
             return executable_path
 
+
 class GromacsExecutable(Executable):
     """
     Executable handler for GROMACS molecular dynamics software.
@@ -275,6 +276,7 @@ class GromacsExecutable(Executable):
             return os.path.join(self.executable_folder, self.executable_name)
 
         return self.executable_name
+
 
 class NCIPLOTExecutable(Executable):
     """

--- a/chemsmart/settings/gromacs.py
+++ b/chemsmart/settings/gromacs.py
@@ -1,16 +1,15 @@
 """
-GROMACS project settings.
+GROMACS project-level settings.
 
-This module defines lightweight settings objects for GROMACS workflows.
-The first supported workflow is the prepared workflow, where users provide
-existing MDP, structure, and topology files.
+This module stores reusable project-level configuration for GROMACS jobs.
+The main purpose is to support project.yaml -> settings -> job creation.
 """
 
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Optional
+from typing import Any, Dict, List, Optional
 
-from chemsmart.io.yaml import YAMLFile
+import yaml
 
 
 @dataclass
@@ -18,25 +17,34 @@ class GromacsProjectSettings:
     """
     Project-level settings for GROMACS workflows.
 
-    These settings do not automatically decide simulation parameters.
-    They record user-defined project information so that GROMACS jobs can be
-    created and executed consistently.
+    These settings are intentionally separated from the job object. The settings
+    object stores reusable project configuration, while the job object stores one
+    concrete executable job.
     """
 
     project_name: Optional[str] = None
     project_dir: Optional[Path] = None
+
     workflow: str = "prepared"
+    job_type: str = "em"
 
     mdp_file: Optional[Path] = None
+    ions_mdp_file: Optional[Path] = None
     structure_file: Optional[Path] = None
+    input_pdb: Optional[Path] = None
     top_file: Optional[Path] = None
     tpr_file: Optional[Path] = None
     index_file: Optional[Path] = None
-    itp_files: list[Path] = field(default_factory=list)
+    itp_files: Optional[List[Path]] = None
+
+    processed_structure_file: Optional[Path] = None
+    boxed_structure_file: Optional[Path] = None
+    solvated_structure_file: Optional[Path] = None
+    ions_tpr_file: Optional[Path] = None
+    ionized_structure_file: Optional[Path] = None
 
     force_field: Optional[str] = None
     water_model: Optional[str] = None
-
     timestep: Optional[float] = None
     temperature: Optional[float] = None
     pressure: Optional[float] = None
@@ -45,120 +53,179 @@ class GromacsProjectSettings:
     constraints: Optional[str] = None
     constraint_algorithm: Optional[str] = None
 
-    @classmethod
-    def from_yaml(cls, filename):
-        """
-        Create GromacsProjectSettings from a YAML file.
+    box_type: Optional[str] = "cubic"
+    box_distance: Optional[float] = 1.0
+    solvent_file: Optional[Path] = None
 
-        Relative input paths are resolved against the YAML file directory.
-        """
-        filename = Path(filename)
-        yaml_file = YAMLFile(filename=filename)
-        data = yaml_file.yaml_contents_dict
+    positive_ion: Optional[str] = "NA"
+    negative_ion: Optional[str] = "CL"
+    neutral: bool = True
+    genion_group: str = "SOL"
 
-        settings_data = {
-            "project_dir": filename.parent,
-        }
-
-        project_data = data.get("project", {})
-        inputs_data = data.get("inputs", {})
-        gromacs_data = data.get("gromacs_settings", {})
-
-        if "name" in project_data:
-            settings_data["project_name"] = project_data["name"]
-
-        if "workflow" in project_data:
-            settings_data["workflow"] = project_data["workflow"]
-        elif "mode" in project_data:
-            settings_data["workflow"] = project_data["mode"]
-
-        settings_data.update(gromacs_data)
-
-        input_key_map = {
-            "mdp_file": "mdp_file",
-            "structure_file": "structure_file",
-            "topology_file": "top_file",
-            "top_file": "top_file",
-            "tpr_file": "tpr_file",
-            "index_file": "index_file",
-            "itp_files": "itp_files",
-        }
-
-        for yaml_key, settings_key in input_key_map.items():
-            if yaml_key in inputs_data:
-                settings_data[settings_key] = inputs_data[yaml_key]
-
-        for key, value in data.items():
-            if key not in {
-                "project",
-                "inputs",
-                "gromacs_settings",
-                "programs",
-                "workflow",
-            }:
-                settings_data.setdefault(key, value)
-
-        return cls.from_dict(settings_data)
+    grompp_maxwarn: Optional[int] = None
+    mdrun_threads: Optional[int] = None
+    mdrun_ntmpi: Optional[int] = None
+    mdrun_ntomp: Optional[int] = None
+    mdrun_extra_args: Optional[List[str]] = None
 
     @classmethod
     def from_dict(cls, data):
         """
-        Create GromacsProjectSettings from a dictionary.
-        """
-        data = data.copy()
+        Create settings from a dictionary.
 
+        Relative paths are resolved against project_dir if project_dir is given.
+        """
         project_dir = data.get("project_dir")
         if project_dir is not None:
             project_dir = Path(project_dir)
-            data["project_dir"] = project_dir
 
-        for key in [
+        mapped = {
+            "project_name": data.get("project_name"),
+            "workflow": data.get("workflow", data.get("mode", "prepared")),
+            "job_type": data.get("job_type", "em"),
+            "mdp_file": data.get("mdp_file"),
+            "ions_mdp_file": data.get("ions_mdp_file"),
+            "structure_file": data.get("structure_file"),
+            "input_pdb": data.get("input_pdb"),
+            "top_file": data.get("top_file") or data.get("topology_file"),
+            "tpr_file": data.get("tpr_file"),
+            "index_file": data.get("index_file"),
+            "itp_files": data.get("itp_files"),
+            "processed_structure_file": data.get("processed_structure_file"),
+            "boxed_structure_file": data.get("boxed_structure_file"),
+            "solvated_structure_file": data.get("solvated_structure_file"),
+            "ions_tpr_file": data.get("ions_tpr_file"),
+            "ionized_structure_file": data.get("ionized_structure_file"),
+            "force_field": data.get("force_field"),
+            "water_model": data.get("water_model"),
+            "timestep": data.get("timestep"),
+            "temperature": data.get("temperature"),
+            "pressure": data.get("pressure"),
+            "thermostat": data.get("thermostat"),
+            "barostat": data.get("barostat"),
+            "constraints": data.get("constraints"),
+            "constraint_algorithm": data.get("constraint_algorithm"),
+            "box_type": data.get("box_type", "cubic"),
+            "box_distance": data.get("box_distance", 1.0),
+            "solvent_file": data.get("solvent_file"),
+            "positive_ion": data.get("positive_ion", "NA"),
+            "negative_ion": data.get("negative_ion", "CL"),
+            "neutral": data.get("neutral", True),
+            "genion_group": data.get("genion_group", "SOL"),
+            "grompp_maxwarn": data.get("grompp_maxwarn"),
+            "mdrun_threads": data.get("mdrun_threads"),
+            "mdrun_ntmpi": data.get("mdrun_ntmpi"),
+            "mdrun_ntomp": data.get("mdrun_ntomp"),
+            "mdrun_extra_args": data.get("mdrun_extra_args"),
+        }
+
+        path_fields = {
             "mdp_file",
+            "ions_mdp_file",
             "structure_file",
+            "input_pdb",
             "top_file",
             "tpr_file",
             "index_file",
-        ]:
-            if data.get(key) is not None:
-                data[key] = Path(data[key])
+            "processed_structure_file",
+            "boxed_structure_file",
+            "solvated_structure_file",
+            "ions_tpr_file",
+            "ionized_structure_file",
+            "solvent_file",
+        }
 
-        if data.get("itp_files") is not None:
-            data["itp_files"] =[
-                cls._make_path(file, project_dir) for file in data["itp_files"]
-            ]
+        resolved = {
+            "project_name": mapped["project_name"],
+            "project_dir": project_dir,
+            "workflow": mapped["workflow"],
+            "job_type": mapped["job_type"],
+        }
 
-        return cls(**data)
+        for key, value in mapped.items():
+            if key in {"project_name", "workflow", "job_type"}:
+                continue
+
+            if key in path_fields:
+                resolved[key] = cls._resolve_path(value, project_dir)
+            elif key == "itp_files":
+                resolved[key] = cls._resolve_paths(value, project_dir)
+            elif key == "mdrun_extra_args":
+                resolved[key] = list(value or []) or None
+            else:
+                resolved[key] = value
+
+        return cls(**resolved)
+
+    @classmethod
+    def from_yaml(cls, yaml_file):
+        """
+        Load settings from a GROMACS project YAML file.
+        """
+        yaml_path = Path(yaml_file).resolve()
+        raw = yaml.safe_load(yaml_path.read_text(encoding="utf-8")) or {}
+
+        project = raw.get("project", {})
+        inputs = raw.get("inputs", {})
+        gromacs_settings = raw.get("gromacs_settings", {})
+        runtime = raw.get("runtime", {})
+
+        flat = {
+            "project_name": project.get("name"),
+            "workflow": project.get("mode", project.get("workflow", "prepared")),
+            "job_type": project.get("job_type", "em"),
+            "project_dir": yaml_path.parent,
+        }
+
+        flat.update(inputs)
+        flat.update(gromacs_settings)
+        flat.update(runtime)
+
+        return cls.from_dict(flat)
 
     @staticmethod
-    def _make_path(path, project_dir=None):
+    def _resolve_path(value, project_dir):
         """
-        Convert a path-like value to Path.
-
-        If project_dir is provided and the path is relative, resolve it against
-        the project directory.
+        Resolve one path-like value.
         """
-        path = Path(path)
+        if value in (None, ""):
+            return None
 
-        if project_dir is not None and not path.is_absolute():
-            return Path(project_dir) / path
+        path = Path(value)
 
-        return path
+        if path.is_absolute() or project_dir is None:
+            return path
+
+        return project_dir / path
+
+    @classmethod
+    def _resolve_paths(cls, values, project_dir):
+        """
+        Resolve a list of path-like values.
+        """
+        if not values:
+            return []
+
+        return [
+            cls._resolve_path(value, project_dir)
+            for value in values
+        ]
 
     def validate_prepared_inputs(self):
         """
-        Validate that the prepared workflow has the minimum required inputs.
+        Validate the minimum inputs for a prepared workflow.
+
+        A prepared workflow starts from user-provided mdp, structure and topology
+        files, then runs grompp -> mdrun.
         """
         missing = []
 
-        required_files = {
-            "mdp_file": self.mdp_file,
-            "structure_file": self.structure_file,
-            "top_file": self.top_file,
-        }
-
-        for name, path in required_files.items():
-            if path is None:
-                missing.append(name)
+        if self.mdp_file is None:
+            missing.append("mdp_file")
+        if self.structure_file is None:
+            missing.append("structure_file")
+        if self.top_file is None:
+            missing.append("top_file")
 
         if missing:
             raise ValueError(
@@ -166,19 +233,103 @@ class GromacsProjectSettings:
                 + ", ".join(missing)
             )
 
+    def validate_full_setup_inputs(self):
+        """
+        Validate the minimum inputs for a full setup workflow.
+
+        The first full setup implementation covers the common non-interactive
+        happy path only.
+        """
+        missing = []
+
+        if self.input_pdb is None and self.structure_file is None:
+            missing.append("input_pdb|structure_file")
+        if self.mdp_file is None:
+            missing.append("mdp_file")
+        if self.force_field is None:
+            missing.append("force_field")
+        if self.water_model is None:
+            missing.append("water_model")
+
+        if missing:
+            raise ValueError(
+                "Missing required GROMACS full_setup settings: "
+                + ", ".join(missing)
+            )
+
+    def validate(self):
+        """
+        Validate settings according to the selected workflow.
+        """
+        if self.workflow == "prepared":
+            self.validate_prepared_inputs()
+            return
+
+        if self.workflow == "full_setup":
+            self.validate_full_setup_inputs()
+            return
+
+        raise ValueError(f"Unsupported GROMACS workflow: {self.workflow}")
+
+    def with_overrides(self, **overrides):
+        """
+        Return a new settings object with selected values overridden.
+
+        None values are ignored so that CLI options can safely override YAML
+        only when the user explicitly provides them.
+        """
+        data = asdict(self)
+
+        for key, value in overrides.items():
+            if value is not None:
+                data[key] = value
+
+        return self.from_dict(data)
+
     def to_job_kwargs(self):
         """
         Convert project settings into keyword arguments for GromacsJob.
-
-        This allows project-level settings to be passed into job creation
-        without duplicating file/path logic.
         """
-        return {
+        data = {
             "mdp_file": self.mdp_file,
+            "ions_mdp_file": self.ions_mdp_file,
             "structure_file": self.structure_file,
+            "input_pdb": self.input_pdb,
             "top_file": self.top_file,
             "tpr_file": self.tpr_file,
-            "itp_files": self.itp_files,
             "index_file": self.index_file,
+            "itp_files": self.itp_files or [],
             "workflow": self.workflow,
+            "processed_structure_file": self.processed_structure_file,
+            "boxed_structure_file": self.boxed_structure_file,
+            "solvated_structure_file": self.solvated_structure_file,
+            "ions_tpr_file": self.ions_tpr_file,
+            "ionized_structure_file": self.ionized_structure_file,
+            "force_field": self.force_field,
+            "water_model": self.water_model,
+            "timestep": self.timestep,
+            "temperature": self.temperature,
+            "pressure": self.pressure,
+            "thermostat": self.thermostat,
+            "barostat": self.barostat,
+            "constraints": self.constraints,
+            "constraint_algorithm": self.constraint_algorithm,
+            "box_type": self.box_type,
+            "box_distance": self.box_distance,
+            "solvent_file": self.solvent_file,
+            "positive_ion": self.positive_ion,
+            "negative_ion": self.negative_ion,
+            "neutral": self.neutral,
+            "genion_group": self.genion_group,
+            "grompp_maxwarn": self.grompp_maxwarn,
+            "mdrun_threads": self.mdrun_threads,
+            "mdrun_ntmpi": self.mdrun_ntmpi,
+            "mdrun_ntomp": self.mdrun_ntomp,
+            "mdrun_extra_args": self.mdrun_extra_args or [],
+        }
+
+        return {
+            key: value
+            for key, value in data.items()
+            if value is not None
         }

--- a/docs/gromacs_prepared_em_demo.md
+++ b/docs/gromacs_prepared_em_demo.md
@@ -1,0 +1,11 @@
+# GROMACS prepared EM demo
+
+This document describes the first real GROMACS validation case for the
+ChemSmart GROMACS integration.
+
+## Goal
+
+The goal is to validate the minimal real execution chain:
+
+```text
+project.yaml -> GromacsProjectSettings -> GromacsEMJob -> GromacsJobRunner -> grompp -> mdrun

--- a/examples/gromacs/prepared_em/em.mdp
+++ b/examples/gromacs/prepared_em/em.mdp
@@ -1,0 +1,24 @@
+; Minimal energy minimization parameters for a prepared GROMACS demo case.
+
+integrator              = steep
+nsteps                  = 50
+emtol                   = 1000.0
+emstep                  = 0.01
+
+; Output control
+nstlog                  = 1
+nstenergy               = 1
+
+; Neighbor searching and non-bonded settings
+cutoff-scheme           = Verlet
+nstlist                 = 1
+coulombtype             = Cut-off
+rcoulomb                = 0.8
+vdwtype                 = Cut-off
+rvdw                    = 0.8
+
+; Boundary condition
+pbc                     = xyz
+
+; Constraints
+constraints             = none

--- a/examples/gromacs/prepared_em/project.yaml
+++ b/examples/gromacs/prepared_em/project.yaml
@@ -1,0 +1,21 @@
+project:
+  name: water_prepared_em
+  type: gromacs
+  job_type: em
+  mode: prepared
+
+gromacs_settings:
+  force_field: user_provided
+  water_model: spc
+  timestep: 0.001
+  temperature: 300.0
+  pressure: 1.0
+  constraints: none
+  grompp_maxwarn: 0
+  mdrun_threads: 1
+
+inputs:
+  mdp_file: em.mdp
+  structure_file: water.gro
+  topology_file: topol.top
+  tpr_file: em.tpr

--- a/examples/gromacs/prepared_em/topol.top
+++ b/examples/gromacs/prepared_em/topol.top
@@ -1,0 +1,10 @@
+; Minimal topology for one SPC water molecule.
+
+#include "oplsaa.ff/forcefield.itp"
+#include "oplsaa.ff/spc.itp"
+
+[ system ]
+Single water molecule prepared EM demo
+
+[ molecules ]
+SOL 1

--- a/examples/gromacs/prepared_em/waterr.gro
+++ b/examples/gromacs/prepared_em/waterr.gro
@@ -1,0 +1,6 @@
+Single water molecule prepared EM demo
+3
+    1SOL     OW    1   0.000   0.000   0.000
+    1SOL    HW1    2   0.096   0.000   0.000
+    1SOL    HW2    3  -0.024   0.093   0.000
+   2.00000   2.00000   2.00000

--- a/tests/test_gromacs_cli.py
+++ b/tests/test_gromacs_cli.py
@@ -1,0 +1,324 @@
+
+import importlib
+
+import pytest
+from click.testing import CliRunner
+
+from chemsmart.cli.gromacs.gromacs import gromacs
+
+
+em_module = importlib.import_module("chemsmart.cli.gromacs.em")
+
+
+class DummyGromacsEMJob:
+    """
+    Dummy job class used to test CLI argument flow without creating a real job
+    or running real GROMACS.
+    """
+
+    captured_from_settings = {}
+    captured_direct_init = {}
+
+    @classmethod
+    def from_project_settings(
+        cls,
+        settings,
+        molecule=None,
+        jobrunner=None,
+        skip_completed=False,
+        **kwargs,
+    ):
+        cls.captured_from_settings = {
+            "settings": settings,
+            "molecule": molecule,
+            "jobrunner": jobrunner,
+            "skip_completed": skip_completed,
+            "kwargs": kwargs,
+        }
+        return cls()
+
+    def __init__(
+        self,
+        molecule=None,
+        label=None,
+        jobrunner=None,
+        mdp_file=None,
+        ions_mdp_file=None,
+        structure_file=None,
+        input_pdb=None,
+        top_file=None,
+        itp_files=None,
+        index_file=None,
+        workflow=None,
+        skip_completed=False,
+        **kwargs,
+    ):
+        self.__class__.captured_direct_init = {
+            "molecule": molecule,
+            "label": label,
+            "jobrunner": jobrunner,
+            "mdp_file": mdp_file,
+            "ions_mdp_file": ions_mdp_file,
+            "structure_file": structure_file,
+            "input_pdb": input_pdb,
+            "top_file": top_file,
+            "itp_files": itp_files,
+            "index_file": index_file,
+            "workflow": workflow,
+            "skip_completed": skip_completed,
+            "kwargs": kwargs,
+        }
+
+
+@pytest.fixture(autouse=True)
+def patch_gromacs_em_job(monkeypatch):
+    """
+    Replace the real GromacsEMJob used by the CLI with a dummy class.
+
+    This keeps the test focused on CLI argument parsing and job creation flow.
+    """
+    DummyGromacsEMJob.captured_from_settings = {}
+    DummyGromacsEMJob.captured_direct_init = {}
+
+    monkeypatch.setattr(
+        em_module,
+        "GromacsEMJob",
+        DummyGromacsEMJob,
+    )
+
+
+@pytest.fixture
+def demo_project_yaml(tmp_path):
+    """
+    Create a minimal prepared GROMACS project YAML and required input files.
+    """
+    yaml_file = tmp_path / "project.yaml"
+
+    yaml_file.write_text(
+        """
+project:
+  name: prepared_em
+  type: gromacs
+  job_type: em
+  mode: prepared
+
+inputs:
+  mdp_file: em.mdp
+  structure_file: input.gro
+  topology_file: topol.top
+""",
+        encoding="utf-8",
+    )
+
+    for filename in ["em.mdp", "input.gro", "topol.top"]:
+        (tmp_path / filename).write_text(
+            "dummy content",
+            encoding="utf-8",
+        )
+
+    return yaml_file
+
+
+def test_cli_project_yaml_creates_job(demo_project_yaml):
+    """
+    Test YAML-driven CLI mode.
+
+    Expected flow:
+        gromacs -p project.yaml em
+        -> GromacsProjectSettings
+        -> GromacsEMJob.from_project_settings()
+    """
+    runner = CliRunner()
+
+    result = runner.invoke(
+        gromacs,
+        [
+            "-p",
+            str(demo_project_yaml),
+            "em",
+        ],
+        obj={"molecule": None},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert result.exception is None
+
+    captured = DummyGromacsEMJob.captured_from_settings
+    assert captured
+
+    settings = captured["settings"]
+
+    assert settings.project_name == "prepared_em"
+    assert settings.workflow == "prepared"
+    assert settings.job_type == "em"
+
+    assert settings.mdp_file == demo_project_yaml.parent / "em.mdp"
+    assert settings.structure_file == demo_project_yaml.parent / "input.gro"
+    assert settings.top_file == demo_project_yaml.parent / "topol.top"
+
+    assert captured["molecule"] is None
+    assert captured["jobrunner"] is None
+
+
+def test_cli_project_yaml_option_creates_job(demo_project_yaml):
+    """
+    Test explicit --project-yaml mode.
+
+    This should behave the same as -p project.yaml.
+    """
+    runner = CliRunner()
+
+    result = runner.invoke(
+        gromacs,
+        [
+            "--project-yaml",
+            str(demo_project_yaml),
+            "em",
+        ],
+        obj={"molecule": None},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert result.exception is None
+
+    captured = DummyGromacsEMJob.captured_from_settings
+    assert captured
+
+    settings = captured["settings"]
+
+    assert settings.project_name == "prepared_em"
+    assert settings.workflow == "prepared"
+    assert settings.job_type == "em"
+
+    assert settings.mdp_file == demo_project_yaml.parent / "em.mdp"
+    assert settings.structure_file == demo_project_yaml.parent / "input.gro"
+    assert settings.top_file == demo_project_yaml.parent / "topol.top"
+
+
+def test_cli_direct_options_creates_job(tmp_path):
+    """
+    Test direct CLI option mode.
+
+    Expected flow:
+        gromacs em --mdp em.mdp --structure input.gro --top topol.top
+        -> GromacsEMJob(...)
+    """
+    runner = CliRunner()
+
+    mdp_file = tmp_path / "em.mdp"
+    structure_file = tmp_path / "input.gro"
+    top_file = tmp_path / "topol.top"
+
+    for file_path in [mdp_file, structure_file, top_file]:
+        file_path.write_text(
+            "dummy content",
+            encoding="utf-8",
+        )
+
+    result = runner.invoke(
+        gromacs,
+        [
+            "em",
+            "--mdp",
+            str(mdp_file),
+            "--structure",
+            str(structure_file),
+            "--top",
+            str(top_file),
+        ],
+        obj={"molecule": None},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert result.exception is None
+
+    captured = DummyGromacsEMJob.captured_direct_init
+    assert captured
+
+    assert captured["label"] == "input_em"
+    assert captured["workflow"] == "prepared"
+
+    assert captured["mdp_file"] == mdp_file
+    assert captured["structure_file"] == structure_file
+    assert captured["top_file"] == top_file
+
+    assert captured["itp_files"] == []
+    assert captured["index_file"] is None
+    assert captured["molecule"] is None
+    assert captured["jobrunner"] is None
+
+
+def test_cli_direct_options_accepts_itp_files(tmp_path):
+    """
+    Test that --itp can be provided multiple times.
+    """
+    runner = CliRunner()
+
+    mdp_file = tmp_path / "em.mdp"
+    structure_file = tmp_path / "input.gro"
+    top_file = tmp_path / "topol.top"
+    ligand_itp = tmp_path / "ligand.itp"
+    forcefield_itp = tmp_path / "forcefield.itp"
+
+    for file_path in [
+        mdp_file,
+        structure_file,
+        top_file,
+        ligand_itp,
+        forcefield_itp,
+    ]:
+        file_path.write_text(
+            "dummy content",
+            encoding="utf-8",
+        )
+
+    result = runner.invoke(
+        gromacs,
+        [
+            "em",
+            "--mdp",
+            str(mdp_file),
+            "--structure",
+            str(structure_file),
+            "--top",
+            str(top_file),
+            "--itp",
+            str(ligand_itp),
+            "--itp",
+            str(forcefield_itp),
+        ],
+        obj={"molecule": None},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert result.exception is None
+
+    captured = DummyGromacsEMJob.captured_direct_init
+    assert captured
+
+    assert captured["itp_files"] == [
+        ligand_itp,
+        forcefield_itp,
+    ]
+
+
+def test_cli_rejects_missing_project_yaml(tmp_path):
+    """
+    Test that an invalid -p path fails early.
+    """
+    runner = CliRunner()
+
+    missing_yaml = tmp_path / "missing_project.yaml"
+
+    result = runner.invoke(
+        gromacs,
+        [
+            "-p",
+            str(missing_yaml),
+            "em",
+        ],
+        obj={"molecule": None},
+    )
+
+    assert result.exit_code != 0
+    assert result.exception is not None

--- a/tests/test_gromacs_job.py
+++ b/tests/test_gromacs_job.py
@@ -1,0 +1,85 @@
+# tests/test_gromacs_job.py
+
+from pathlib import Path
+import pytest
+
+from chemsmart.jobs.gromacs.job import GromacsEMJob, GromacsJob
+from chemsmart.settings.gromacs import GromacsProjectSettings
+
+def test_gromacs_job_can_be_created_from_project_settings(tmp_path):
+    # Prepare virtual project settings
+    settings = GromacsProjectSettings.from_dict({
+        "project_name": "prepared_em",
+        "workflow": "prepared",
+        "mdp_file": tmp_path / "em.mdp",
+        "structure_file": tmp_path / "input.gro",
+        "top_file": tmp_path / "topol.top",
+        "tpr_file": tmp_path / "em.tpr",
+        "index_file": tmp_path / "index.ndx",
+        "itp_files": [tmp_path / "forcefield.itp"],
+    })
+
+    # Create a Job through settings
+    job = GromacsEMJob.from_project_settings(
+        settings=settings,
+        molecule=None,
+        jobrunner=None
+    )
+
+    assert isinstance(job, GromacsEMJob)
+    assert job.label == "prepared_em"
+    assert job.workflow == "prepared"
+    assert job.mdp_file == tmp_path / "em.mdp"
+    assert job.structure_file == tmp_path / "input.gro"
+    assert job.top_file == tmp_path / "topol.top"
+    assert job.tpr_file == tmp_path / "em.tpr"
+    assert job.index_file == tmp_path / "index.ndx"
+    assert job.itp_files == [tmp_path / "forcefield.itp"]
+
+def test_gromacs_job_default_tpr(tmp_path):
+    settings = GromacsProjectSettings.from_dict({
+        "project_name": "prepared_em",
+        "workflow": "prepared",
+        "mdp_file": tmp_path / "em.mdp",
+        "structure_file": tmp_path / "input.gro",
+        "top_file": tmp_path / "topol.top",
+    })
+
+    job = GromacsEMJob.from_project_settings(
+        settings=settings,
+        molecule=None,
+        jobrunner=None
+    )
+
+    # Set folder
+    job.set_folder(tmp_path)
+
+    # Automatic tpr file generation
+    expected_tpr = tmp_path / f"{job.label}.tpr"
+    assert job.tpr_file == expected_tpr
+
+def test_gromacs_job_has_required_prepared_inputs(tmp_path):
+    settings = GromacsProjectSettings.from_dict({
+        "mdp_file": tmp_path / "em.mdp",
+        "structure_file": tmp_path / "input.gro",
+        "top_file": tmp_path / "topol.top",
+    })
+
+    job = GromacsEMJob.from_project_settings(
+        settings=settings,
+        molecule=None,
+        jobrunner=None
+    )
+
+    job.set_folder(tmp_path)
+
+    # Return ture when all necessary files exist
+    assert job.has_required_prepared_inputs() is False
+    # Because the file does not exist on the disk
+
+    # Create a file simulation existence
+    for file_attr in ["mdp_file", "structure_file", "top_file"]:
+        f = getattr(job, file_attr)
+        f.write_text("dummy content", encoding="utf-8")
+
+    assert job.has_required_prepared_inputs() is True

--- a/tests/test_gromacs_real_prepared_em.py
+++ b/tests/test_gromacs_real_prepared_em.py
@@ -1,0 +1,177 @@
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from chemsmart.jobs.gromacs.job import GromacsEMJob
+from chemsmart.jobs.gromacs.runner import GromacsJobRunner
+from chemsmart.settings.gromacs import GromacsProjectSettings
+
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("gmx") is None,
+    reason="Real GROMACS executable 'gmx' is not available in PATH.",
+)
+
+
+def _write_demo_case(tmp_path):
+    """
+    Write a minimal prepared GROMACS EM demo case.
+
+    This case is intentionally small so that it can be used for local
+    integration testing. It uses one SPC water molecule and the built-in
+    OPLS-AA force field files available in a standard GROMACS installation.
+    """
+    project_yaml = tmp_path / "project.yaml"
+    mdp_file = tmp_path / "em.mdp"
+    structure_file = tmp_path / "water.gro"
+    top_file = tmp_path / "topol.top"
+
+    project_yaml.write_text(
+        """
+project:
+  name: water_prepared_em
+  type: gromacs
+  job_type: em
+  mode: prepared
+
+gromacs_settings:
+  force_field: user_provided
+  water_model: spc
+  timestep: 0.001
+  temperature: 300.0
+  pressure: 1.0
+  constraints: none
+  grompp_maxwarn: 0
+  mdrun_threads: 1
+
+inputs:
+  mdp_file: em.mdp
+  structure_file: water.gro
+  topology_file: topol.top
+  tpr_file: em.tpr
+""",
+        encoding="utf-8",
+    )
+
+    mdp_file.write_text(
+        """
+integrator              = steep
+nsteps                  = 50
+emtol                   = 1000.0
+emstep                  = 0.01
+
+nstlog                  = 1
+nstenergy               = 1
+
+cutoff-scheme           = Verlet
+nstlist                 = 1
+coulombtype             = Cut-off
+rcoulomb                = 0.8
+vdwtype                 = Cut-off
+rvdw                    = 0.8
+
+pbc                     = xyz
+constraints             = none
+""",
+        encoding="utf-8",
+    )
+
+    structure_file.write_text(
+        """Single water molecule prepared EM demo
+3
+    1SOL     OW    1   0.000   0.000   0.000
+    1SOL    HW1    2   0.096   0.000   0.000
+    1SOL    HW2    3  -0.024   0.093   0.000
+   2.00000   2.00000   2.00000
+""",
+        encoding="utf-8",
+    )
+
+    top_file.write_text(
+        """
+#include "oplsaa.ff/forcefield.itp"
+#include "oplsaa.ff/spc.itp"
+
+[ system ]
+Single water molecule prepared EM demo
+
+[ molecules ]
+SOL 1
+""",
+        encoding="utf-8",
+    )
+
+    return project_yaml
+
+
+def _make_real_runner(tmp_path):
+    """
+    Create a minimal real GROMACS runner for integration testing.
+
+    __new__ is used to avoid depending on a real ChemSmart server object in
+    this integration test. The goal here is to validate the GROMACS execution
+    path, not the cluster submission layer.
+    """
+    runner = GromacsJobRunner.__new__(GromacsJobRunner)
+    runner.gmx_executable = "gmx"
+    runner.gmx_modules = []
+    runner.gmx_env = {}
+    runner.gmx_source_scripts = []
+    runner.fake = False
+    runner.running_directory = str(tmp_path)
+    runner.job_outputfile = str(tmp_path / "water_prepared_em.out")
+    runner.job_errfile = str(tmp_path / "water_prepared_em.err")
+    return runner
+
+
+def test_real_gromacs_prepared_em_from_project_yaml(tmp_path):
+    """
+    Test project.yaml -> settings -> job -> runner -> real grompp -> real mdrun.
+    """
+    project_yaml = _write_demo_case(tmp_path)
+
+    settings = GromacsProjectSettings.from_yaml(project_yaml)
+    settings.validate()
+
+    job = GromacsEMJob.from_project_settings(
+        settings=settings,
+        molecule=None,
+        jobrunner=None,
+    )
+    job.set_folder(str(tmp_path))
+
+    runner = _make_real_runner(tmp_path)
+
+    runner._assign_variables(job)
+    runner._validate_gromacs_inputs(job)
+
+    runner._assemble_tpr(job)
+    assert (tmp_path / "em.tpr").exists()
+
+    runner._run_command(
+        runner._get_mdrun_command(job),
+        cwd=tmp_path,
+        check=True,
+        stage="mdrun",
+    )
+
+    assert (tmp_path / "em.log").exists()
+    assert (tmp_path / "em.edr").exists()
+    assert (tmp_path / "em.gro").exists()
+
+
+def test_real_gromacs_is_available():
+    """
+    Record the GROMACS version in the test log.
+    """
+    result = subprocess.run(
+        ["gmx", "--version"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=True,
+    )
+
+    assert "GROMACS" in result.stdout

--- a/tests/test_gromacs_runner.py
+++ b/tests/test_gromacs_runner.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -16,6 +17,10 @@ def _make_runner(gmx_executable="gmx"):
     """
     runner = GromacsJobRunner.__new__(GromacsJobRunner)
     runner.gmx_executable = gmx_executable
+    runner.gmx_modules = []
+    runner.gmx_env = {}
+    runner.gmx_source_scripts = []
+    runner.fake = False
     return runner
 
 
@@ -226,6 +231,30 @@ def test_gromacs_runner_get_grompp_command_with_index(tmp_path):
     ]
 
 
+def test_gromacs_runner_get_grompp_command_with_maxwarn(tmp_path):
+    mdp_file = tmp_path / "em.mdp"
+    structure_file = tmp_path / "input.gro"
+    top_file = tmp_path / "topol.top"
+    tpr_file = tmp_path / "em.tpr"
+
+    job = GromacsEMJob(
+        molecule=None,
+        label="em",
+        jobrunner=None,
+        mdp_file=mdp_file,
+        structure_file=structure_file,
+        top_file=top_file,
+        tpr_file=tpr_file,
+        grompp_maxwarn=1,
+    )
+
+    runner = _make_runner()
+
+    command = runner._get_grompp_command(job)
+
+    assert command[-2:] == ["-maxwarn", "1"]
+
+
 def test_gromacs_runner_get_mdrun_command(tmp_path):
     tpr_file = tmp_path / "em.tpr"
 
@@ -248,6 +277,43 @@ def test_gromacs_runner_get_mdrun_command(tmp_path):
         "mdrun",
         "-deffnm",
         str(tmp_path / "em"),
+    ]
+
+
+def test_gromacs_runner_get_mdrun_command_with_runtime_options(tmp_path):
+    tpr_file = tmp_path / "em.tpr"
+
+    job = GromacsEMJob(
+        molecule=None,
+        label="em",
+        jobrunner=None,
+        mdp_file=tmp_path / "em.mdp",
+        structure_file=tmp_path / "input.gro",
+        top_file=tmp_path / "topol.top",
+        tpr_file=tpr_file,
+        mdrun_threads=4,
+        mdrun_ntmpi=1,
+        mdrun_ntomp=4,
+        mdrun_extra_args=["-pin", "auto"],
+    )
+
+    runner = _make_runner()
+
+    command = runner._get_mdrun_command(job)
+
+    assert command == [
+        "gmx",
+        "mdrun",
+        "-deffnm",
+        str(tmp_path / "em"),
+        "-nt",
+        "4",
+        "-ntmpi",
+        "1",
+        "-ntomp",
+        "4",
+        "-pin",
+        "auto",
     ]
 
 
@@ -330,12 +396,12 @@ def test_gromacs_runner_get_pdb2gmx_command(tmp_path):
         jobrunner=None,
         mdp_file=tmp_path / "em.mdp",
         structure_file=output_gro,
+        input_pdb=input_pdb,
         top_file=top_file,
+        processed_structure_file=output_gro,
+        force_field="amber99sb-ildn",
+        water_model="tip3p",
     )
-    job.input_pdb = input_pdb
-    job.output_gro = output_gro
-    job.force_field = "amber99sb-ildn"
-    job.water_model = "tip3p"
 
     runner = _make_runner()
 
@@ -368,11 +434,11 @@ def test_gromacs_runner_get_editconf_command(tmp_path):
         mdp_file=tmp_path / "em.mdp",
         structure_file=input_structure,
         top_file=tmp_path / "topol.top",
+        processed_structure_file=input_structure,
+        boxed_structure_file=output_structure,
+        box_type="cubic",
+        box_distance=1.0,
     )
-    job.editconf_input_file = input_structure
-    job.editconf_output_file = output_structure
-    job.box_type = "cubic"
-    job.box_distance = 1.0
 
     runner = _make_runner()
 
@@ -404,9 +470,9 @@ def test_gromacs_runner_get_solvate_command(tmp_path):
         mdp_file=tmp_path / "em.mdp",
         structure_file=tmp_path / "input.gro",
         top_file=top_file,
+        boxed_structure_file=input_structure,
+        solvated_structure_file=output_structure,
     )
-    job.boxed_structure_file = input_structure
-    job.solvated_structure_file = output_structure
 
     runner = _make_runner()
 
@@ -436,12 +502,12 @@ def test_gromacs_runner_get_genion_command(tmp_path):
         mdp_file=tmp_path / "em.mdp",
         structure_file=tmp_path / "input.gro",
         top_file=top_file,
+        ions_tpr_file=input_tpr,
+        ionized_structure_file=output_structure,
+        positive_ion="NA",
+        negative_ion="CL",
+        neutral=True,
     )
-    job.ions_tpr_file = input_tpr
-    job.ions_output_file = output_structure
-    job.positive_ion = "NA"
-    job.negative_ion = "CL"
-    job.neutral = True
 
     runner = _make_runner()
 
@@ -464,18 +530,45 @@ def test_gromacs_runner_get_genion_command(tmp_path):
     ]
 
 
-def test_gromacs_runner_full_setup_is_not_implemented():
+def test_gromacs_runner_get_commands_for_full_setup(tmp_path):
+    input_pdb = tmp_path / "input.pdb"
+    mdp_file = tmp_path / "em.mdp"
+    top_file = tmp_path / "topol.top"
+
+    input_pdb.write_text("dummy pdb\n", encoding="utf-8")
+    mdp_file.write_text("integrator = steep\n", encoding="utf-8")
+
     job = GromacsEMJob(
         molecule=None,
         label="em",
         jobrunner=None,
+        mdp_file=mdp_file,
+        input_pdb=input_pdb,
+        top_file=top_file,
         workflow="full_setup",
+        force_field="amber99sb-ildn",
+        water_model="tip3p",
     )
 
-    runner = _make_runner()
+    job.set_folder(str(tmp_path))
 
-    with pytest.raises(NotImplementedError):
-        runner._get_commands(job)
+    runner = _make_runner()
+    commands = runner._get_commands(job)
+
+    assert commands[0][1] == "pdb2gmx"
+    assert commands[1][1] == "editconf"
+    assert commands[2][1] == "solvate"
+    assert commands[3][1] == "grompp"
+    assert commands[4][1] == "genion"
+    assert commands[5][1] == "grompp"
+    assert commands[6][1] == "mdrun"
+
+    assert job.processed_structure_file == tmp_path / "processed.gro"
+    assert job.boxed_structure_file == tmp_path / "boxed.gro"
+    assert job.solvated_structure_file == tmp_path / "solvated.gro"
+    assert job.ions_tpr_file == tmp_path / "ions.tpr"
+    assert job.ionized_structure_file == tmp_path / "ionized.gro"
+    assert job.tpr_file == tmp_path / "em.tpr"
 
 
 def test_gromacs_runner_raises_for_unsupported_workflow():
@@ -490,6 +583,49 @@ def test_gromacs_runner_raises_for_unsupported_workflow():
 
     with pytest.raises(ValueError, match="Unsupported GROMACS workflow"):
         runner._get_commands(job)
+
+
+def test_gromacs_runner_run_command_passes_stdin(tmp_path, monkeypatch):
+    runner = _make_runner()
+    runner.running_directory = str(tmp_path)
+    runner.job_outputfile = str(tmp_path / "job.out")
+    runner.job_errfile = str(tmp_path / "job.err")
+
+    captured = {}
+
+    def fake_run(*args, **kwargs):
+        captured["input"] = kwargs.get("input")
+        return subprocess.CompletedProcess(
+            args=args[0],
+            returncode=0,
+            stdout="ok",
+            stderr="",
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    runner._run_command(
+        ["gmx", "genion"],
+        input_text="SOL\n",
+        stage="genion",
+    )
+
+    assert captured["input"] == "SOL\n"
+
+
+def test_gromacs_runner_wraps_command_for_modules():
+    runner = _make_runner(gmx_executable="/opt/gromacs/bin/gmx")
+    runner.gmx_modules = ["gcc/13", "gromacs/2026"]
+    runner.gmx_source_scripts = ["/opt/gromacs/bin/GMXRC"]
+
+    wrapped = runner._wrap_command_if_needed(
+        ["/opt/gromacs/bin/gmx", "mdrun", "-deffnm", "em"]
+    )
+
+    assert wrapped[:2] == ["bash", "-lc"]
+    assert "module load gcc/13" in wrapped[2]
+    assert "module load gromacs/2026" in wrapped[2]
+    assert "source /opt/gromacs/bin/GMXRC" in wrapped[2]
 
 
 def test_gromacs_executable_defaults_to_gmx():

--- a/tests/test_gromacs_settings.py
+++ b/tests/test_gromacs_settings.py
@@ -2,8 +2,9 @@ from pathlib import Path
 
 import pytest
 
-from chemsmart.settings.gromacs import GromacsProjectSettings
 from chemsmart.jobs.gromacs.job import GromacsEMJob, GromacsJob
+from chemsmart.settings.gromacs import GromacsProjectSettings
+
 
 def test_gromacs_project_settings_from_dict_converts_paths():
     settings = GromacsProjectSettings.from_dict(
@@ -84,15 +85,13 @@ def test_gromacs_project_settings_to_job_kwargs():
 
     job_kwargs = settings.to_job_kwargs()
 
-    assert job_kwargs == {
-        "mdp_file": Path("em.mdp"),
-        "structure_file": Path("input.gro"),
-        "top_file": Path("topol.top"),
-        "tpr_file": Path("em.tpr"),
-        "itp_files": [Path("forcefield.itp")],
-        "index_file": Path("index.ndx"),
-        "workflow": "prepared",
-    }
+    assert job_kwargs["mdp_file"] == Path("em.mdp")
+    assert job_kwargs["structure_file"] == Path("input.gro")
+    assert job_kwargs["top_file"] == Path("topol.top")
+    assert job_kwargs["tpr_file"] == Path("em.tpr")
+    assert job_kwargs["index_file"] == Path("index.ndx")
+    assert job_kwargs["itp_files"] == [Path("forcefield.itp")]
+    assert job_kwargs["workflow"] == "prepared"
 
 
 def test_gromacs_project_settings_defaults_to_prepared_workflow():
@@ -135,6 +134,37 @@ def test_gromacs_project_settings_accepts_project_level_parameters():
     assert settings.constraints == "h-bonds"
     assert settings.constraint_algorithm == "LINCS"
 
+
+def test_gromacs_project_settings_validate_full_setup_inputs_passes():
+    settings = GromacsProjectSettings.from_dict(
+        {
+            "workflow": "full_setup",
+            "input_pdb": "input.pdb",
+            "mdp_file": "em.mdp",
+            "force_field": "amber99sb-ildn",
+            "water_model": "tip3p",
+        }
+    )
+
+    settings.validate_full_setup_inputs()
+
+
+def test_gromacs_project_settings_validate_full_setup_inputs_raises():
+    settings = GromacsProjectSettings.from_dict(
+        {
+            "workflow": "full_setup",
+            "input_pdb": "input.pdb",
+            "mdp_file": "em.mdp",
+        }
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="Missing required GROMACS full_setup settings",
+    ):
+        settings.validate_full_setup_inputs()
+
+
 def test_gromacs_job_can_be_created_from_project_settings():
     settings = GromacsProjectSettings.from_dict(
         {
@@ -163,6 +193,7 @@ def test_gromacs_job_can_be_created_from_project_settings():
     assert job.tpr_file == Path("em.tpr")
     assert job.index_file == Path("index.ndx")
     assert job.itp_files == [Path("forcefield.itp")]
+
 
 def test_gromacs_em_job_can_be_created_from_project_settings():
     settings = GromacsProjectSettings.from_dict(
@@ -194,115 +225,150 @@ def test_gromacs_em_job_can_be_created_from_project_settings():
     assert job.index_file == Path("index.ndx")
     assert job.itp_files == [Path("forcefield.itp")]
 
-    def test_gromacs_project_settings_from_yaml(tmp_path):
-        yaml_file = tmp_path / "project.yaml"
-        yaml_file.write_text(
-            """
-    project:
-      name: prepared_em
-      type: gromacs
-      mode: prepared
 
-    gromacs_settings:
-      force_field: user_provided
-      water_model: user_provided
-      timestep: 0.002
-      temperature: 300.0
-      pressure: 1.0
-      thermostat: V-rescale
-      barostat: Parrinello-Rahman
-      constraints: h-bonds
-      constraint_algorithm: LINCS
+def test_gromacs_project_settings_from_yaml(tmp_path):
+    yaml_file = tmp_path / "project.yaml"
+    yaml_file.write_text(
+        """
+project:
+  name: prepared_em
+  type: gromacs
+  mode: prepared
 
-    inputs:
-      mdp_file: em.mdp
-      structure_file: input.gro
-      topology_file: topol.top
-      tpr_file: em.tpr
-      index_file: index.ndx
-      itp_files:
-        - forcefield.itp
-        - ligand.itp
-    """,
-            encoding="utf-8",
-        )
+gromacs_settings:
+  force_field: user_provided
+  water_model: user_provided
+  timestep: 0.002
+  temperature: 300.0
+  pressure: 1.0
+  thermostat: V-rescale
+  barostat: Parrinello-Rahman
+  constraints: h-bonds
+  constraint_algorithm: LINCS
 
-        settings = GromacsProjectSettings.from_yaml(yaml_file)
+inputs:
+  mdp_file: em.mdp
+  structure_file: input.gro
+  topology_file: topol.top
+  tpr_file: em.tpr
+  index_file: index.ndx
+  itp_files:
+    - forcefield.itp
+    - ligand.itp
+""",
+        encoding="utf-8",
+    )
 
-        assert settings.project_name == "prepared_em"
-        assert settings.workflow == "prepared"
+    settings = GromacsProjectSettings.from_yaml(yaml_file)
 
-        assert settings.force_field == "user_provided"
-        assert settings.water_model == "user_provided"
-        assert settings.timestep == 0.002
-        assert settings.temperature == 300.0
-        assert settings.pressure == 1.0
-        assert settings.thermostat == "V-rescale"
-        assert settings.barostat == "Parrinello-Rahman"
-        assert settings.constraints == "h-bonds"
-        assert settings.constraint_algorithm == "LINCS"
+    assert settings.project_name == "prepared_em"
+    assert settings.workflow == "prepared"
 
-        assert settings.project_dir == tmp_path
-        assert settings.mdp_file == tmp_path / "em.mdp"
-        assert settings.structure_file == tmp_path / "input.gro"
-        assert settings.top_file == tmp_path / "topol.top"
-        assert settings.tpr_file == tmp_path / "em.tpr"
-        assert settings.index_file == tmp_path / "index.ndx"
-        assert settings.itp_files == [
-            tmp_path / "forcefield.itp",
-            tmp_path / "ligand.itp",
-        ]
+    assert settings.force_field == "user_provided"
+    assert settings.water_model == "user_provided"
+    assert settings.timestep == 0.002
+    assert settings.temperature == 300.0
+    assert settings.pressure == 1.0
+    assert settings.thermostat == "V-rescale"
+    assert settings.barostat == "Parrinello-Rahman"
+    assert settings.constraints == "h-bonds"
+    assert settings.constraint_algorithm == "LINCS"
 
-    def test_gromacs_em_job_can_be_created_from_yaml_settings(tmp_path):
-        yaml_file = tmp_path / "project.yaml"
-        yaml_file.write_text(
-            """
-    project:
-      name: prepared_em
-      type: gromacs
-      mode: prepared
+    assert settings.project_dir == tmp_path
+    assert settings.mdp_file == tmp_path / "em.mdp"
+    assert settings.structure_file == tmp_path / "input.gro"
+    assert settings.top_file == tmp_path / "topol.top"
+    assert settings.tpr_file == tmp_path / "em.tpr"
+    assert settings.index_file == tmp_path / "index.ndx"
+    assert settings.itp_files == [
+        tmp_path / "forcefield.itp",
+        tmp_path / "ligand.itp",
+    ]
 
-    inputs:
-      mdp_file: em.mdp
-      structure_file: input.gro
-      topology_file: topol.top
-      tpr_file: em.tpr
-      index_file: index.ndx
-      itp_files:
-        - forcefield.itp
-    """,
-            encoding="utf-8",
-        )
 
-        settings = GromacsProjectSettings.from_yaml(yaml_file)
+def test_gromacs_em_job_can_be_created_from_yaml_settings(tmp_path):
+    yaml_file = tmp_path / "project.yaml"
+    yaml_file.write_text(
+        """
+project:
+  name: prepared_em
+  type: gromacs
+  mode: prepared
 
-        job = GromacsEMJob.from_project_settings(
-            settings=settings,
-            molecule=None,
-            jobrunner=None,
-        )
+inputs:
+  mdp_file: em.mdp
+  structure_file: input.gro
+  topology_file: topol.top
+  tpr_file: em.tpr
+  index_file: index.ndx
+  itp_files:
+    - forcefield.itp
+""",
+        encoding="utf-8",
+    )
 
-        assert job.label == "prepared_em"
-        assert job.workflow == "prepared"
-        assert job.mdp_file == tmp_path / "em.mdp"
-        assert job.structure_file == tmp_path / "input.gro"
-        assert job.top_file == tmp_path / "topol.top"
-        assert job.tpr_file == tmp_path / "em.tpr"
-        assert job.index_file == tmp_path / "index.ndx"
-        assert job.itp_files == [tmp_path / "forcefield.itp"]
+    settings = GromacsProjectSettings.from_yaml(yaml_file)
 
-    def test_gromacs_project_settings_keeps_absolute_paths(tmp_path):
-        mdp_file = tmp_path / "em.mdp"
+    job = GromacsEMJob.from_project_settings(
+        settings=settings,
+        molecule=None,
+        jobrunner=None,
+    )
 
-        settings = GromacsProjectSettings.from_dict(
-            {
-                "project_dir": tmp_path / "project",
-                "mdp_file": mdp_file,
-                "structure_file": "input.gro",
-                "top_file": "topol.top",
-            }
-        )
+    assert job.label == "prepared_em"
+    assert job.workflow == "prepared"
+    assert job.mdp_file == tmp_path / "em.mdp"
+    assert job.structure_file == tmp_path / "input.gro"
+    assert job.top_file == tmp_path / "topol.top"
+    assert job.tpr_file == tmp_path / "em.tpr"
+    assert job.index_file == tmp_path / "index.ndx"
+    assert job.itp_files == [tmp_path / "forcefield.itp"]
 
-        assert settings.mdp_file == mdp_file
-        assert settings.structure_file == tmp_path / "project" / "input.gro"
-        assert settings.top_file == tmp_path / "project" / "topol.top"
+
+def test_gromacs_project_settings_keeps_absolute_paths(tmp_path):
+    mdp_file = tmp_path / "em.mdp"
+
+    settings = GromacsProjectSettings.from_dict(
+        {
+            "project_dir": tmp_path / "project",
+            "mdp_file": mdp_file,
+            "structure_file": "input.gro",
+            "top_file": "topol.top",
+        }
+    )
+
+    assert settings.mdp_file == mdp_file
+    assert settings.structure_file == tmp_path / "project" / "input.gro"
+    assert settings.top_file == tmp_path / "project" / "topol.top"
+
+
+def test_gromacs_project_settings_with_overrides_ignores_none(tmp_path):
+    yaml_file = tmp_path / "project.yaml"
+    yaml_file.write_text(
+        """
+project:
+  name: prepared_em
+  mode: prepared
+
+inputs:
+  mdp_file: em.mdp
+  structure_file: input.gro
+  topology_file: topol.top
+""",
+        encoding="utf-8",
+    )
+
+    settings = GromacsProjectSettings.from_yaml(yaml_file)
+    updated = settings.with_overrides(
+        mdp_file=None,
+        workflow="full_setup",
+        input_pdb="input.pdb",
+        force_field="amber99sb-ildn",
+        water_model="tip3p",
+    )
+
+    assert updated.mdp_file == tmp_path / "em.mdp"
+    assert updated.workflow == "full_setup"
+    assert updated.input_pdb == tmp_path / "input.pdb"
+    assert updated.force_field == "amber99sb-ildn"
+    assert updated.water_model == "tip3p"


### PR DESCRIPTION
## Summary

This PR improves the GROMACS integration in ChemSmart by adding CLI and Job unit tests. 

## Updates

- Added CLI tests for YAML and direct options, including multiple `--itp` support.
- Fixed argument handling for `molecule` and `itp_files`.
- Verified `GromacsEMJob` creation, default TPR path, and required input checks.
- Mocked runner tests for `grompp`/`mdrun` command generation and workflow sequences.

## Status

The workflow from CLI/project settings -> Job -> Runner -> generated commands is fully tested without requiring a real GROMACS installation. Next step is end-to-end testing with real GROMACS.