### PR TITLE
Update config.py

### DIFF
--- a/chemsmart/cli/config.py
+++ b/chemsmart/cli/config.py
@@ -312,6 +312,7 @@ class Config:
             ("Gaussian g16", "~/bin/g16", "Gaussian g16 folder"),
             ("ORCA", "~/bin/orca_6_0_0", "ORCA folder"),
             ("NCIPLOT", "~/bin/nciplot", "NCIPLOT folder"),
+            ("GROMACS", "~/bin/gromacs", "GROMACS folder"),
         ]:
             try:
                 folder = click.prompt(
@@ -566,6 +567,34 @@ def orca(ctx, folder):
     "--folder",
     type=str,
     required=True,
+    help="Path to the GROMACS folder.",
+)
+def gromacs(ctx, folder):
+    """
+    Configure paths to the GROMACS folder.
+
+    Replaces '~/bin/gromacs' with the specified folder in YAML files.
+
+    Examples:
+        chemsmart config gromacs --folder <GROMACSFOLDER>
+    """
+    cfg = ctx.obj["cfg"]
+    if "~" in folder:
+        gromacs_folder = os.path.expanduser(folder)
+        assert os.path.exists(
+            os.path.abspath(gromacs_folder)
+        ), f"GROMACS folder not found: {gromacs_folder}"
+    logger.info(f"Configuring GROMACS with folder: {folder}")
+    update_yaml_files(cfg.chemsmart_server, "~/bin/gromacs", folder)
+
+
+@config.command()
+@click.pass_context
+@click.option(
+    "-f",
+    "--folder",
+    type=str,
+    required=True,
     help="Path to the NCIPLOT folder.",
 )
 def nciplot(ctx, folder):
@@ -590,6 +619,7 @@ def nciplot(ctx, folder):
 config.add_command(server)
 config.add_command(gaussian)
 config.add_command(orca)
+config.add_command(gromacs)
 config.add_command(nciplot)
 
 if __name__ == "__main__":

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -704,7 +704,7 @@ class TestConfigurePathsInteractively:
     """Tests for Config.configure_paths_interactively."""
 
     def test_updates_yaml_for_provided_paths(self, tmp_path):
-        """When the user provides all three paths, update_yaml_files is called for each."""
+        """When the user provides all  paths, update_yaml_files is called for each."""
         cfg = Config()
         with (
             patch.object(
@@ -719,15 +719,19 @@ class TestConfigurePathsInteractively:
                 "/path/to/g16",
                 "/path/to/orca",
                 "/path/to/nci",
+                "/path/to/gromacs",
             ]
             cfg.configure_paths_interactively()
 
-        assert mock_update.call_count == 3
+        assert mock_update.call_count == 4
         mock_update.assert_any_call(tmp_path, "~/bin/g16", "/path/to/g16")
         mock_update.assert_any_call(
             tmp_path, "~/bin/orca_6_0_0", "/path/to/orca"
         )
         mock_update.assert_any_call(tmp_path, "~/bin/nciplot", "/path/to/nci")
+        mock_update.assert_any_call(
+            tmp_path, "~/bin/gromacs", "/path/to/gromacs"
+        )
 
     def test_skips_when_all_prompts_empty(self, tmp_path):
         """When the user presses Enter for all prompts, no YAML updates are made."""
@@ -758,7 +762,7 @@ class TestConfigurePathsInteractively:
             patch("chemsmart.cli.config.click.prompt") as mock_prompt,
         ):
             # Provide Gaussian, skip ORCA and NCIPLOT
-            mock_prompt.side_effect = ["/opt/g16", "", ""]
+            mock_prompt.side_effect = ["/opt/g16", "", "", ""]
             cfg.configure_paths_interactively()
 
         assert mock_update.call_count == 1


### PR DESCRIPTION
Add GROMACS support to ChemSmart configuration so users can configure the GROMACS executable path via make configure / chemsmart config gromacs.