### PR TITLE
Add GROMACS NVT job type and MDP writer

### DIFF
--- a/chemsmart/cli/gromacs/__init__.py
+++ b/chemsmart/cli/gromacs/__init__.py
@@ -6,8 +6,10 @@ This module provides CLI subcommands for GROMACS workflows.
 
 from .em import em
 from .gromacs import gromacs
+from .nvt import nvt
 
 __all__ = [
     "gromacs",
     "em",
+    "nvt",
 ]

--- a/chemsmart/cli/gromacs/factory.py
+++ b/chemsmart/cli/gromacs/factory.py
@@ -10,17 +10,41 @@ class GromacsJobFactory:
 
     JOB_TYPE_MAP = {
         "em": GromacsEMJob,
+        "nvt": GromacsNVTJob,
     }
 
     @classmethod
-    def create_from_project_yaml(cls, project_yaml, molecule=None, label=None, jobrunner=None, **kwargs):
+    def create_from_project_yaml(
+            cls,
+            project_yaml,
+            molecule=None,
+            label=None,
+            jobrunner=None,
+            **kwargs):
         settings = GromacsProjectSettings.from_yaml(project_yaml)
-        return cls.create_from_settings(settings, molecule=molecule, label=label, jobrunner=jobrunner, **kwargs)
+        return cls.create_from_settings(
+            settings,
+            molecule=molecule,
+            label=label, jobrunner=jobrunner,
+            **kwargs)
 
     @classmethod
-    def create_from_settings(cls, settings, molecule=None, label=None, jobrunner=None, **kwargs):
+    def create_from_settings(
+        cls,
+        settings,
+        molecule=None,
+        label=None,
+        jobrunner=None,
+        **kwarg,
+    ):
         settings.validate()
         job_cls = cls.JOB_TYPE_MAP.get(settings.job_type)
         if job_cls is None:
             raise ValueError(f"Unsupported GROMACS job type: {settings.job_type}")
-        return job_cls.from_project_settings(settings=settings, molecule=molecule, label=label, jobrunner=jobrunner, **kwargs)
+        return job_cls.from_project_settings(
+            settings=settings,
+            molecule=molecule,
+            label=label,
+            jobrunner=jobrunner,
+            **kwargs,
+        )

--- a/chemsmart/cli/gromacs/nvt.py
+++ b/chemsmart/cli/gromacs/nvt.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+"""
+GROMACS NVT equilibration CLI command.
+
+This command supports two creation modes:
+1. YAML-driven mode: chemsmart run gromacs -p project.yaml nvt
+2. Direct CLI mode: chemsmart run gromacs nvt --mdp nvt.mdp --structure em.gro --top topol.top
+"""
+
+import logging
+from pathlib import Path
+
+import click
+
+from chemsmart.cli.gromacs.gromacs import gromacs
+from chemsmart.cli.job import click_job_options
+from chemsmart.jobs.gromacs.job import GromacsNVTJob
+from chemsmart.utils.cli import MyGroup
+
+logger = logging.getLogger(__name__)
+
+
+@gromacs.group("nvt", cls=MyGroup, invoke_without_command=True)
+@click_job_options
+@click.option(
+    "--mdp",
+    "mdp_file",
+    type=click.Path(
+        exists=True,
+        dir_okay=False,
+        resolve_path=True,
+        path_type=Path,
+    ),
+    default=None,
+    help="GROMACS .mdp file for NVT equilibration.",
+)
+@click.option(
+    "--structure",
+    "-s",
+    "structure_file",
+    type=click.Path(
+        exists=True,
+        dir_okay=False,
+        resolve_path=True,
+        path_type=Path,
+    ),
+    default=None,
+    help="Input structure file for NVT equilibration, such as EM output .gro.",
+)
+@click.option(
+    "--input-pdb",
+    "input_pdb",
+    type=click.Path(
+        exists=True,
+        dir_okay=False,
+        resolve_path=True,
+        path_type=Path,
+    ),
+    default=None,
+    help="Raw PDB file used by the full_setup workflow.",
+)
+@click.option(
+    "--top",
+    "top_file",
+    type=click.Path(
+        exists=True,
+        dir_okay=False,
+        resolve_path=True,
+        path_type=Path,
+    ),
+    default=None,
+    help="GROMACS topology .top file.",
+)
+@click.option(
+    "--index",
+    "index_file",
+    type=click.Path(
+        exists=True,
+        dir_okay=False,
+        resolve_path=True,
+        path_type=Path,
+    ),
+    default=None,
+    help="Optional GROMACS index .ndx file.",
+)
+@click.option(
+    "--itp",
+    "itp_files",
+    multiple=True,
+    type=click.Path(
+        exists=True,
+        dir_okay=False,
+        resolve_path=True,
+        path_type=Path,
+    ),
+    help="Optional GROMACS .itp include file. Can be used multiple times.",
+)
+@click.option(
+    "--workflow",
+    type=click.Choice(["prepared", "full_setup"]),
+    default=None,
+    help="GROMACS workflow mode.",
+)
+@click.pass_context
+def nvt(
+    ctx,
+    skip_completed,
+    mdp_file,
+    structure_file,
+    input_pdb,
+    top_file,
+    index_file,
+    itp_files,
+    workflow,
+    molecule=None,
+    **kwargs,
+):
+    """
+    CLI subcommand for running GROMACS NVT equilibration.
+    """
+
+    jobrunner = ctx.obj.get("jobrunner", None)
+    project = ctx.obj.get("project", None)
+    project_yaml = ctx.obj.get("project_yaml", None)
+    project_settings = ctx.obj.get("project_settings", None)
+    filename = ctx.obj.get("filename", None)
+
+    if structure_file is None:
+        structure_file = filename
+
+    if project_settings is not None:
+        settings = project_settings.with_overrides(
+            mdp_file=Path(mdp_file) if mdp_file else None,
+            structure_file=Path(structure_file) if structure_file else None,
+            input_pdb=Path(input_pdb) if input_pdb else None,
+            top_file=Path(top_file) if top_file else None,
+            index_file=Path(index_file) if index_file else None,
+            workflow=workflow,
+            itp_files=list(itp_files) if itp_files else None,
+        )
+
+        settings.validate()
+
+        logger.info(
+            "Creating GROMACS NVT job from project YAML: %s",
+            project_yaml,
+        )
+
+        if ctx.invoked_subcommand is None:
+            return GromacsNVTJob.from_project_settings(
+                settings=settings,
+                molecule=molecule,
+                jobrunner=jobrunner,
+                skip_completed=skip_completed,
+                **kwargs,
+            )
+        return None
+
+    # direct CLI mode
+    label = "gromacs_nvt"
+    if structure_file is not None:
+        label = Path(structure_file).stem + "_nvt"
+
+    workflow = workflow or "prepared"
+
+    logger.info("Creating GROMACS NVT job from direct CLI options.")
+    logger.info("GROMACS NVT structure file: %s", structure_file)
+    logger.info("GROMACS NVT mdp file: %s", mdp_file)
+    logger.info("GROMACS NVT topology file: %s", top_file)
+    logger.info("GROMACS NVT itp files: %s", itp_files)
+    logger.info("GROMACS NVT workflow: %s", workflow)
+
+    if ctx.invoked_subcommand is None:
+        return GromacsNVTJob(
+            molecule=molecule,
+            label=label,
+            jobrunner=jobrunner,
+            mdp_file=Path(mdp_file) if mdp_file else None,
+            structure_file=Path(structure_file) if structure_file else None,
+            input_pdb=Path(input_pdb) if input_pdb else None,
+            top_file=Path(top_file) if top_file else None,
+            itp_files=list(itp_files) if itp_files else [],
+            index_file=Path(index_file) if index_file else None,
+            workflow=workflow,
+            skip_completed=skip_completed,
+            **kwargs,
+        )
+

--- a/chemsmart/jobs/gromacs/__init__.py
+++ b/chemsmart/jobs/gromacs/__init__.py
@@ -4,5 +4,6 @@ from .runner import GromacsJobRunner
 __all__ = [
     "GromacsJob",
     "GromacsEMJob",
+    "GromacsNVTJob",
     "GromacsJobRunner",
 ]

--- a/chemsmart/jobs/gromacs/factory.py
+++ b/chemsmart/jobs/gromacs/factory.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-from typing import Any, Optional
 
 from chemsmart.jobs.gromacs.job import GromacsEMJob
 from chemsmart.settings.gromacs import GromacsProjectSettings
@@ -12,6 +10,7 @@ class GromacsJobFactory:
 
     JOB_TYPE_MAP = {
         "em": GromacsEMJob,
+        "nvt": GromacsNVTJob,
     }
 
     @classmethod

--- a/chemsmart/jobs/gromacs/job.py
+++ b/chemsmart/jobs/gromacs/job.py
@@ -256,3 +256,41 @@ class GromacsEMJob(GromacsJob):
             workflow=workflow,
             **kwargs,
         )
+
+class GromacsNVTJob(GromacsJob):
+    """
+    NVT equilibration job for GROMACS.
+    """
+
+    TYPE = "gmxnvt"
+
+    def __init__(
+        self,
+        molecule=None,
+        label="gromacs_nvt",
+        jobrunner=None,
+        mdp_file=None,
+        structure_file=None,
+        input_pdb=None,
+        top_file=None,
+        tpr_file=None,
+        itp_files=None,
+        index_file=None,
+        workflow="prepared",
+        **kwargs,
+    ):
+        super().__init__(
+            molecule=molecule,
+            label=label,
+            jobrunner=jobrunner,
+            mdp_file=mdp_file,
+            structure_file=structure_file,
+            input_pdb=input_pdb,
+            top_file=top_file,
+            tpr_file=tpr_file,
+            itp_files=itp_files,
+            index_file=index_file,
+            workflow=workflow,
+            **kwargs,
+        )
+

--- a/chemsmart/jobs/gromacs/runner.py
+++ b/chemsmart/jobs/gromacs/runner.py
@@ -35,6 +35,7 @@ class GromacsJobRunner(JobRunner):
         "gmx",
         "gromacs",
         "gmxem",
+        "gmxnvt",
     ]
 
     PROGRAM = "gromacs"

--- a/chemsmart/jobs/gromacs/runner.py
+++ b/chemsmart/jobs/gromacs/runner.py
@@ -84,6 +84,11 @@ class GromacsJobRunner(JobRunner):
         """
         self._assign_variables(job)
 
+        # Generate missing GROMACS input files before validation.
+        # For example, if job.mdp_file is None, this can write em.mdp / nvt.mdp
+        # and assign the generated file back to job.mdp_file.
+        self._write_input(job)
+
         workflow = getattr(job, "workflow", "prepared")
 
         if workflow == "prepared":
@@ -117,11 +122,15 @@ class GromacsJobRunner(JobRunner):
 
     def _write_input(self, job):
         """
-        GROMACS input writing is not required for prepared workflows.
+        Write missing GROMACS input files.
 
-        MDP auto-writing can be added later through chemsmart.jobs.gromacs.writer.
+        If the user already supplied an MDP file, it is respected. Otherwise,
+        ChemSmart generates a default MDP file from the GROMACS job settings.
         """
-        pass
+        from chemsmart.jobs.gromacs.writer import GromacsInputWriter
+
+        writer = GromacsInputWriter(job=job, jobrunner=self)
+        writer.write(target_directory=job.folder)
 
     def _get_executable(self):
         """

--- a/chemsmart/jobs/gromacs/writer.py
+++ b/chemsmart/jobs/gromacs/writer.py
@@ -3,35 +3,163 @@ from __future__ import annotations
 """
 GROMACS input writer.
 
-At this stage, prepared workflows use user-provided MDP, structure and topology
-files directly. This writer is kept as a small extension point for future MDP
-generation.
+This module writes GROMACS .mdp files from ChemSmart GROMACS job settings.
+
+The first implementation supports automatic MDP generation for:
+- EM  / gmxem
+- NVT / gmxnvt
+
+Topology preparation and structure conversion are intentionally not handled
+here. Those belong to the GROMACS workflow setup layer.
 """
 
+import logging
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 
 class GromacsInputWriter:
     """
-    Minimal writer interface for future GROMACS input generation.
+    Write GROMACS input files for a GROMACS job.
+
+    The current scope is limited to .mdp generation. If the user already
+    supplies job.mdp_file, this writer does not overwrite it. If job.mdp_file
+    is missing, the writer creates a default .mdp file in the job folder and
+    assigns it back to job.mdp_file.
+
+    This keeps user-provided MDP files as an advanced override while allowing
+    ChemSmart to generate reasonable default inputs automatically.
     """
 
-    def __init__(self, job):
+    def __init__(self, job, jobrunner=None):
         self.job = job
+        self.jobrunner = jobrunner
 
-    def write(self):
+    def write(self, target_directory=None):
         """
-        Write generated GROMACS input files.
+        Write missing GROMACS input files.
 
-        The current implementation does not generate files automatically because
-        prepared workflows rely on user-provided files.
+        Returns:
+            Path | None: The written .mdp file path, or None if no file was
+            written because job.mdp_file was already provided.
         """
-        return []
+        return self.write_mdp(target_directory=target_directory)
 
-    def write_text_file(self, filename, content):
+    def write_mdp(self, target_directory=None):
         """
-        Utility method for writing a text file into the job folder.
+        Write an .mdp file if job.mdp_file is not already set.
+
+        Existing user-provided MDP files are respected and never overwritten.
         """
-        path = Path(self.job.folder) / filename
-        path.write_text(content, encoding="utf-8")
-        return path
+        if getattr(self.job, "mdp_file", None) is not None:
+            logger.info(
+                "Using user-provided GROMACS MDP file: %s",
+                self.job.mdp_file,
+            )
+            return None
+
+        folder = Path(target_directory or self.job.folder)
+        folder.mkdir(parents=True, exist_ok=True)
+
+        job_type = getattr(self.job, "TYPE", "").lower()
+
+        if job_type == "gmxem":
+            mdp_path = folder / "em.mdp"
+            content = self._build_em_mdp()
+        elif job_type == "gmxnvt":
+            mdp_path = folder / "nvt.mdp"
+            content = self._build_nvt_mdp()
+        else:
+            raise ValueError(
+                f"Unsupported GROMACS job type for MDP writing: {job_type}"
+            )
+
+        logger.info("Writing GROMACS MDP file: %s", mdp_path)
+        mdp_path.write_text(content, encoding="utf-8")
+
+        self.job.mdp_file = mdp_path
+        return mdp_path
+
+    def _build_em_mdp(self):
+        """
+        Build a default EM .mdp file.
+        """
+        emtol = self._get("emtol", 1000.0)
+        emstep = self._get("emstep", 0.01)
+        nsteps = self._get("nsteps", self._get("em_nsteps", 50000))
+
+        return self._format_mdp(
+            {
+                "integrator": "steep",
+                "emtol": emtol,
+                "emstep": emstep,
+                "nsteps": nsteps,
+                "cutoff-scheme": "Verlet",
+                "nstlist": 10,
+                "rcoulomb": 1.0,
+                "rvdw": 1.0,
+                "coulombtype": "PME",
+                "pbc": "xyz",
+            }
+        )
+
+    def _build_nvt_mdp(self):
+        """
+        Build a default NVT .mdp file.
+        """
+        temperature = self._get("temperature", 300)
+        timestep = self._get("timestep", 0.002)
+        nsteps = self._get("nsteps", self._get("nvt_nsteps", 50000))
+        constraints = self._get("constraints", "h-bonds")
+        constraint_algorithm = self._get("constraint_algorithm", "lincs")
+        thermostat = self._get("thermostat", "V-rescale")
+        tau_t = self._get("tau_t", 0.1)
+        tc_grps = self._get("tc_grps", "System")
+
+        return self._format_mdp(
+            {
+                "integrator": "md",
+                "nsteps": nsteps,
+                "dt": timestep,
+                "continuation": "no",
+                "constraint_algorithm": constraint_algorithm,
+                "constraints": constraints,
+                "cutoff-scheme": "Verlet",
+                "nstlist": 10,
+                "rcoulomb": 1.0,
+                "rvdw": 1.0,
+                "coulombtype": "PME",
+                "pbc": "xyz",
+                "tcoupl": thermostat,
+                "tc-grps": tc_grps,
+                "tau_t": tau_t,
+                "ref_t": temperature,
+                "pcoupl": "no",
+                "gen_vel": "yes",
+                "gen_temp": temperature,
+                "gen_seed": -1,
+            }
+        )
+
+    def _get(self, name, default=None):
+        """
+        Read an optional job attribute with a default fallback.
+        """
+        value = getattr(self.job, name, None)
+        return default if value is None else value
+
+    @staticmethod
+    def _format_mdp(options):
+        """
+        Format a dictionary of MDP options into GROMACS .mdp text.
+        """
+        lines = []
+
+        for key, value in options.items():
+            if value is None:
+                continue
+            lines.append(f"{key:<24} = {value}")
+
+        return "\n".join(lines) + "\n"
+

--- a/chemsmart/settings/gromacs.py
+++ b/chemsmart/settings/gromacs.py
@@ -220,8 +220,6 @@ class GromacsProjectSettings:
         """
         missing = []
 
-        if self.mdp_file is None:
-            missing.append("mdp_file")
         if self.structure_file is None:
             missing.append("structure_file")
         if self.top_file is None:
@@ -244,8 +242,6 @@ class GromacsProjectSettings:
 
         if self.input_pdb is None and self.structure_file is None:
             missing.append("input_pdb|structure_file")
-        if self.mdp_file is None:
-            missing.append("mdp_file")
         if self.force_field is None:
             missing.append("force_field")
         if self.water_model is None:

--- a/tests/test_gromacs_runner.py
+++ b/tests/test_gromacs_runner.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from chemsmart.jobs.gromacs.job import GromacsEMJob
+from chemsmart.jobs.gromacs.job import GromacsEMJob, GromacsNVTJob
 from chemsmart.jobs.gromacs.runner import GromacsJobRunner
 from chemsmart.settings.executable import GromacsExecutable
 
@@ -26,6 +26,7 @@ def _make_runner(gmx_executable="gmx"):
 
 def test_gromacs_em_job_type_matches_runner_jobtypes():
     assert GromacsEMJob.TYPE in GromacsJobRunner.JOBTYPES
+    assert GromacsNVTJob.TYPE in GromacsJobRunner.JOBTYPES
 
 
 def test_gromacs_em_job_stores_file_attributes(tmp_path):
@@ -359,6 +360,47 @@ def test_gromacs_runner_get_commands_for_prepared_workflow(tmp_path):
         ],
     ]
 
+def test_gromacs_runner_get_commands_for_nvt_prepared_workflow(tmp_path):
+    mdp_file = tmp_path / "nvt.mdp"
+    structure_file = tmp_path / "em.gro"
+    top_file = tmp_path / "topol.top"
+    tpr_file = tmp_path / "nvt.tpr"
+
+    job = GromacsNVTJob(
+        molecule=None,
+        label="nvt",
+        jobrunner=None,
+        mdp_file=mdp_file,
+        structure_file=structure_file,
+        top_file=top_file,
+        tpr_file=tpr_file,
+        workflow="prepared",
+    )
+
+    runner = _make_runner()
+
+    commands = runner._get_commands(job)
+
+    assert commands == [
+        [
+            "gmx",
+            "grompp",
+            "-f",
+            str(mdp_file),
+            "-c",
+            str(structure_file),
+            "-p",
+            str(top_file),
+            "-o",
+            str(tpr_file),
+        ],
+        [
+            "gmx",
+            "mdrun",
+            "-deffnm",
+            str(tmp_path / "nvt"),
+        ],
+    ]
 
 def test_gromacs_runner_accepts_custom_gmx_executable(tmp_path):
     tpr_file = tmp_path / "em.tpr"

--- a/tests/test_gromacs_runner.py
+++ b/tests/test_gromacs_runner.py
@@ -680,3 +680,108 @@ def test_gromacs_executable_uses_executable_folder(tmp_path):
     executable = GromacsExecutable(executable_folder=tmp_path)
 
     assert executable.get_executable() == os.path.join(str(tmp_path), "gmx")
+def test_gromacs_writer_generates_em_mdp_when_missing(tmp_path):
+    job = GromacsEMJob(
+        molecule=None,
+        label="em",
+        jobrunner=None,
+        mdp_file=None,
+        structure_file=tmp_path / "input.gro",
+        top_file=tmp_path / "topol.top",
+        workflow="prepared",
+    )
+
+    job.set_folder(str(tmp_path))
+
+    runner = _make_runner()
+    runner._write_input(job)
+
+    assert job.mdp_file == tmp_path / "em.mdp"
+    assert job.mdp_file.exists()
+
+    content = job.mdp_file.read_text(encoding="utf-8")
+    assert "integrator" in content
+    assert "steep" in content
+    assert "emtol" in content
+
+
+def test_gromacs_writer_generates_nvt_mdp_when_missing(tmp_path):
+    job = GromacsNVTJob(
+        molecule=None,
+        label="nvt",
+        jobrunner=None,
+        mdp_file=None,
+        structure_file=tmp_path / "em.gro",
+        top_file=tmp_path / "topol.top",
+        workflow="prepared",
+        temperature=310,
+        timestep=0.001,
+    )
+
+    job.set_folder(str(tmp_path))
+
+    runner = _make_runner()
+    runner._write_input(job)
+
+    assert job.mdp_file == tmp_path / "nvt.mdp"
+    assert job.mdp_file.exists()
+
+    content = job.mdp_file.read_text(encoding="utf-8")
+    assert "integrator" in content
+    assert "md" in content
+    assert "ref_t" in content
+    assert "310" in content
+    assert "dt" in content
+    assert "0.001" in content
+
+def test_gromacs_writer_does_not_overwrite_user_mdp(tmp_path):
+    mdp_file = tmp_path / "custom.mdp"
+    mdp_file.write_text("integrator = md\n; custom file\n", encoding="utf-8")
+
+    job = GromacsNVTJob(
+        molecule=None,
+        label="nvt",
+        jobrunner=None,
+        mdp_file=mdp_file,
+        structure_file=tmp_path / "em.gro",
+        top_file=tmp_path / "topol.top",
+        workflow="prepared",
+        temperature=310,
+    )
+
+    job.set_folder(str(tmp_path))
+
+    runner = _make_runner()
+    runner._write_input(job)
+
+    assert job.mdp_file == mdp_file
+    assert mdp_file.read_text(encoding="utf-8") == "integrator = md\n; custom file\n"
+    assert not (tmp_path / "nvt.mdp").exists()
+
+def test_gromacs_prerun_generates_missing_mdp_before_validation(tmp_path):
+    structure_file = tmp_path / "em.gro"
+    top_file = tmp_path / "topol.top"
+
+    structure_file.write_text("dummy structure\n", encoding="utf-8")
+    top_file.write_text("dummy topology\n", encoding="utf-8")
+
+    job = GromacsNVTJob(
+        molecule=None,
+        label="nvt",
+        jobrunner=None,
+        mdp_file=None,
+        structure_file=structure_file,
+        top_file=top_file,
+        workflow="prepared",
+    )
+
+    job.set_folder(str(tmp_path))
+
+    runner = _make_runner()
+    runner._assemble_tpr = lambda job: None
+
+    runner._prerun(job)
+
+    assert job.mdp_file == tmp_path / "nvt.mdp"
+    assert job.mdp_file.exists()
+    assert "integrator" in job.mdp_file.read_text(encoding="utf-8")

--- a/tests/test_gromacs_settings.py
+++ b/tests/test_gromacs_settings.py
@@ -372,3 +372,38 @@ inputs:
     assert updated.input_pdb == tmp_path / "input.pdb"
     assert updated.force_field == "amber99sb-ildn"
     assert updated.water_model == "tip3p"
+
+def test_gromacs_project_settings_allows_missing_mdp_for_prepared():
+    settings = GromacsProjectSettings(
+        workflow="prepared",
+        job_type="nvt",
+        mdp_file=None,
+        structure_file="em.gro",
+        top_file="topol.top",
+    )
+
+    settings.validate()
+
+
+def test_gromacs_project_settings_passes_mdp_writer_parameters_to_job_kwargs():
+    settings = GromacsProjectSettings(
+        workflow="prepared",
+        job_type="nvt",
+        mdp_file=None,
+        structure_file="em.gro",
+        top_file="topol.top",
+        temperature=310,
+        timestep=0.001,
+        thermostat="V-rescale",
+        constraints="h-bonds",
+        constraint_algorithm="lincs",
+    )
+
+    job_kwargs = settings.to_job_kwargs()
+
+    assert job_kwargs["temperature"] == 310
+    assert job_kwargs["timestep"] == 0.001
+    assert job_kwargs["thermostat"] == "V-rescale"
+    assert job_kwargs["constraints"] == "h-bonds"
+    assert job_kwargs["constraint_algorithm"] == "lincs"
+    assert "mdp_file" not in job_kwargs


### PR DESCRIPTION
## Summary

This PR adds the next stage of GROMACS workflow integration.

It includes:

- `GromacsNVTJob`
- `gromacs nvt` CLI entry point
- factory registration for NVT jobs
- runner support for the `gmxnvt` job type
- `GromacsInputWriter` for automatic MDP generation
- automatic `em.mdp` generation for EM jobs
- automatic `nvt.mdp` generation for NVT jobs
- project settings validation update so `mdp_file` is optional when it can be generated
- tests for NVT command generation, MDP writing, and project settings behavior

User-provided `.mdp` files are still respected and are not overwritten.

## Test

Targeted tests passed locally:

```bash
python -m pytest tests/test_gromacs_runner.py tests/test_gromacs_settings.py -q