### PR TITLE
add GROMACS NVT job type

### DIFF
--- a/chemsmart/cli/gromacs/__init__.py
+++ b/chemsmart/cli/gromacs/__init__.py
@@ -6,8 +6,10 @@ This module provides CLI subcommands for GROMACS workflows.
 
 from .em import em
 from .gromacs import gromacs
+from .nvt import nvt
 
 __all__ = [
     "gromacs",
     "em",
+    "nvt",
 ]

--- a/chemsmart/cli/gromacs/factory.py
+++ b/chemsmart/cli/gromacs/factory.py
@@ -10,17 +10,41 @@ class GromacsJobFactory:
 
     JOB_TYPE_MAP = {
         "em": GromacsEMJob,
+        "nvt": GromacsNVTJob,
     }
 
     @classmethod
-    def create_from_project_yaml(cls, project_yaml, molecule=None, label=None, jobrunner=None, **kwargs):
+    def create_from_project_yaml(
+            cls,
+            project_yaml,
+            molecule=None,
+            label=None,
+            jobrunner=None,
+            **kwargs):
         settings = GromacsProjectSettings.from_yaml(project_yaml)
-        return cls.create_from_settings(settings, molecule=molecule, label=label, jobrunner=jobrunner, **kwargs)
+        return cls.create_from_settings(
+            settings,
+            molecule=molecule,
+            label=label, jobrunner=jobrunner,
+            **kwargs)
 
     @classmethod
-    def create_from_settings(cls, settings, molecule=None, label=None, jobrunner=None, **kwargs):
+    def create_from_settings(
+        cls,
+        settings,
+        molecule=None,
+        label=None,
+        jobrunner=None,
+        **kwarg,
+    ):
         settings.validate()
         job_cls = cls.JOB_TYPE_MAP.get(settings.job_type)
         if job_cls is None:
             raise ValueError(f"Unsupported GROMACS job type: {settings.job_type}")
-        return job_cls.from_project_settings(settings=settings, molecule=molecule, label=label, jobrunner=jobrunner, **kwargs)
+        return job_cls.from_project_settings(
+            settings=settings,
+            molecule=molecule,
+            label=label,
+            jobrunner=jobrunner,
+            **kwargs,
+        )

--- a/chemsmart/cli/gromacs/nvt.py
+++ b/chemsmart/cli/gromacs/nvt.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+"""
+GROMACS NVT equilibration CLI command.
+
+This command supports two creation modes:
+1. YAML-driven mode: chemsmart run gromacs -p project.yaml nvt
+2. Direct CLI mode: chemsmart run gromacs nvt --mdp nvt.mdp --structure em.gro --top topol.top
+"""
+
+import logging
+from pathlib import Path
+
+import click
+
+from chemsmart.cli.gromacs.gromacs import gromacs
+from chemsmart.cli.job import click_job_options
+from chemsmart.jobs.gromacs.job import GromacsNVTJob
+from chemsmart.utils.cli import MyGroup
+
+logger = logging.getLogger(__name__)
+
+
+@gromacs.group("nvt", cls=MyGroup, invoke_without_command=True)
+@click_job_options
+@click.option(
+    "--mdp",
+    "mdp_file",
+    type=click.Path(
+        exists=True,
+        dir_okay=False,
+        resolve_path=True,
+        path_type=Path,
+    ),
+    default=None,
+    help="GROMACS .mdp file for NVT equilibration.",
+)
+@click.option(
+    "--structure",
+    "-s",
+    "structure_file",
+    type=click.Path(
+        exists=True,
+        dir_okay=False,
+        resolve_path=True,
+        path_type=Path,
+    ),
+    default=None,
+    help="Input structure file for NVT equilibration, such as EM output .gro.",
+)
+@click.option(
+    "--input-pdb",
+    "input_pdb",
+    type=click.Path(
+        exists=True,
+        dir_okay=False,
+        resolve_path=True,
+        path_type=Path,
+    ),
+    default=None,
+    help="Raw PDB file used by the full_setup workflow.",
+)
+@click.option(
+    "--top",
+    "top_file",
+    type=click.Path(
+        exists=True,
+        dir_okay=False,
+        resolve_path=True,
+        path_type=Path,
+    ),
+    default=None,
+    help="GROMACS topology .top file.",
+)
+@click.option(
+    "--index",
+    "index_file",
+    type=click.Path(
+        exists=True,
+        dir_okay=False,
+        resolve_path=True,
+        path_type=Path,
+    ),
+    default=None,
+    help="Optional GROMACS index .ndx file.",
+)
+@click.option(
+    "--itp",
+    "itp_files",
+    multiple=True,
+    type=click.Path(
+        exists=True,
+        dir_okay=False,
+        resolve_path=True,
+        path_type=Path,
+    ),
+    help="Optional GROMACS .itp include file. Can be used multiple times.",
+)
+@click.option(
+    "--workflow",
+    type=click.Choice(["prepared", "full_setup"]),
+    default=None,
+    help="GROMACS workflow mode.",
+)
+@click.pass_context
+def nvt(
+    ctx,
+    skip_completed,
+    mdp_file,
+    structure_file,
+    input_pdb,
+    top_file,
+    index_file,
+    itp_files,
+    workflow,
+    molecule=None,
+    **kwargs,
+):
+    """
+    CLI subcommand for running GROMACS NVT equilibration.
+    """
+
+    jobrunner = ctx.obj.get("jobrunner", None)
+    project = ctx.obj.get("project", None)
+    project_yaml = ctx.obj.get("project_yaml", None)
+    project_settings = ctx.obj.get("project_settings", None)
+    filename = ctx.obj.get("filename", None)
+
+    if structure_file is None:
+        structure_file = filename
+
+    if project_settings is not None:
+        settings = project_settings.with_overrides(
+            mdp_file=Path(mdp_file) if mdp_file else None,
+            structure_file=Path(structure_file) if structure_file else None,
+            input_pdb=Path(input_pdb) if input_pdb else None,
+            top_file=Path(top_file) if top_file else None,
+            index_file=Path(index_file) if index_file else None,
+            workflow=workflow,
+            itp_files=list(itp_files) if itp_files else None,
+        )
+
+        settings.validate()
+
+        logger.info(
+            "Creating GROMACS NVT job from project YAML: %s",
+            project_yaml,
+        )
+
+        if ctx.invoked_subcommand is None:
+            return GromacsNVTJob.from_project_settings(
+                settings=settings,
+                molecule=molecule,
+                jobrunner=jobrunner,
+                skip_completed=skip_completed,
+                **kwargs,
+            )
+        return None
+
+    # direct CLI mode
+    label = "gromacs_nvt"
+    if structure_file is not None:
+        label = Path(structure_file).stem + "_nvt"
+
+    workflow = workflow or "prepared"
+
+    logger.info("Creating GROMACS NVT job from direct CLI options.")
+    logger.info("GROMACS NVT structure file: %s", structure_file)
+    logger.info("GROMACS NVT mdp file: %s", mdp_file)
+    logger.info("GROMACS NVT topology file: %s", top_file)
+    logger.info("GROMACS NVT itp files: %s", itp_files)
+    logger.info("GROMACS NVT workflow: %s", workflow)
+
+    if ctx.invoked_subcommand is None:
+        return GromacsNVTJob(
+            molecule=molecule,
+            label=label,
+            jobrunner=jobrunner,
+            mdp_file=Path(mdp_file) if mdp_file else None,
+            structure_file=Path(structure_file) if structure_file else None,
+            input_pdb=Path(input_pdb) if input_pdb else None,
+            top_file=Path(top_file) if top_file else None,
+            itp_files=list(itp_files) if itp_files else [],
+            index_file=Path(index_file) if index_file else None,
+            workflow=workflow,
+            skip_completed=skip_completed,
+            **kwargs,
+        )
+

--- a/chemsmart/jobs/gromacs/__init__.py
+++ b/chemsmart/jobs/gromacs/__init__.py
@@ -4,5 +4,6 @@ from .runner import GromacsJobRunner
 __all__ = [
     "GromacsJob",
     "GromacsEMJob",
+    "GromacsNVTJob",
     "GromacsJobRunner",
 ]

--- a/chemsmart/jobs/gromacs/factory.py
+++ b/chemsmart/jobs/gromacs/factory.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-from typing import Any, Optional
 
 from chemsmart.jobs.gromacs.job import GromacsEMJob
 from chemsmart.settings.gromacs import GromacsProjectSettings
@@ -12,6 +10,7 @@ class GromacsJobFactory:
 
     JOB_TYPE_MAP = {
         "em": GromacsEMJob,
+        "nvt": GromacsNVTJob,
     }
 
     @classmethod

--- a/chemsmart/jobs/gromacs/job.py
+++ b/chemsmart/jobs/gromacs/job.py
@@ -256,3 +256,41 @@ class GromacsEMJob(GromacsJob):
             workflow=workflow,
             **kwargs,
         )
+
+class GromacsNVTJob(GromacsJob):
+    """
+    NVT equilibration job for GROMACS.
+    """
+
+    TYPE = "gmxnvt"
+
+    def __init__(
+        self,
+        molecule=None,
+        label="gromacs_nvt",
+        jobrunner=None,
+        mdp_file=None,
+        structure_file=None,
+        input_pdb=None,
+        top_file=None,
+        tpr_file=None,
+        itp_files=None,
+        index_file=None,
+        workflow="prepared",
+        **kwargs,
+    ):
+        super().__init__(
+            molecule=molecule,
+            label=label,
+            jobrunner=jobrunner,
+            mdp_file=mdp_file,
+            structure_file=structure_file,
+            input_pdb=input_pdb,
+            top_file=top_file,
+            tpr_file=tpr_file,
+            itp_files=itp_files,
+            index_file=index_file,
+            workflow=workflow,
+            **kwargs,
+        )
+

--- a/chemsmart/jobs/gromacs/runner.py
+++ b/chemsmart/jobs/gromacs/runner.py
@@ -35,6 +35,7 @@ class GromacsJobRunner(JobRunner):
         "gmx",
         "gromacs",
         "gmxem",
+        "gmxnvt",
     ]
 
     PROGRAM = "gromacs"

--- a/tests/test_gromacs_runner.py
+++ b/tests/test_gromacs_runner.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from chemsmart.jobs.gromacs.job import GromacsEMJob
+from chemsmart.jobs.gromacs.job import GromacsEMJob, GromacsNVTJob
 from chemsmart.jobs.gromacs.runner import GromacsJobRunner
 from chemsmart.settings.executable import GromacsExecutable
 
@@ -26,6 +26,7 @@ def _make_runner(gmx_executable="gmx"):
 
 def test_gromacs_em_job_type_matches_runner_jobtypes():
     assert GromacsEMJob.TYPE in GromacsJobRunner.JOBTYPES
+    assert GromacsNVTJob.TYPE in GromacsJobRunner.JOBTYPES
 
 
 def test_gromacs_em_job_stores_file_attributes(tmp_path):
@@ -359,6 +360,47 @@ def test_gromacs_runner_get_commands_for_prepared_workflow(tmp_path):
         ],
     ]
 
+def test_gromacs_runner_get_commands_for_nvt_prepared_workflow(tmp_path):
+    mdp_file = tmp_path / "nvt.mdp"
+    structure_file = tmp_path / "em.gro"
+    top_file = tmp_path / "topol.top"
+    tpr_file = tmp_path / "nvt.tpr"
+
+    job = GromacsNVTJob(
+        molecule=None,
+        label="nvt",
+        jobrunner=None,
+        mdp_file=mdp_file,
+        structure_file=structure_file,
+        top_file=top_file,
+        tpr_file=tpr_file,
+        workflow="prepared",
+    )
+
+    runner = _make_runner()
+
+    commands = runner._get_commands(job)
+
+    assert commands == [
+        [
+            "gmx",
+            "grompp",
+            "-f",
+            str(mdp_file),
+            "-c",
+            str(structure_file),
+            "-p",
+            str(top_file),
+            "-o",
+            str(tpr_file),
+        ],
+        [
+            "gmx",
+            "mdrun",
+            "-deffnm",
+            str(tmp_path / "nvt"),
+        ],
+    ]
 
 def test_gromacs_runner_accepts_custom_gmx_executable(tmp_path):
     tpr_file = tmp_path / "em.tpr"


### PR DESCRIPTION
## Summary

Add a GROMACS NVT job type following the existing EM job structure.

This PR introduces:

- `GromacsNVTJob`
- `gromacs nvt` CLI entry point
- factory registration for NVT jobs
- runner support for the NVT job type
- unit coverage for NVT prepared workflow command generation

The implementation reuses the existing GromacsJobRunner execution path, so it can call real GROMACS commands on a configured server. Local validation focuses on CLI/job creation and command generation without requiring a local GROMACS installation.