### PR TITLE
Add GROMACS NPT job type

### DIFF
--- a/chemsmart/cli/gromacs/__init__.py
+++ b/chemsmart/cli/gromacs/__init__.py
@@ -6,10 +6,13 @@ This module provides CLI subcommands for GROMACS workflows.
 
 from .em import em
 from .gromacs import gromacs
+from .npt import npt
 from .nvt import nvt
+
 
 __all__ = [
     "gromacs",
     "em",
+    "npt",
     "nvt",
 ]

--- a/chemsmart/cli/gromacs/factory.py
+++ b/chemsmart/cli/gromacs/factory.py
@@ -1,6 +1,10 @@
 
 
-from chemsmart.jobs.gromacs.job import GromacsEMJob
+from chemsmart.jobs.gromacs.job import (
+    GromacsEMJob,
+    GromacsNPTJob,
+    GromacsNVTJob,
+)
 from chemsmart.settings.gromacs import GromacsProjectSettings
 
 class GromacsJobFactory:
@@ -11,6 +15,7 @@ class GromacsJobFactory:
     JOB_TYPE_MAP = {
         "em": GromacsEMJob,
         "nvt": GromacsNVTJob,
+        "npt": GromacsNPTJob,
     }
 
     @classmethod

--- a/chemsmart/cli/gromacs/factory.py
+++ b/chemsmart/cli/gromacs/factory.py
@@ -1,6 +1,11 @@
-from chemsmart.jobs.gromacs.job import GromacsEMJob, GromacsNVTJob
-from chemsmart.settings.gromacs import GromacsProjectSettings
 
+
+from chemsmart.jobs.gromacs.job import (
+    GromacsEMJob,
+    GromacsNPTJob,
+    GromacsNVTJob,
+)
+from chemsmart.settings.gromacs import GromacsProjectSettings
 
 class GromacsJobFactory:
     """
@@ -10,20 +15,23 @@ class GromacsJobFactory:
     JOB_TYPE_MAP = {
         "em": GromacsEMJob,
         "nvt": GromacsNVTJob,
+        "npt": GromacsNPTJob,
     }
 
     @classmethod
     def create_from_project_yaml(
-        cls, project_yaml, molecule=None, label=None, jobrunner=None, **kwargs
-    ):
+            cls,
+            project_yaml,
+            molecule=None,
+            label=None,
+            jobrunner=None,
+            **kwargs):
         settings = GromacsProjectSettings.from_yaml(project_yaml)
         return cls.create_from_settings(
             settings,
             molecule=molecule,
-            label=label,
-            jobrunner=jobrunner,
-            **kwargs,
-        )
+            label=label, jobrunner=jobrunner,
+            **kwargs)
 
     @classmethod
     def create_from_settings(
@@ -32,14 +40,12 @@ class GromacsJobFactory:
         molecule=None,
         label=None,
         jobrunner=None,
-        **kwargs,
+        **kwarg,
     ):
         settings.validate()
         job_cls = cls.JOB_TYPE_MAP.get(settings.job_type)
         if job_cls is None:
-            raise ValueError(
-                f"Unsupported GROMACS job type: {settings.job_type}"
-            )
+            raise ValueError(f"Unsupported GROMACS job type: {settings.job_type}")
         return job_cls.from_project_settings(
             settings=settings,
             molecule=molecule,

--- a/chemsmart/cli/gromacs/npt.py
+++ b/chemsmart/cli/gromacs/npt.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+"""
+GROMACS NPT equilibration CLI command.
+
+This command supports two creation modes:
+1. YAML-driven mode: chemsmart run gromacs -p project.yaml npt
+2. Direct CLI mode: chemsmart run gromacs npt --mdp npt.mdp --structure nvt.gro --top topol.top
+"""
+
+import logging
+from pathlib import Path
+
+import click
+
+from chemsmart.cli.gromacs.gromacs import gromacs
+from chemsmart.cli.job import click_job_options
+from chemsmart.jobs.gromacs.job import GromacsNPTJob
+from chemsmart.utils.cli import MyGroup
+
+logger = logging.getLogger(__name__)
+
+
+@gromacs.group("npt", cls=MyGroup, invoke_without_command=True)
+@click_job_options
+@click.option(
+    "--mdp",
+    "mdp_file",
+    type=click.Path(
+        exists=True,
+        dir_okay=False,
+        resolve_path=True,
+        path_type=Path,
+    ),
+    default=None,
+    help="GROMACS .mdp file for NPT equilibration.",
+)
+@click.option(
+    "--structure",
+    "-s",
+    "structure_file",
+    type=click.Path(
+        exists=True,
+        dir_okay=False,
+        resolve_path=True,
+        path_type=Path,
+    ),
+    default=None,
+    help="Input structure file for NPT equilibration, such as NVT output .gro.",
+)
+@click.option(
+    "--input-pdb",
+    "input_pdb",
+    type=click.Path(
+        exists=True,
+        dir_okay=False,
+        resolve_path=True,
+        path_type=Path,
+    ),
+    default=None,
+    help="Raw PDB file used by the full_setup workflow.",
+)
+@click.option(
+    "--top",
+    "top_file",
+    type=click.Path(
+        exists=True,
+        dir_okay=False,
+        resolve_path=True,
+        path_type=Path,
+    ),
+    default=None,
+    help="GROMACS topology .top file.",
+)
+@click.option(
+    "--index",
+    "index_file",
+    type=click.Path(
+        exists=True,
+        dir_okay=False,
+        resolve_path=True,
+        path_type=Path,
+    ),
+    default=None,
+    help="Optional GROMACS index .ndx file.",
+)
+@click.option(
+    "--itp",
+    "itp_files",
+    multiple=True,
+    type=click.Path(
+        exists=True,
+        dir_okay=False,
+        resolve_path=True,
+        path_type=Path,
+    ),
+    help="Optional GROMACS .itp include file. Can be used multiple times.",
+)
+@click.option(
+    "--workflow",
+    type=click.Choice(["prepared", "full_setup"]),
+    default=None,
+    help="GROMACS workflow mode.",
+)
+@click.pass_context
+def npt(
+    ctx,
+    skip_completed,
+    mdp_file,
+    structure_file,
+    input_pdb,
+    top_file,
+    index_file,
+    itp_files,
+    workflow,
+    molecule=None,
+    **kwargs,
+):
+    """
+    CLI subcommand for running GROMACS NPT equilibration.
+    """
+
+    jobrunner = ctx.obj.get("jobrunner", None)
+    project_yaml = ctx.obj.get("project_yaml", None)
+    project_settings = ctx.obj.get("project_settings", None)
+    filename = ctx.obj.get("filename", None)
+
+    if structure_file is None:
+        structure_file = filename
+
+    if project_settings is not None:
+        settings = project_settings.with_overrides(
+            mdp_file=Path(mdp_file) if mdp_file else None,
+            structure_file=Path(structure_file) if structure_file else None,
+            input_pdb=Path(input_pdb) if input_pdb else None,
+            top_file=Path(top_file) if top_file else None,
+            index_file=Path(index_file) if index_file else None,
+            workflow=workflow,
+            itp_files=list(itp_files) if itp_files else None,
+        )
+
+        settings.validate()
+
+        logger.info(
+            "Creating GROMACS NPT job from project YAML: %s",
+            project_yaml,
+        )
+
+        if ctx.invoked_subcommand is None:
+            return GromacsNPTJob.from_project_settings(
+                settings=settings,
+                molecule=molecule,
+                jobrunner=jobrunner,
+                skip_completed=skip_completed,
+                **kwargs,
+            )
+        return None
+
+    # direct CLI mode
+    label = "gromacs_npt"
+    if structure_file is not None:
+        label = Path(structure_file).stem + "_npt"
+
+    workflow = workflow or "prepared"
+
+    logger.info("Creating GROMACS NPT job from direct CLI options.")
+    logger.info("GROMACS NPT structure file: %s", structure_file)
+    logger.info("GROMACS NPT mdp file: %s", mdp_file)
+    logger.info("GROMACS NPT topology file: %s", top_file)
+    logger.info("GROMACS NPT itp files: %s", itp_files)
+    logger.info("GROMACS NPT workflow: %s", workflow)
+
+    if ctx.invoked_subcommand is None:
+        return GromacsNPTJob(
+            molecule=molecule,
+            label=label,
+            jobrunner=jobrunner,
+            mdp_file=Path(mdp_file) if mdp_file else None,
+            structure_file=Path(structure_file) if structure_file else None,
+            input_pdb=Path(input_pdb) if input_pdb else None,
+            top_file=Path(top_file) if top_file else None,
+            itp_files=list(itp_files) if itp_files else [],
+            index_file=Path(index_file) if index_file else None,
+            workflow=workflow,
+            skip_completed=skip_completed,
+            **kwargs,
+        )

--- a/chemsmart/jobs/gromacs/__init__.py
+++ b/chemsmart/jobs/gromacs/__init__.py
@@ -5,5 +5,6 @@ __all__ = [
     "GromacsJob",
     "GromacsEMJob",
     "GromacsNVTJob",
+    "GromacsNPTJob",
     "GromacsJobRunner",
 ]

--- a/chemsmart/jobs/gromacs/factory.py
+++ b/chemsmart/jobs/gromacs/factory.py
@@ -1,5 +1,9 @@
 
-from chemsmart.jobs.gromacs.job import GromacsEMJob
+from chemsmart.jobs.gromacs.job import (
+    GromacsEMJob,
+    GromacsNVTJob,
+    GromacsNPTJob,
+)
 from chemsmart.settings.gromacs import GromacsProjectSettings
 
 
@@ -11,6 +15,7 @@ class GromacsJobFactory:
     JOB_TYPE_MAP = {
         "em": GromacsEMJob,
         "nvt": GromacsNVTJob,
+        "npt": GromacsNPTJob,
     }
 
     @classmethod

--- a/chemsmart/jobs/gromacs/factory.py
+++ b/chemsmart/jobs/gromacs/factory.py
@@ -1,4 +1,9 @@
-from chemsmart.jobs.gromacs.job import GromacsEMJob, GromacsNVTJob
+
+from chemsmart.jobs.gromacs.job import (
+    GromacsEMJob,
+    GromacsNVTJob,
+    GromacsNPTJob,
+)
 from chemsmart.settings.gromacs import GromacsProjectSettings
 
 
@@ -10,6 +15,7 @@ class GromacsJobFactory:
     JOB_TYPE_MAP = {
         "em": GromacsEMJob,
         "nvt": GromacsNVTJob,
+        "npt": GromacsNPTJob,
     }
 
     @classmethod

--- a/chemsmart/jobs/gromacs/job.py
+++ b/chemsmart/jobs/gromacs/job.py
@@ -49,6 +49,13 @@ class GromacsJob(Job):
         barostat=None,
         constraints=None,
         constraint_algorithm=None,
+        nsteps=None,
+        emtol=None,
+        emstep=None,
+        tau_t=None,
+        tc_grps=None,
+        tau_p=None,
+        compressibility=None,
         box_type="cubic",
         box_distance=1.0,
         solvent_file=None,
@@ -122,6 +129,16 @@ class GromacsJob(Job):
         self.constraints = constraints
         self.constraint_algorithm = constraint_algorithm
 
+        # Optional MDP parameters used by GromacsInputWriter.
+        # These are explicit job attributes, not project-level YAML settings.
+        self.nsteps = nsteps
+        self.emtol = emtol
+        self.emstep = emstep
+        self.tau_t = tau_t
+        self.tc_grps = tc_grps
+        self.tau_p = tau_p
+        self.compressibility = compressibility
+
         self.box_type = box_type
         self.box_distance = box_distance
         self.solvent_file = Path(solvent_file) if solvent_file else None
@@ -165,6 +182,9 @@ class GromacsJob(Job):
 
     def _run(self, **kwargs):
         self.jobrunner.run(self, **kwargs)
+
+    def _output(self):
+        return self.tpr_file
 
     def has_tpr(self):
         """
@@ -257,6 +277,7 @@ class GromacsEMJob(GromacsJob):
             **kwargs,
         )
 
+
 class GromacsNVTJob(GromacsJob):
     """
     NVT equilibration job for GROMACS.
@@ -294,42 +315,7 @@ class GromacsNVTJob(GromacsJob):
             **kwargs,
         )
 
-class GromacsNPTJob(GromacsJob):
-    """
-    NPT equilibration job for GROMACS.
-    """
 
-    TYPE = "gmxnpt"
-
-    def __init__(
-        self,
-        molecule=None,
-        label="gromacs_npt",
-        jobrunner=None,
-        mdp_file=None,
-        structure_file=None,
-        input_pdb=None,
-        top_file=None,
-        tpr_file=None,
-        itp_files=None,
-        index_file=None,
-        workflow="prepared",
-        **kwargs,
-    ):
-        super().__init__(
-            molecule=molecule,
-            label=label,
-            jobrunner=jobrunner,
-            mdp_file=mdp_file,
-            structure_file=structure_file,
-            input_pdb=input_pdb,
-            top_file=top_file,
-            tpr_file=tpr_file,
-            itp_files=itp_files,
-            index_file=index_file,
-            workflow=workflow,
-            **kwargs,
-        )
 class GromacsNPTJob(GromacsJob):
     """
     NPT equilibration job for GROMACS.

--- a/chemsmart/jobs/gromacs/job.py
+++ b/chemsmart/jobs/gromacs/job.py
@@ -294,3 +294,75 @@ class GromacsNVTJob(GromacsJob):
             **kwargs,
         )
 
+class GromacsNPTJob(GromacsJob):
+    """
+    NPT equilibration job for GROMACS.
+    """
+
+    TYPE = "gmxnpt"
+
+    def __init__(
+        self,
+        molecule=None,
+        label="gromacs_npt",
+        jobrunner=None,
+        mdp_file=None,
+        structure_file=None,
+        input_pdb=None,
+        top_file=None,
+        tpr_file=None,
+        itp_files=None,
+        index_file=None,
+        workflow="prepared",
+        **kwargs,
+    ):
+        super().__init__(
+            molecule=molecule,
+            label=label,
+            jobrunner=jobrunner,
+            mdp_file=mdp_file,
+            structure_file=structure_file,
+            input_pdb=input_pdb,
+            top_file=top_file,
+            tpr_file=tpr_file,
+            itp_files=itp_files,
+            index_file=index_file,
+            workflow=workflow,
+            **kwargs,
+        )
+class GromacsNPTJob(GromacsJob):
+    """
+    NPT equilibration job for GROMACS.
+    """
+
+    TYPE = "gmxnpt"
+
+    def __init__(
+        self,
+        molecule=None,
+        label="gromacs_npt",
+        jobrunner=None,
+        mdp_file=None,
+        structure_file=None,
+        input_pdb=None,
+        top_file=None,
+        tpr_file=None,
+        itp_files=None,
+        index_file=None,
+        workflow="prepared",
+        **kwargs,
+    ):
+        super().__init__(
+            molecule=molecule,
+            label=label,
+            jobrunner=jobrunner,
+            mdp_file=mdp_file,
+            structure_file=structure_file,
+            input_pdb=input_pdb,
+            top_file=top_file,
+            tpr_file=tpr_file,
+            itp_files=itp_files,
+            index_file=index_file,
+            workflow=workflow,
+            **kwargs,
+        )

--- a/chemsmart/jobs/gromacs/job.py
+++ b/chemsmart/jobs/gromacs/job.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+"""
+GROMACS job definitions.
+"""
+
 from pathlib import Path
-from types import SimpleNamespace
 
 from chemsmart.jobs.job import Job
 
@@ -92,14 +95,20 @@ class GromacsJob(Job):
             else None
         )
         self.boxed_structure_file = (
-            Path(boxed_structure_file) if boxed_structure_file else None
+            Path(boxed_structure_file)
+            if boxed_structure_file
+            else None
         )
         self.solvated_structure_file = (
-            Path(solvated_structure_file) if solvated_structure_file else None
+            Path(solvated_structure_file)
+            if solvated_structure_file
+            else None
         )
         self.ions_tpr_file = Path(ions_tpr_file) if ions_tpr_file else None
         self.ionized_structure_file = (
-            Path(ionized_structure_file) if ionized_structure_file else None
+            Path(ionized_structure_file)
+            if ionized_structure_file
+            else None
         )
 
         self.force_field = force_field
@@ -180,7 +189,8 @@ class GromacsJob(Job):
         ]
 
         return all(
-            path is not None and Path(path).exists() for path in required_files
+            path is not None and Path(path).exists()
+            for path in required_files
         )
 
     def has_required_full_setup_inputs(self):
@@ -206,17 +216,6 @@ class GromacsJob(Job):
 
         if self._use_default_tpr_file:
             self.tpr_file = Path(self.folder) / f"{self.label}.tpr"
-
-    def _output(self):
-        if self.tpr_file is None:
-            return None
-        log_file = Path(self.tpr_file).with_suffix(".log")
-        if not log_file.exists():
-            return None
-        text = log_file.read_text(encoding="utf-8", errors="ignore")
-        return SimpleNamespace(
-            normal_termination="Finished mdrun" in text,
-        )
 
 
 class GromacsEMJob(GromacsJob):
@@ -258,7 +257,6 @@ class GromacsEMJob(GromacsJob):
             **kwargs,
         )
 
-
 class GromacsNVTJob(GromacsJob):
     """
     NVT equilibration job for GROMACS.
@@ -270,6 +268,79 @@ class GromacsNVTJob(GromacsJob):
         self,
         molecule=None,
         label="gromacs_nvt",
+        jobrunner=None,
+        mdp_file=None,
+        structure_file=None,
+        input_pdb=None,
+        top_file=None,
+        tpr_file=None,
+        itp_files=None,
+        index_file=None,
+        workflow="prepared",
+        **kwargs,
+    ):
+        super().__init__(
+            molecule=molecule,
+            label=label,
+            jobrunner=jobrunner,
+            mdp_file=mdp_file,
+            structure_file=structure_file,
+            input_pdb=input_pdb,
+            top_file=top_file,
+            tpr_file=tpr_file,
+            itp_files=itp_files,
+            index_file=index_file,
+            workflow=workflow,
+            **kwargs,
+        )
+
+class GromacsNPTJob(GromacsJob):
+    """
+    NPT equilibration job for GROMACS.
+    """
+
+    TYPE = "gmxnpt"
+
+    def __init__(
+        self,
+        molecule=None,
+        label="gromacs_npt",
+        jobrunner=None,
+        mdp_file=None,
+        structure_file=None,
+        input_pdb=None,
+        top_file=None,
+        tpr_file=None,
+        itp_files=None,
+        index_file=None,
+        workflow="prepared",
+        **kwargs,
+    ):
+        super().__init__(
+            molecule=molecule,
+            label=label,
+            jobrunner=jobrunner,
+            mdp_file=mdp_file,
+            structure_file=structure_file,
+            input_pdb=input_pdb,
+            top_file=top_file,
+            tpr_file=tpr_file,
+            itp_files=itp_files,
+            index_file=index_file,
+            workflow=workflow,
+            **kwargs,
+        )
+class GromacsNPTJob(GromacsJob):
+    """
+    NPT equilibration job for GROMACS.
+    """
+
+    TYPE = "gmxnpt"
+
+    def __init__(
+        self,
+        molecule=None,
+        label="gromacs_npt",
         jobrunner=None,
         mdp_file=None,
         structure_file=None,

--- a/chemsmart/jobs/gromacs/runner.py
+++ b/chemsmart/jobs/gromacs/runner.py
@@ -35,6 +35,7 @@ class GromacsJobRunner(JobRunner):
         "gromacs",
         "gmxem",
         "gmxnvt",
+        "gmxnpt",
     ]
 
     PROGRAM = "gromacs"

--- a/chemsmart/jobs/gromacs/runner.py
+++ b/chemsmart/jobs/gromacs/runner.py
@@ -36,6 +36,7 @@ class GromacsJobRunner(JobRunner):
         "gromacs",
         "gmxem",
         "gmxnvt",
+        "gmxnpt",
     ]
 
     PROGRAM = "gromacs"

--- a/chemsmart/jobs/gromacs/writer.py
+++ b/chemsmart/jobs/gromacs/writer.py
@@ -1,17 +1,18 @@
+from __future__ import annotations
+
 """
 GROMACS input writer.
 
 This module writes GROMACS .mdp files from ChemSmart GROMACS job settings.
 
-The first implementation supports automatic MDP generation for:
+The current implementation supports automatic MDP generation for:
 - EM  / gmxem
 - NVT / gmxnvt
+- NPT / gmxnpt
 
 Topology preparation and structure conversion are intentionally not handled
 here. Those belong to the GROMACS workflow setup layer.
 """
-
-from __future__ import annotations
 
 import logging
 from pathlib import Path
@@ -23,10 +24,9 @@ class GromacsInputWriter:
     """
     Write GROMACS input files for a GROMACS job.
 
-    The current scope is limited to .mdp generation. If the user already
-    supplies job.mdp_file, this writer does not overwrite it. If job.mdp_file
-    is missing, the writer creates a default .mdp file in the job folder and
-    assigns it back to job.mdp_file.
+    If the user already supplies job.mdp_file, this writer does not overwrite
+    it. If job.mdp_file is missing, the writer creates a default .mdp file in
+    the job folder and assigns it back to job.mdp_file.
 
     This keeps user-provided MDP files as an advanced override while allowing
     ChemSmart to generate reasonable default inputs automatically.
@@ -52,7 +52,7 @@ class GromacsInputWriter:
 
         Existing user-provided MDP files are respected and never overwritten.
         """
-        if getattr(self.job, "mdp_file", None) is not None:
+        if self.job.mdp_file is not None:
             logger.info(
                 "Using user-provided GROMACS MDP file: %s",
                 self.job.mdp_file,
@@ -62,7 +62,7 @@ class GromacsInputWriter:
         folder = Path(target_directory or self.job.folder)
         folder.mkdir(parents=True, exist_ok=True)
 
-        job_type = getattr(self.job, "TYPE", "").lower()
+        job_type = self.job.TYPE.lower()
 
         if job_type == "gmxem":
             mdp_path = folder / "em.mdp"
@@ -88,9 +88,9 @@ class GromacsInputWriter:
         """
         Build a default EM .mdp file.
         """
-        emtol = self._get("emtol", 1000.0)
-        emstep = self._get("emstep", 0.01)
-        nsteps = self._get("nsteps", self._get("em_nsteps", 50000))
+        emtol = self._value_or_default(self.job.emtol, 1000.0)
+        emstep = self._value_or_default(self.job.emstep, 0.01)
+        nsteps = self._value_or_default(self.job.nsteps, 50000)
 
         return self._format_mdp(
             {
@@ -111,14 +111,17 @@ class GromacsInputWriter:
         """
         Build a default NVT .mdp file.
         """
-        temperature = self._get("temperature", 300)
-        timestep = self._get("timestep", 0.002)
-        nsteps = self._get("nsteps", self._get("nvt_nsteps", 50000))
-        constraints = self._get("constraints", "h-bonds")
-        constraint_algorithm = self._get("constraint_algorithm", "lincs")
-        thermostat = self._get("thermostat", "V-rescale")
-        tau_t = self._get("tau_t", 0.1)
-        tc_grps = self._get("tc_grps", "System")
+        temperature = self._value_or_default(self.job.temperature, 300)
+        timestep = self._value_or_default(self.job.timestep, 0.002)
+        nsteps = self._value_or_default(self.job.nsteps, 50000)
+        constraints = self._value_or_default(self.job.constraints, "h-bonds")
+        constraint_algorithm = self._value_or_default(
+            self.job.constraint_algorithm,
+            "lincs",
+        )
+        thermostat = self._value_or_default(self.job.thermostat, "V-rescale")
+        tau_t = self._value_or_default(self.job.tau_t, 0.1)
+        tc_grps = self._value_or_default(self.job.tc_grps, "System")
 
         return self._format_mdp(
             {
@@ -149,18 +152,27 @@ class GromacsInputWriter:
         """
         Build a default NPT .mdp file.
         """
-        temperature = self._get("temperature", 300)
-        pressure = self._get("pressure", 1.0)
-        timestep = self._get("timestep", 0.002)
-        nsteps = self._get("nsteps", self._get("npt_nsteps", 50000))
-        constraints = self._get("constraints", "h-bonds")
-        constraint_algorithm = self._get("constraint_algorithm", "lincs")
-        thermostat = self._get("thermostat", "V-rescale")
-        barostat = self._get("barostat", "Parrinello-Rahman")
-        tau_t = self._get("tau_t", 0.1)
-        tc_grps = self._get("tc_grps", "System")
-        tau_p = self._get("tau_p", 2.0)
-        compressibility = self._get("compressibility", "4.5e-5")
+        temperature = self._value_or_default(self.job.temperature, 300)
+        pressure = self._value_or_default(self.job.pressure, 1.0)
+        timestep = self._value_or_default(self.job.timestep, 0.002)
+        nsteps = self._value_or_default(self.job.nsteps, 50000)
+        constraints = self._value_or_default(self.job.constraints, "h-bonds")
+        constraint_algorithm = self._value_or_default(
+            self.job.constraint_algorithm,
+            "lincs",
+        )
+        thermostat = self._value_or_default(self.job.thermostat, "V-rescale")
+        barostat = self._value_or_default(
+            self.job.barostat,
+            "Parrinello-Rahman",
+        )
+        tau_t = self._value_or_default(self.job.tau_t, 0.1)
+        tc_grps = self._value_or_default(self.job.tc_grps, "System")
+        tau_p = self._value_or_default(self.job.tau_p, 2.0)
+        compressibility = self._value_or_default(
+            self.job.compressibility,
+            "4.5e-5",
+        )
 
         return self._format_mdp(
             {
@@ -188,12 +200,12 @@ class GromacsInputWriter:
                 "gen_vel": "no",
             }
         )
-    
-    def _get(self, name, default=None):
+
+    @staticmethod
+    def _value_or_default(value, default=None):
         """
-        Read an optional job attribute with a default fallback.
+        Return default when the given value is None.
         """
-        value = getattr(self.job, name, None)
         return default if value is None else value
 
     @staticmethod

--- a/chemsmart/jobs/gromacs/writer.py
+++ b/chemsmart/jobs/gromacs/writer.py
@@ -70,6 +70,9 @@ class GromacsInputWriter:
         elif job_type == "gmxnvt":
             mdp_path = folder / "nvt.mdp"
             content = self._build_nvt_mdp()
+        elif job_type == "gmxnpt":
+            mdp_path = folder / "npt.mdp"
+            content = self._build_npt_mdp()
         else:
             raise ValueError(
                 f"Unsupported GROMACS job type for MDP writing: {job_type}"
@@ -142,6 +145,50 @@ class GromacsInputWriter:
             }
         )
 
+    def _build_npt_mdp(self):
+        """
+        Build a default NPT .mdp file.
+        """
+        temperature = self._get("temperature", 300)
+        pressure = self._get("pressure", 1.0)
+        timestep = self._get("timestep", 0.002)
+        nsteps = self._get("nsteps", self._get("npt_nsteps", 50000))
+        constraints = self._get("constraints", "h-bonds")
+        constraint_algorithm = self._get("constraint_algorithm", "lincs")
+        thermostat = self._get("thermostat", "V-rescale")
+        barostat = self._get("barostat", "Parrinello-Rahman")
+        tau_t = self._get("tau_t", 0.1)
+        tc_grps = self._get("tc_grps", "System")
+        tau_p = self._get("tau_p", 2.0)
+        compressibility = self._get("compressibility", "4.5e-5")
+
+        return self._format_mdp(
+            {
+                "integrator": "md",
+                "nsteps": nsteps,
+                "dt": timestep,
+                "continuation": "yes",
+                "constraint_algorithm": constraint_algorithm,
+                "constraints": constraints,
+                "cutoff-scheme": "Verlet",
+                "nstlist": 10,
+                "rcoulomb": 1.0,
+                "rvdw": 1.0,
+                "coulombtype": "PME",
+                "pbc": "xyz",
+                "tcoupl": thermostat,
+                "tc-grps": tc_grps,
+                "tau_t": tau_t,
+                "ref_t": temperature,
+                "pcoupl": barostat,
+                "pcoupltype": "isotropic",
+                "tau_p": tau_p,
+                "ref_p": pressure,
+                "compressibility": compressibility,
+                "gen_vel": "no",
+            }
+        )
+    
     def _get(self, name, default=None):
         """
         Read an optional job attribute with a default fallback.

--- a/docs/source/chemsmart.jobs.gromacs.rst
+++ b/docs/source/chemsmart.jobs.gromacs.rst
@@ -1,271 +1,439 @@
-GROMACS jobs
-============
+############
+GROMACS Jobs
+############
 
-ChemSmart provides initial support for prepared GROMACS workflows.
+ChemSmart provides workflow generation and execution support for GROMACS.
+The stable interface currently covers prepared energy minimization (EM),
+constant-volume equilibration (NVT), and constant-pressure equilibration (NPT)
+jobs.
 
-The implementation follows the standard GROMACS workflow pattern used in the
-official GROMACS tutorials: a simulation step is prepared with ``gmx grompp``
-and then executed with ``gmx mdrun``. In GROMACS, ``grompp`` assembles the
-simulation parameter file, structure file and topology file into a binary
-``.tpr`` run input file. The ``mdrun`` command then runs the calculation from
-that ``.tpr`` input.
+This page distinguishes between:
 
-The current ChemSmart implementation focuses on a simplified prepared workflow.
-Users provide a prepared structure file and a matching topology file. ChemSmart
-can generate a default ``.mdp`` file when it is not provided, call ``grompp`` to
-generate a ``.tpr`` file, and then call ``mdrun``.
+* the behavior currently implemented by ChemSmart;
+* the standard GROMACS workflow described in the official documentation; and
+* features that are not automated yet.
+
+The documentation below is aligned with the GROMACS 2026.3 user guide,
+command reference, and official introductory molecular-dynamics tutorial.
+
+Workflow overview
+=================
+
+The stable prepared workflow is:
+
+.. code-block:: text
+
+   structure + topology + MDP
+              |
+              v
+          gmx grompp
+              |
+              v
+             TPR
+              |
+              v
+          gmx mdrun
+
+``gmx grompp`` reads the molecular topology, coordinates, simulation
+parameters, and an optional index file, then produces a binary ``.tpr`` run
+input file. ``gmx mdrun`` uses the ``.tpr`` file to run energy minimization or
+molecular dynamics.
+
+ChemSmart follows this pattern by:
+
+#. accepting a prepared structure and matching topology;
+#. using a user-provided MDP file or generating one when it is absent;
+#. assembling the TPR with ``grompp``; and
+#. executing the calculation with ``mdrun``.
 
 Supported job types
--------------------
+===================
 
 .. list-table::
    :header-rows: 1
-   :widths: 15 25 35 25 35
+   :widths: 15 27 28 30
 
-   * - Job type
-     - CLI command
-     - Required prepared inputs
-     - Auto-generated MDP
-     - Notes
+   * - Job
+     - CLI subcommand
+     - Generated MDP
+     - Intended stage
    * - EM
      - ``chemsmart run gromacs em``
-     - ``structure_file``, ``topology_file`` / ``top_file``
      - ``em.mdp``
-     - Energy minimization.
+     - Energy minimization
    * - NVT
      - ``chemsmart run gromacs nvt``
-     - ``structure_file``, ``topology_file`` / ``top_file``
      - ``nvt.mdp``
-     - Constant-volume equilibration.
+     - Temperature equilibration at fixed volume
    * - NPT
      - ``chemsmart run gromacs npt``
-     - ``structure_file``, ``topology_file`` / ``top_file``
      - ``npt.mdp``
-     - Constant-pressure equilibration.
+     - Pressure and density equilibration at fixed temperature
 
-Relationship to the official GROMACS tutorial
----------------------------------------------
-
-The official GROMACS introductory tutorial uses the following general sequence:
-
-.. list-table::
-   :header-rows: 1
-   :widths: 15 45 45
-
-   * - Step
-     - Official tutorial pattern
-     - Current ChemSmart prepared workflow
-   * - EM
-     - ``grompp`` with an EM ``.mdp``, structure and topology, followed by
-       ``mdrun``.
-     - Supported. ChemSmart can generate ``em.mdp`` if ``mdp_file`` is not
-       provided.
-   * - NVT
-     - ``grompp`` with an NVT ``.mdp``, ``em.gro``, topology and often a
-       restraint reference structure through ``-r``, followed by ``mdrun``.
-     - Supported in simplified form. ChemSmart currently uses the prepared
-       structure and topology, and can generate ``nvt.mdp``.
-   * - NPT
-     - ``grompp`` with an NPT ``.mdp``, ``nvt.gro``, topology and often the
-       NVT checkpoint through ``-t nvt.cpt``, followed by ``mdrun``.
-     - Supported in simplified form. ChemSmart currently uses the prepared
-       structure and topology, and can generate ``npt.mdp``.
-
-The current prepared workflow does not yet automatically manage all optional
-tutorial files, such as restraint reference structures passed with ``-r`` or
-checkpoint continuation files passed with ``-t``. These can be added in future
-workflow extensions.
+The CLI subcommand selects the concrete job class. When a YAML file is used,
+keep ``project.job_type`` consistent with the selected subcommand.
 
 Prepared workflow
------------------
+=================
 
-In a prepared workflow, ChemSmart expects the GROMACS structure and topology
-to already be consistent with each other.
+Required inputs
+---------------
 
-The minimum required inputs are:
+A prepared workflow requires:
 
-.. code-block:: yaml
+``structure_file``
+   A coordinate file accepted by ``gmx grompp``, normally a ``.gro`` file.
 
-   inputs:
-     structure_file: input.gro
-     topology_file: topol.top
+``top_file`` or ``topology_file``
+   A matching GROMACS topology.
 
-The ``topology_file`` key is accepted as an alias for ``top_file`` in project
-YAML files.
+The MDP file is optional in ChemSmart. When ``mdp_file`` is absent,
+``GromacsInputWriter`` writes a stage-specific default file before validation.
 
-If ``topol.top`` includes additional files such as ``.itp`` or ``posre.itp``,
-those files must also be available in the working directory or otherwise
-resolvable by GROMACS when ``grompp`` is executed.
+Optional inputs
+---------------
 
-Automatic topology generation is not included in the prepared workflow yet.
+``mdp_file``
+   A custom MDP file. When supplied, ChemSmart uses it without overwriting it.
+
+``tpr_file``
+   The desired TPR path. When absent, the job supplies its default output name.
+
+``index_file``
+   An optional ``.ndx`` file passed to ``gmx grompp`` with ``-n``.
+
+``itp_files``
+   Include-topology files associated with the project.
+
+.. important::
+
+   The current runner passes the main topology to ``gmx grompp`` with ``-p``.
+   It does not rewrite topology ``#include`` directives or automatically create
+   include search paths. Every referenced ``.itp`` or position-restraint file
+   must already be resolvable from the working directory, the topology include
+   path, or the GROMACS library path.
+
+Prepared command pattern
+------------------------
+
+For a prepared job, ChemSmart builds commands equivalent to:
+
+.. code-block:: bash
+
+   gmx grompp \
+     -f stage.mdp \
+     -c input.gro \
+     -p topol.top \
+     -o stage.tpr
+
+   gmx mdrun -deffnm stage
+
+When configured, ChemSmart may additionally pass:
+
+* ``-n index.ndx`` to ``grompp``;
+* ``-maxwarn N`` to ``grompp``;
+* ``-nt N`` to ``mdrun``;
+* ``-ntmpi N`` to ``mdrun``;
+* ``-ntomp N`` to ``mdrun``; and
+* values from ``mdrun_extra_args``.
+
+``-deffnm`` sets the default filename stem for the GROMACS output files.
+
+.. warning::
+
+   GROMACS documents ``grompp -maxwarn`` as an option that is not intended for
+   normal use and may produce unstable systems. Correct and understand warnings
+   before setting ``grompp_maxwarn`` above zero.
 
 MDP generation
---------------
+==============
 
-If an ``mdp_file`` is provided, ChemSmart uses it directly and does not
-overwrite it.
+Behavior
+--------
 
-If no ``mdp_file`` is provided, ChemSmart generates a default MDP file according
-to the selected job type.
+When ``mdp_file`` is supplied:
+
+* the file is used directly;
+* ChemSmart does not overwrite it; and
+* the user is responsible for protocol validity.
+
+When ``mdp_file`` is absent:
+
+* EM writes ``em.mdp``;
+* NVT writes ``nvt.mdp``; and
+* NPT writes ``npt.mdp``.
+
+The generated MDP files are minimal implementation defaults. They are useful
+for workflow automation and testing, but they are not universal scientific
+protocols. Force-field requirements, system composition, restraints, timestep,
+coupling groups, equilibration duration, and production settings must be
+reviewed for each system.
+
+Generated EM defaults
+---------------------
 
 .. list-table::
    :header-rows: 1
-   :widths: 20 30 35
+   :widths: 34 22 44
 
-   * - Job type
-     - Generated file
-     - Generated by
-   * - EM
-     - ``em.mdp``
-     - ``GromacsInputWriter``
-   * - NVT
-     - ``nvt.mdp``
-     - ``GromacsInputWriter``
-   * - NPT
-     - ``npt.mdp``
-     - ``GromacsInputWriter``
+   * - Option
+     - Value
+     - Meaning
+   * - ``integrator``
+     - ``steep``
+     - Steepest-descent energy minimization
+   * - ``emtol``
+     - ``1000.0``
+     - Maximum-force convergence threshold
+   * - ``emstep``
+     - ``0.01``
+     - Initial minimization step in nm
+   * - ``nsteps``
+     - ``50000``
+     - Maximum minimization steps
+   * - ``cutoff-scheme``
+     - ``Verlet``
+     - Verlet cutoff scheme
+   * - ``coulombtype``
+     - ``PME``
+     - Particle-mesh Ewald electrostatics
+   * - ``rcoulomb`` / ``rvdw``
+     - ``1.0`` / ``1.0``
+     - Cutoff distances in nm
+   * - ``pbc``
+     - ``xyz``
+     - Periodic boundaries in all dimensions
 
-Project YAML structure
+Generated NVT defaults
 ----------------------
 
-A GROMACS project YAML file contains three main sections:
+.. list-table::
+   :header-rows: 1
+   :widths: 34 22 44
 
-``project``
-   Defines the project name, job type and workflow mode.
+   * - Option
+     - Value
+     - Meaning
+   * - ``integrator``
+     - ``md``
+     - Leap-frog molecular dynamics
+   * - ``dt``
+     - ``0.002``
+     - Timestep in ps
+   * - ``nsteps``
+     - ``50000``
+     - 100 ps at the default timestep
+   * - ``continuation``
+     - ``no``
+     - Start a new constrained run
+   * - ``constraints``
+     - ``h-bonds``
+     - Constrain bonds involving hydrogen
+   * - ``constraint_algorithm``
+     - ``lincs``
+     - LINCS constraint solver
+   * - ``tcoupl``
+     - ``V-rescale``
+     - Stochastic velocity-rescaling thermostat
+   * - ``tc-grps``
+     - ``System``
+     - One temperature-coupling group
+   * - ``tau_t``
+     - ``0.1``
+     - Temperature-coupling time constant in ps
+   * - ``ref_t``
+     - ``300``
+     - Reference temperature in K
+   * - ``pcoupl``
+     - ``no``
+     - No pressure coupling
+   * - ``gen_vel``
+     - ``yes``
+     - Generate Maxwell-distributed velocities
+   * - ``gen_temp``
+     - ``300``
+     - Velocity-generation temperature in K
+   * - ``gen_seed``
+     - ``-1``
+     - Use a pseudo-random seed
 
-``gromacs_settings``
-   Stores common GROMACS settings shared across job types.
+``temperature``, ``timestep``, ``constraints``, ``constraint_algorithm``, and
+``thermostat`` can be supplied through project settings. Other stage-specific
+defaults remain internal to the job and writer.
 
-``inputs``
-   Stores concrete input files for the selected workflow.
-
-The ``gromacs_settings`` section should contain common GROMACS settings only.
-Task-specific MDP defaults are handled inside ``GromacsInputWriter`` and should
-not be duplicated in the project YAML.
-
-Common GROMACS settings
------------------------
+Generated NPT defaults
+----------------------
 
 .. list-table::
    :header-rows: 1
-   :widths: 30 25 45
+   :widths: 34 22 44
 
-   * - Setting
-     - Example
-     - Description
-   * - ``force_field``
-     - ``user_provided``
-     - Force field name or marker for user-provided topology.
-   * - ``water_model``
-     - ``spc``
-     - Water model used for setup workflows.
-   * - ``timestep``
-     - ``0.001``
-     - MD timestep in ps.
-   * - ``temperature``
-     - ``300.0``
-     - Reference temperature in K.
-   * - ``pressure``
-     - ``1.0``
-     - Reference pressure in bar.
+   * - Option
+     - Value
+     - Meaning
+   * - ``integrator``
+     - ``md``
+     - Leap-frog molecular dynamics
+   * - ``dt``
+     - ``0.002``
+     - Timestep in ps
+   * - ``nsteps``
+     - ``50000``
+     - 100 ps at the default timestep
+   * - ``continuation``
+     - ``yes``
+     - Continue from an equilibrated structure
    * - ``constraints``
-     - ``none``
-     - Constraint setting used by generated MDP files.
-   * - ``thermostat``
+     - ``h-bonds``
+     - Constrain bonds involving hydrogen
+   * - ``constraint_algorithm``
+     - ``lincs``
+     - LINCS constraint solver
+   * - ``tcoupl``
      - ``V-rescale``
-     - Temperature coupling method used by generated MDP files.
-   * - ``barostat``
+     - Stochastic velocity-rescaling thermostat
+   * - ``tc-grps``
+     - ``System``
+     - One temperature-coupling group
+   * - ``tau_t``
+     - ``0.1``
+     - Temperature-coupling time constant in ps
+   * - ``ref_t``
+     - ``300``
+     - Reference temperature in K
+   * - ``pcoupl``
      - ``Parrinello-Rahman``
-     - Pressure coupling method used by generated MDP files.
-   * - ``grompp_maxwarn``
-     - ``0``
-     - Optional ``grompp -maxwarn`` value.
-   * - ``mdrun_threads``
-     - ``1``
-     - Optional ``mdrun -nt`` value.
+     - Current ChemSmart implementation default
+   * - ``pcoupltype``
+     - ``isotropic``
+     - Isotropic pressure coupling
+   * - ``tau_p``
+     - ``2.0``
+     - Pressure-coupling time constant in ps
+   * - ``ref_p``
+     - ``1.0``
+     - Reference pressure in bar
+   * - ``compressibility``
+     - ``4.5e-5``
+     - Water compressibility near 300 K in bar :sup:`-1`
+   * - ``gen_vel``
+     - ``no``
+     - Reuse velocities from the input state
 
-Example prepared EM project
----------------------------
+.. important::
 
-.. code-block:: yaml
+   The current official GROMACS introductory tutorial uses ``C-rescale`` for
+   NPT equilibration. The GROMACS manual states that C-rescale can be used for
+   both equilibration and production, while Parrinello-Rahman can show large
+   oscillations when the starting pressure is far from the target.
 
-   project:
-     name: water_prepared_em
-     type: gromacs
-     job_type: em
-     mode: prepared
+   ChemSmart currently generates ``Parrinello-Rahman`` unless ``barostat`` is
+   overridden. This is an implementation default, not a recommendation for
+   every system. Use a reviewed custom MDP file when protocol fidelity matters.
 
-   gromacs_settings:
-     force_field: user_provided
-     water_model: spc
-     timestep: 0.001
-     temperature: 300.0
-     pressure: 1.0
-     constraints: none
-     grompp_maxwarn: 0
-     mdrun_threads: 1
+Relationship to the official tutorial
+=====================================
 
-   inputs:
-     structure_file: water.gro
-     topology_file: topol.top
+The official introductory tutorial follows this general sequence:
 
-Example prepared NVT project
-----------------------------
+.. code-block:: text
 
-.. code-block:: yaml
+   system preparation
+        |
+        v
+       EM
+        |
+        v
+       NVT
+        |
+        v
+       NPT
+        |
+        v
+   production MD
 
-   project:
-     name: water_prepared_nvt
-     type: gromacs
-     job_type: nvt
-     mode: prepared
-
-   gromacs_settings:
-     force_field: user_provided
-     water_model: spc
-     timestep: 0.001
-     temperature: 300.0
-     pressure: 1.0
-     constraints: none
-     thermostat: V-rescale
-     grompp_maxwarn: 0
-     mdrun_threads: 1
-
-   inputs:
-     structure_file: em.gro
-     topology_file: topol.top
-
-Example prepared NPT project
-----------------------------
-
-.. code-block:: yaml
-
-   project:
-     name: water_prepared_npt
-     type: gromacs
-     job_type: npt
-     mode: prepared
-
-   gromacs_settings:
-     force_field: user_provided
-     water_model: spc
-     timestep: 0.001
-     temperature: 300.0
-     pressure: 1.0
-     constraints: none
-     thermostat: V-rescale
-     barostat: Parrinello-Rahman
-     grompp_maxwarn: 0
-     mdrun_threads: 1
-
-   inputs:
-     structure_file: nvt.gro
-     topology_file: topol.top
-
-Direct CLI examples
+Energy minimization
 -------------------
 
-Run EM with an automatically generated ``em.mdp``:
+The official example assembles an EM TPR from an MDP file, an ionized
+coordinate file, and the topology, then runs ``mdrun``:
+
+.. code-block:: bash
+
+   gmx grompp -f em.mdp -c solv_ions.gro -p topol.top -o em.tpr
+   gmx mdrun -deffnm em
+
+ChemSmart's prepared EM workflow represents this pattern directly.
+
+NVT equilibration
+-----------------
+
+The official introductory example uses the energy-minimized structure and also
+passes restraint reference coordinates:
+
+.. code-block:: bash
+
+   gmx grompp \
+     -f nvt.mdp \
+     -c em.gro \
+     -r em.gro \
+     -p topol.top \
+     -o nvt.tpr
+
+   gmx mdrun -deffnm nvt
+
+The official NVT example generates velocities, uses V-rescale temperature
+coupling, and disables pressure coupling.
+
+.. warning::
+
+   When position restraints are active, GROMACS requires restraint coordinates
+   through ``grompp -r``. The current ChemSmart prepared runner does not yet
+   expose a dedicated restraint-reference input and does not add ``-r``.
+
+   Therefore, a topology that activates position restraints may not work with
+   the current generated command. This is a known workflow limitation, not a
+   reason to bypass the resulting GROMACS error.
+
+NPT equilibration
+-----------------
+
+The official introductory example uses the final NVT coordinates, the
+restraint-reference coordinates, and the NVT checkpoint:
+
+.. code-block:: bash
+
+   gmx grompp \
+     -f npt.mdp \
+     -c nvt.gro \
+     -r nvt.gro \
+     -t nvt.cpt \
+     -p topol.top \
+     -o npt.tpr
+
+   gmx mdrun -deffnm npt
+
+The checkpoint preserves velocities and state variables needed for a continuous
+simulation. The official tutorial sets ``continuation = yes`` and
+``gen_vel = no`` for this stage.
+
+.. warning::
+
+   The current ChemSmart prepared runner does not yet add ``grompp -t`` or
+   ``mdrun -cpi``. A prepared NPT job can read velocities stored in a ``.gro``
+   file, but it does not provide exact checkpoint continuation of thermostat,
+   barostat, and other state variables.
+
+   Do not describe the current NPT command as an exact continuation of the NVT
+   run. Checkpoint-aware continuation requires a future runner extension.
+
+CLI usage
+=========
+
+Direct prepared jobs
+--------------------
+
+Generate an EM MDP automatically:
 
 .. code-block:: bash
 
@@ -274,7 +442,17 @@ Run EM with an automatically generated ``em.mdp``:
      --top topol.top \
      --workflow prepared
 
-Run NVT with an automatically generated ``nvt.mdp``:
+Use a custom EM MDP:
+
+.. code-block:: bash
+
+   chemsmart run gromacs em \
+     --mdp em.mdp \
+     --structure input.gro \
+     --top topol.top \
+     --workflow prepared
+
+Generate an NVT MDP automatically:
 
 .. code-block:: bash
 
@@ -283,7 +461,7 @@ Run NVT with an automatically generated ``nvt.mdp``:
      --top topol.top \
      --workflow prepared
 
-Run NPT with an automatically generated ``npt.mdp``:
+Generate an NPT MDP automatically:
 
 .. code-block:: bash
 
@@ -292,26 +470,468 @@ Run NPT with an automatically generated ``npt.mdp``:
      --top topol.top \
      --workflow prepared
 
-Use a custom MDP file:
+Use an index file and associated ITP files:
 
 .. code-block:: bash
 
    chemsmart run gromacs nvt \
-     --mdp nvt.mdp \
      --structure em.gro \
      --top topol.top \
+     --index index.ndx \
+     --itp protein.itp \
+     --itp posre.itp \
      --workflow prepared
 
-Current limitations
+The ``--itp`` option can be supplied multiple times. The topology must still
+contain correct and resolvable ``#include`` statements.
+
+YAML-driven jobs
+----------------
+
+Run a stage from a project YAML file:
+
+.. code-block:: bash
+
+   chemsmart run gromacs -p project.yaml em
+   chemsmart run gromacs -p project.yaml nvt
+   chemsmart run gromacs -p project.yaml npt
+
+The explicit equivalent is:
+
+.. code-block:: bash
+
+   chemsmart run gromacs --project-yaml project.yaml npt
+
+Project YAML
+============
+
+Structure
+---------
+
+A GROMACS project YAML can contain:
+
+``project``
+   Project metadata, workflow mode, and expected job type.
+
+``inputs``
+   Concrete input and output file paths.
+
+``gromacs_settings``
+   Reusable GROMACS settings shared by job stages.
+
+``runtime``
+   ``grompp`` warning handling and ``mdrun`` resource arguments.
+
+Relative paths are resolved from the directory containing the YAML file.
+
+Minimal prepared EM project
+---------------------------
+
+.. code-block:: yaml
+
+   project:
+     name: prepared_em
+     type: gromacs
+     job_type: em
+     mode: prepared
+
+   inputs:
+     structure_file: input.gro
+     topology_file: topol.top
+
+   runtime:
+     grompp_maxwarn: 0
+
+Run it with:
+
+.. code-block:: bash
+
+   chemsmart run gromacs -p project.yaml em
+
+Minimal prepared NVT project
+----------------------------
+
+.. code-block:: yaml
+
+   project:
+     name: prepared_nvt
+     type: gromacs
+     job_type: nvt
+     mode: prepared
+
+   inputs:
+     structure_file: em.gro
+     topology_file: topol.top
+
+   gromacs_settings:
+     timestep: 0.002
+     temperature: 300.0
+     thermostat: V-rescale
+     constraints: h-bonds
+     constraint_algorithm: lincs
+
+   runtime:
+     grompp_maxwarn: 0
+     mdrun_ntmpi: 1
+     mdrun_ntomp: 8
+
+Run it with:
+
+.. code-block:: bash
+
+   chemsmart run gromacs -p project.yaml nvt
+
+Minimal prepared NPT project
+----------------------------
+
+.. code-block:: yaml
+
+   project:
+     name: prepared_npt
+     type: gromacs
+     job_type: npt
+     mode: prepared
+
+   inputs:
+     structure_file: nvt.gro
+     topology_file: topol.top
+
+   gromacs_settings:
+     timestep: 0.002
+     temperature: 300.0
+     pressure: 1.0
+     thermostat: V-rescale
+     barostat: C-rescale
+     constraints: h-bonds
+     constraint_algorithm: lincs
+
+   runtime:
+     grompp_maxwarn: 0
+     mdrun_ntmpi: 1
+     mdrun_ntomp: 8
+
+Run it with:
+
+.. code-block:: bash
+
+   chemsmart run gromacs -p project.yaml npt
+
+The example explicitly selects ``C-rescale`` to follow the current official
+introductory tutorial more closely. Omitting ``barostat`` uses the current
+ChemSmart writer default.
+
+Custom MDP project
+------------------
+
+A custom MDP file takes priority over generated defaults:
+
+.. code-block:: yaml
+
+   project:
+     name: custom_npt
+     type: gromacs
+     job_type: npt
+     mode: prepared
+
+   inputs:
+     mdp_file: npt-reviewed.mdp
+     structure_file: nvt.gro
+     topology_file: topol.top
+     index_file: index.ndx
+     itp_files:
+       - protein.itp
+       - posre.itp
+
+   runtime:
+     grompp_maxwarn: 0
+     mdrun_extra_args:
+       - -pin
+       - "on"
+
+Project settings reference
+--------------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 28 25 47
+
+   * - Key
+     - Typical section
+     - Purpose
+   * - ``workflow``
+     - ``project.mode``
+     - ``prepared`` or ``full_setup``
+   * - ``job_type``
+     - ``project.job_type``
+     - Expected stage: ``em``, ``nvt``, or ``npt``
+   * - ``mdp_file``
+     - ``inputs``
+     - Optional custom MDP
+   * - ``ions_mdp_file``
+     - ``inputs``
+     - MDP used to assemble the ion-placement TPR
+   * - ``structure_file``
+     - ``inputs``
+     - Prepared coordinate file
+   * - ``input_pdb``
+     - ``inputs``
+     - Raw PDB or structure for ``full_setup``
+   * - ``top_file`` / ``topology_file``
+     - ``inputs``
+     - Main topology
+   * - ``tpr_file``
+     - ``inputs``
+     - Desired run-input output path
+   * - ``index_file``
+     - ``inputs``
+     - Optional index file
+   * - ``itp_files``
+     - ``inputs``
+     - Associated include-topology files
+   * - ``force_field``
+     - ``gromacs_settings``
+     - ``pdb2gmx -ff`` value for ``full_setup``
+   * - ``water_model``
+     - ``gromacs_settings``
+     - ``pdb2gmx -water`` value for ``full_setup``
+   * - ``timestep``
+     - ``gromacs_settings``
+     - Generated NVT/NPT ``dt`` in ps
+   * - ``temperature``
+     - ``gromacs_settings``
+     - Generated NVT/NPT reference temperature in K
+   * - ``pressure``
+     - ``gromacs_settings``
+     - Generated NPT reference pressure in bar
+   * - ``thermostat``
+     - ``gromacs_settings``
+     - Generated NVT/NPT ``tcoupl``
+   * - ``barostat``
+     - ``gromacs_settings``
+     - Generated NPT ``pcoupl``
+   * - ``constraints``
+     - ``gromacs_settings``
+     - Generated NVT/NPT bond constraints
+   * - ``constraint_algorithm``
+     - ``gromacs_settings``
+     - Generated NVT/NPT constraint solver
+   * - ``box_type``
+     - ``gromacs_settings``
+     - ``editconf -bt`` value
+   * - ``box_distance``
+     - ``gromacs_settings``
+     - ``editconf -d`` value in nm
+   * - ``solvent_file``
+     - ``inputs`` or ``gromacs_settings``
+     - Optional ``solvate -cs`` file
+   * - ``positive_ion``
+     - ``gromacs_settings``
+     - ``genion -pname`` value
+   * - ``negative_ion``
+     - ``gromacs_settings``
+     - ``genion -nname`` value
+   * - ``neutral``
+     - ``gromacs_settings``
+     - Add ``genion -neutral`` when true
+   * - ``genion_group``
+     - ``gromacs_settings``
+     - Group name supplied to interactive ``genion``
+   * - ``grompp_maxwarn``
+     - ``runtime``
+     - ``grompp -maxwarn`` value
+   * - ``mdrun_threads``
+     - ``runtime``
+     - ``mdrun -nt`` value
+   * - ``mdrun_ntmpi``
+     - ``runtime``
+     - ``mdrun -ntmpi`` value
+   * - ``mdrun_ntomp``
+     - ``runtime``
+     - ``mdrun -ntomp`` value
+   * - ``mdrun_extra_args``
+     - ``runtime``
+     - Extra arguments appended to ``mdrun``
+
+Experimental full setup
+=======================
+
+ChemSmart also contains an initial non-interactive setup path:
+
+.. code-block:: text
+
+   pdb2gmx
+      |
+   editconf
+      |
+   solvate
+      |
+   grompp for ion placement
+      |
+   genion
+      |
+   final grompp
+      |
+   mdrun
+
+This maps to the standard GROMACS preparation tools:
+
+``pdb2gmx``
+   Adds hydrogens and creates GROMACS coordinates and topology information from
+   a supported structure, using the selected force field and water model.
+
+``editconf``
+   Defines or changes the simulation box.
+
+``solvate``
+   Adds solvent and updates the topology when ``-p`` is used.
+
+``genion``
+   Replaces solvent molecules with monoatomic ions and can update the topology.
+
+Current requirements
+--------------------
+
+The ``full_setup`` settings validator requires:
+
+* ``input_pdb`` or ``structure_file``;
+* ``force_field``; and
+* ``water_model``.
+
+Current defaults include:
+
+* cubic box;
+* 1.0 nm solute-to-box distance;
+* positive ion ``NA``;
+* negative ion ``CL``;
+* neutralization enabled; and
+* solvent group ``SOL``.
+
+.. warning::
+
+   The current full-setup runner is an initial happy-path implementation. Its
+   final state and command labels are still organized around EM setup. Use
+   ``full_setup`` with the EM job while this workflow remains experimental.
+
+   Prepared EM, NVT, and NPT jobs are the stable documented interface.
+
+Output files
+============
+
+With ``mdrun -deffnm stage``, GROMACS normally writes files using the same
+``stage`` stem. Typical outputs include:
+
+``stage.log``
+   Text log.
+
+``stage.gro``
+   Final coordinates and velocities.
+
+``stage.edr``
+   Energy, temperature, pressure, and related quantities.
+
+``stage.trr`` and/or ``stage.xtc``
+   Trajectory data, depending on the MDP output settings.
+
+``stage.cpt``
+   Checkpoint state when checkpoint output is enabled.
+
+ChemSmart considers a GROMACS job normally terminated when the corresponding
+log file contains ``Finished mdrun``.
+
+Validation and troubleshooting
+==============================
+
+Structure/topology consistency
+------------------------------
+
+The coordinates and topology must describe the same system. A common failure is
+a mismatch between the number of coordinates and the molecule counts in the
+topology.
+
+Topology includes
+-----------------
+
+Use valid GROMACS ``#include`` directives and ensure the referenced files are
+available. ``gmx grompp -pp processed.top`` can be useful when debugging
+preprocessor and include behavior.
+
+GROMPP warnings
+---------------
+
+Read and correct warnings rather than automatically increasing
+``grompp_maxwarn``. Inspect ``mdout.mdp`` to see the parameters actually read by
+``grompp``. ``gmx dump -s stage.tpr`` can be used to inspect the generated run
+input.
+
+Position restraints
 -------------------
 
-The current implementation does not yet generate topology files automatically.
+If the MDP activates position restraints, the current prepared runner lacks the
+required ``-r`` reference-coordinate option. This needs workflow support rather
+than a warning override.
 
-For prepared workflows, users must provide a structure file and a matching
-topology file. If the topology includes additional ``.itp`` files, these files
-must also be available to GROMACS during ``grompp``.
+NPT continuation
+----------------
 
-The current NVT and NPT prepared workflows follow the common ``grompp`` to
-``mdrun`` pattern, but they do not yet automatically manage all optional
-tutorial files such as position-restraint reference structures or checkpoint
-continuation files.
+For continuous NVT-to-NPT state transfer, the official tutorial supplies the
+NVT checkpoint with ``grompp -t``. Current prepared jobs do not yet model this
+checkpoint input.
+
+Scientific validation
+---------------------
+
+A successful command is not sufficient evidence that a system is equilibrated.
+Evaluate at least:
+
+* maximum force after EM;
+* temperature during NVT;
+* pressure and density during NPT; and
+* warnings, LINCS messages, box behavior, and physical stability.
+
+Pressure fluctuates strongly in finite molecular systems. Assess averages,
+density behavior, equilibration length, and system-specific convergence rather
+than expecting an instantaneously constant pressure.
+
+Current limitations
+===================
+
+The current implementation does not yet:
+
+* generate a complete topology for arbitrary systems in the stable prepared
+  workflow;
+* rewrite or stage topology include files automatically;
+* pass restraint reference coordinates with ``grompp -r``;
+* pass checkpoint continuation input with ``grompp -t``;
+* restart ``mdrun`` with ``-cpi``;
+* automatically chain EM output into NVT and NVT output into NPT;
+* validate the scientific suitability of generated MDP defaults;
+* select coupling groups based on system composition;
+* distinguish protein, solvent, membrane, ligand, or multi-component protocols;
+  or
+* replace system-specific equilibration and production validation.
+
+Official GROMACS references
+===========================
+
+The following official resources were used to align this page:
+
+* `GROMACS introductory molecular-dynamics tutorial
+  <https://tutorials.gromacs.org/docs/md-intro-tutorial.html>`_
+* `GROMACS getting-started guide
+  <https://manual.gromacs.org/current/user-guide/getting-started.html>`_
+* `gmx grompp
+  <https://manual.gromacs.org/current/onlinehelp/gmx-grompp.html>`_
+* `gmx mdrun
+  <https://manual.gromacs.org/current/onlinehelp/gmx-mdrun.html>`_
+* `gmx pdb2gmx
+  <https://manual.gromacs.org/current/onlinehelp/gmx-pdb2gmx.html>`_
+* `gmx editconf
+  <https://manual.gromacs.org/current/onlinehelp/gmx-editconf.html>`_
+* `gmx solvate
+  <https://manual.gromacs.org/current/onlinehelp/gmx-solvate.html>`_
+* `gmx genion
+  <https://manual.gromacs.org/current/onlinehelp/gmx-genion.html>`_
+* `GROMACS MDP options
+  <https://manual.gromacs.org/current/user-guide/mdp-options.html>`_
+* `GROMACS file formats
+  <https://manual.gromacs.org/current/reference-manual/file-formats.html>`_

--- a/docs/source/chemsmart.jobs.gromacs.rst
+++ b/docs/source/chemsmart.jobs.gromacs.rst
@@ -1,163 +1,317 @@
-##############
- GROMACS Jobs
-##############
+GROMACS jobs
+============
 
-This module provides the initial GROMACS job and runner structure for executing prepared molecular dynamics workflows in
-ChemSmart.
+ChemSmart provides initial support for prepared GROMACS workflows.
 
-***************
- Current Scope
-***************
+The implementation follows the standard GROMACS workflow pattern used in the
+official GROMACS tutorials: a simulation step is prepared with ``gmx grompp``
+and then executed with ``gmx mdrun``. In GROMACS, ``grompp`` assembles the
+simulation parameter file, structure file and topology file into a binary
+``.tpr`` run input file. The ``mdrun`` command then runs the calculation from
+that ``.tpr`` input.
 
-The current implementation focuses on prepared GROMACS workflows, where the user provides the required GROMACS input
-files:
+The current ChemSmart implementation focuses on a simplified prepared workflow.
+Users provide a prepared structure file and a matching topology file. ChemSmart
+can generate a default ``.mdp`` file when it is not provided, call ``grompp`` to
+generate a ``.tpr`` file, and then call ``mdrun``.
 
--  MDP file
--  structure file, such as GRO or PDB
--  topology file
--  optional ITP files
--  optional index file
+Supported job types
+-------------------
 
-For the prepared workflow, the runner assembles the TPR file using ``grompp`` and then executes the simulation using
-``mdrun``:
+.. list-table::
+   :header-rows: 1
+   :widths: 15 25 35 25 35
 
-.. code:: text
+   * - Job type
+     - CLI command
+     - Required prepared inputs
+     - Auto-generated MDP
+     - Notes
+   * - EM
+     - ``chemsmart run gromacs em``
+     - ``structure_file``, ``topology_file`` / ``top_file``
+     - ``em.mdp``
+     - Energy minimization.
+   * - NVT
+     - ``chemsmart run gromacs nvt``
+     - ``structure_file``, ``topology_file`` / ``top_file``
+     - ``nvt.mdp``
+     - Constant-volume equilibration.
+   * - NPT
+     - ``chemsmart run gromacs npt``
+     - ``structure_file``, ``topology_file`` / ``top_file``
+     - ``npt.mdp``
+     - Constant-pressure equilibration.
 
-   grompp -> mdrun
+Relationship to the official GROMACS tutorial
+---------------------------------------------
 
-***************
- Runner Design
-***************
+The official GROMACS introductory tutorial uses the following general sequence:
 
-The GROMACS runner separates different GROMACS subcommands into individual command builders. This allows different
-workflows to reuse and combine commands as needed.
+.. list-table::
+   :header-rows: 1
+   :widths: 15 45 45
 
-Current command builders include:
+   * - Step
+     - Official tutorial pattern
+     - Current ChemSmart prepared workflow
+   * - EM
+     - ``grompp`` with an EM ``.mdp``, structure and topology, followed by
+       ``mdrun``.
+     - Supported. ChemSmart can generate ``em.mdp`` if ``mdp_file`` is not
+       provided.
+   * - NVT
+     - ``grompp`` with an NVT ``.mdp``, ``em.gro``, topology and often a
+       restraint reference structure through ``-r``, followed by ``mdrun``.
+     - Supported in simplified form. ChemSmart currently uses the prepared
+       structure and topology, and can generate ``nvt.mdp``.
+   * - NPT
+     - ``grompp`` with an NPT ``.mdp``, ``nvt.gro``, topology and often the
+       NVT checkpoint through ``-t nvt.cpt``, followed by ``mdrun``.
+     - Supported in simplified form. ChemSmart currently uses the prepared
+       structure and topology, and can generate ``npt.mdp``.
 
--  ``_get_grompp_command()``
--  ``_get_mdrun_command()``
--  ``_get_pdb2gmx_command()``
--  ``_get_editconf_command()``
--  ``_get_solvate_command()``
--  ``_get_genion_command()``
+The current prepared workflow does not yet automatically manage all optional
+tutorial files, such as restraint reference structures passed with ``-r`` or
+checkpoint continuation files passed with ``-t``. These can be added in future
+workflow extensions.
 
-The current stable workflow is the prepared workflow:
+Prepared workflow
+-----------------
 
-.. code:: text
+In a prepared workflow, ChemSmart expects the GROMACS structure and topology
+to already be consistent with each other.
 
-   grompp -> mdrun
+The minimum required inputs are:
 
-Other workflows, such as full system setup, are planned but not fully implemented yet.
+.. code-block:: yaml
 
-**************************
- Executable Configuration
-**************************
+   inputs:
+     structure_file: input.gro
+     topology_file: topol.top
 
-The GROMACS executable is handled through ``GromacsExecutable`` and used by the GROMACS runner. The default executable
-is:
+The ``topology_file`` key is accepted as an alias for ``top_file`` in project
+YAML files.
 
-.. code:: text
+If ``topol.top`` includes additional files such as ``.itp`` or ``posre.itp``,
+those files must also be available in the working directory or otherwise
+resolvable by GROMACS when ``grompp`` is executed.
 
-   gmx
+Automatic topology generation is not included in the prepared workflow yet.
 
-A custom executable path can also be provided to the runner. In future server-specific workflows, this can be further
-connected to ChemSmart server YAML settings so that the same workflow can run on local machines, clusters, or servers.
+MDP generation
+--------------
 
-******************
- Project Settings
-******************
+If an ``mdp_file`` is provided, ChemSmart uses it directly and does not
+overwrite it.
 
-GROMACS project-level settings are represented by ``GromacsProjectSettings``. These settings are designed to store
-reusable project information, including input files, workflow type, and simulation parameters.
+If no ``mdp_file`` is provided, ChemSmart generates a default MDP file according
+to the selected job type.
 
-The settings can be created from a dictionary:
+.. list-table::
+   :header-rows: 1
+   :widths: 20 30 35
 
-.. code:: python
+   * - Job type
+     - Generated file
+     - Generated by
+   * - EM
+     - ``em.mdp``
+     - ``GromacsInputWriter``
+   * - NVT
+     - ``nvt.mdp``
+     - ``GromacsInputWriter``
+   * - NPT
+     - ``npt.mdp``
+     - ``GromacsInputWriter``
 
-   from chemsmart.settings.gromacs import GromacsProjectSettings
+Project YAML structure
+----------------------
 
-   settings = GromacsProjectSettings.from_dict(
-       {
-           "project_name": "prepared_em",
-           "workflow": "prepared",
-           "mdp_file": "em.mdp",
-           "structure_file": "input.gro",
-           "top_file": "topol.top",
-           "tpr_file": "em.tpr",
-           "itp_files": ["forcefield.itp"],
-       }
-   )
+A GROMACS project YAML file contains three main sections:
 
-They can also be created from a YAML file:
+``project``
+   Defines the project name, job type and workflow mode.
 
-.. code:: python
+``gromacs_settings``
+   Stores common GROMACS settings shared across job types.
 
-   settings = GromacsProjectSettings.from_yaml("project.yaml")
+``inputs``
+   Stores concrete input files for the selected workflow.
 
-When settings are loaded from YAML, relative input paths are resolved against the directory containing the YAML file.
-This allows a GROMACS project folder to be moved or executed from a different working directory more safely.
+The ``gromacs_settings`` section should contain common GROMACS settings only.
+Task-specific MDP defaults are handled inside ``GromacsInputWriter`` and should
+not be duplicated in the project YAML.
 
-Example YAML structure:
+Common GROMACS settings
+-----------------------
 
-.. code:: yaml
+.. list-table::
+   :header-rows: 1
+   :widths: 30 25 45
+
+   * - Setting
+     - Example
+     - Description
+   * - ``force_field``
+     - ``user_provided``
+     - Force field name or marker for user-provided topology.
+   * - ``water_model``
+     - ``spc``
+     - Water model used for setup workflows.
+   * - ``timestep``
+     - ``0.001``
+     - MD timestep in ps.
+   * - ``temperature``
+     - ``300.0``
+     - Reference temperature in K.
+   * - ``pressure``
+     - ``1.0``
+     - Reference pressure in bar.
+   * - ``constraints``
+     - ``none``
+     - Constraint setting used by generated MDP files.
+   * - ``thermostat``
+     - ``V-rescale``
+     - Temperature coupling method used by generated MDP files.
+   * - ``barostat``
+     - ``Parrinello-Rahman``
+     - Pressure coupling method used by generated MDP files.
+   * - ``grompp_maxwarn``
+     - ``0``
+     - Optional ``grompp -maxwarn`` value.
+   * - ``mdrun_threads``
+     - ``1``
+     - Optional ``mdrun -nt`` value.
+
+Example prepared EM project
+---------------------------
+
+.. code-block:: yaml
 
    project:
-     name: prepared_em
+     name: water_prepared_em
      type: gromacs
+     job_type: em
      mode: prepared
 
    gromacs_settings:
      force_field: user_provided
-     water_model: user_provided
-     timestep: 0.002
+     water_model: spc
+     timestep: 0.001
      temperature: 300.0
      pressure: 1.0
-     thermostat: V-rescale
-     barostat: Parrinello-Rahman
-     constraints: h-bonds
-     constraint_algorithm: LINCS
+     constraints: none
+     grompp_maxwarn: 0
+     mdrun_threads: 1
 
    inputs:
-     mdp_file: em.mdp
-     structure_file: input.gro
+     structure_file: water.gro
      topology_file: topol.top
-     tpr_file: em.tpr
-     index_file: index.ndx
-     itp_files:
-       - forcefield.itp
-       - ligand.itp
 
-****************************
- Job Creation from Settings
-****************************
+Example prepared NVT project
+----------------------------
 
-Project settings can be converted into GROMACS jobs:
+.. code-block:: yaml
 
-.. code:: python
+   project:
+     name: water_prepared_nvt
+     type: gromacs
+     job_type: nvt
+     mode: prepared
 
-   from chemsmart.jobs.gromacs.job import GromacsEMJob
+   gromacs_settings:
+     force_field: user_provided
+     water_model: spc
+     timestep: 0.001
+     temperature: 300.0
+     pressure: 1.0
+     constraints: none
+     thermostat: V-rescale
+     grompp_maxwarn: 0
+     mdrun_threads: 1
 
-   job = GromacsEMJob.from_project_settings(
-       settings=settings,
-       molecule=None,
-       jobrunner=None,
-   )
+   inputs:
+     structure_file: em.gro
+     topology_file: topol.top
 
-This provides a direct path from project configuration to executable job objects:
+Example prepared NPT project
+----------------------------
 
-.. code:: text
+.. code-block:: yaml
 
-   project.yaml
-       -> GromacsProjectSettings
-       -> GromacsEMJob
-       -> GromacsJobRunner
+   project:
+     name: water_prepared_npt
+     type: gromacs
+     job_type: npt
+     mode: prepared
 
-*******
- Notes
-*******
+   gromacs_settings:
+     force_field: user_provided
+     water_model: spc
+     timestep: 0.001
+     temperature: 300.0
+     pressure: 1.0
+     constraints: none
+     thermostat: V-rescale
+     barostat: Parrinello-Rahman
+     grompp_maxwarn: 0
+     mdrun_threads: 1
 
-The project settings do not automatically decide simulation parameters. Instead, they record user-defined settings
-explicitly and make the workflow easier to reproduce and automate.
+   inputs:
+     structure_file: nvt.gro
+     topology_file: topol.top
 
-The current stable workflow is the prepared workflow, where users provide existing MDP, structure, and topology files.
-Full system setup is planned but not fully implemented yet.
+Direct CLI examples
+-------------------
+
+Run EM with an automatically generated ``em.mdp``:
+
+.. code-block:: bash
+
+   chemsmart run gromacs em \
+     --structure input.gro \
+     --top topol.top \
+     --workflow prepared
+
+Run NVT with an automatically generated ``nvt.mdp``:
+
+.. code-block:: bash
+
+   chemsmart run gromacs nvt \
+     --structure em.gro \
+     --top topol.top \
+     --workflow prepared
+
+Run NPT with an automatically generated ``npt.mdp``:
+
+.. code-block:: bash
+
+   chemsmart run gromacs npt \
+     --structure nvt.gro \
+     --top topol.top \
+     --workflow prepared
+
+Use a custom MDP file:
+
+.. code-block:: bash
+
+   chemsmart run gromacs nvt \
+     --mdp nvt.mdp \
+     --structure em.gro \
+     --top topol.top \
+     --workflow prepared
+
+Current limitations
+-------------------
+
+The current implementation does not yet generate topology files automatically.
+
+For prepared workflows, users must provide a structure file and a matching
+topology file. If the topology includes additional ``.itp`` files, these files
+must also be available to GROMACS during ``grompp``.
+
+The current NVT and NPT prepared workflows follow the common ``grompp`` to
+``mdrun`` pattern, but they do not yet automatically manage all optional
+tutorial files such as position-restraint reference structures or checkpoint
+continuation files.

--- a/tests/test_gromacs_cli.py
+++ b/tests/test_gromacs_cli.py
@@ -6,7 +6,7 @@ from click.testing import CliRunner
 from chemsmart.cli.gromacs.gromacs import gromacs
 
 em_module = importlib.import_module("chemsmart.cli.gromacs.em")
-
+npt_module = importlib.import_module("chemsmart.cli.gromacs.npt")
 
 class DummyGromacsEMJob:
     """
@@ -66,7 +66,62 @@ class DummyGromacsEMJob:
             "skip_completed": skip_completed,
             "kwargs": kwargs,
         }
+class DummyGromacsNPTJob:
+    """
+    Dummy NPT job class used to test CLI argument flow without creating a real
+    job or running real GROMACS.
+    """
 
+    captured_from_settings = {}
+    captured_direct_init = {}
+
+    @classmethod
+    def from_project_settings(
+        cls,
+        settings,
+        molecule=None,
+        jobrunner=None,
+        skip_completed=False,
+        **kwargs,
+    ):
+        cls.captured_from_settings = {
+            "settings": settings,
+            "molecule": molecule,
+            "jobrunner": jobrunner,
+            "skip_completed": skip_completed,
+            "kwargs": kwargs,
+        }
+        return cls()
+
+    def __init__(
+        self,
+        molecule=None,
+        label=None,
+        jobrunner=None,
+        mdp_file=None,
+        structure_file=None,
+        input_pdb=None,
+        top_file=None,
+        itp_files=None,
+        index_file=None,
+        workflow=None,
+        skip_completed=False,
+        **kwargs,
+    ):
+        self.__class__.captured_direct_init = {
+            "molecule": molecule,
+            "label": label,
+            "jobrunner": jobrunner,
+            "mdp_file": mdp_file,
+            "structure_file": structure_file,
+            "input_pdb": input_pdb,
+            "top_file": top_file,
+            "itp_files": itp_files,
+            "index_file": index_file,
+            "workflow": workflow,
+            "skip_completed": skip_completed,
+            "kwargs": kwargs,
+        }
 
 @pytest.fixture(autouse=True)
 def patch_gromacs_em_job(monkeypatch):
@@ -77,11 +132,18 @@ def patch_gromacs_em_job(monkeypatch):
     """
     DummyGromacsEMJob.captured_from_settings = {}
     DummyGromacsEMJob.captured_direct_init = {}
+    DummyGromacsNPTJob.captured_from_settings = {}
+    DummyGromacsNPTJob.captured_direct_init = {}
 
     monkeypatch.setattr(
         em_module,
         "GromacsEMJob",
         DummyGromacsEMJob,
+    )
+    monkeypatch.setattr(
+        npt_module,
+        "GromacsNPTJob",
+        DummyGromacsNPTJob,
     )
 
 
@@ -109,6 +171,36 @@ inputs:
     )
 
     for filename in ["em.mdp", "input.gro", "topol.top"]:
+        (tmp_path / filename).write_text(
+            "dummy content",
+            encoding="utf-8",
+        )
+
+    return yaml_file
+
+@pytest.fixture
+def demo_npt_project_yaml(tmp_path):
+    """
+    Create a minimal prepared GROMACS NPT project YAML and required input files.
+    """
+    yaml_file = tmp_path / "project_npt.yaml"
+
+    yaml_file.write_text(
+        """
+project:
+  name: prepared_npt
+  type: gromacs
+  job_type: npt
+  mode: prepared
+
+inputs:
+  structure_file: nvt.gro
+  topology_file: topol.top
+""",
+        encoding="utf-8",
+    )
+
+    for filename in ["nvt.gro", "topol.top"]:
         (tmp_path / filename).write_text(
             "dummy content",
             encoding="utf-8",
@@ -320,3 +412,95 @@ def test_cli_rejects_missing_project_yaml(tmp_path):
 
     assert result.exit_code != 0
     assert result.exception is not None
+
+def test_cli_project_yaml_creates_npt_job(demo_npt_project_yaml):
+    """
+    Test YAML-driven NPT CLI mode.
+
+    Expected flow:
+        gromacs -p project_npt.yaml npt
+        -> GromacsProjectSettings
+        -> GromacsNPTJob.from_project_settings()
+    """
+    runner = CliRunner()
+
+    result = runner.invoke(
+        gromacs,
+        [
+            "-p",
+            str(demo_npt_project_yaml),
+            "npt",
+        ],
+        obj={"molecule": None},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert result.exception is None
+
+    captured = DummyGromacsNPTJob.captured_from_settings
+    assert captured
+
+    settings = captured["settings"]
+
+    assert settings.project_name == "prepared_npt"
+    assert settings.workflow == "prepared"
+    assert settings.job_type == "npt"
+
+    assert settings.mdp_file is None
+    assert settings.structure_file == demo_npt_project_yaml.parent / "nvt.gro"
+    assert settings.top_file == demo_npt_project_yaml.parent / "topol.top"
+
+    assert captured["molecule"] is None
+    assert captured["jobrunner"] is None
+
+
+def test_cli_direct_options_create_npt_job(tmp_path):
+    """
+    Test direct NPT CLI option mode.
+
+    Expected flow:
+        gromacs npt --structure nvt.gro --top topol.top
+        -> GromacsNPTJob(...)
+    """
+    runner = CliRunner()
+
+    structure_file = tmp_path / "nvt.gro"
+    top_file = tmp_path / "topol.top"
+
+    for file_path in [structure_file, top_file]:
+        file_path.write_text(
+            "dummy content",
+            encoding="utf-8",
+        )
+
+    result = runner.invoke(
+        gromacs,
+        [
+            "npt",
+            "--structure",
+            str(structure_file),
+            "--top",
+            str(top_file),
+            "--workflow",
+            "prepared",
+        ],
+        obj={"molecule": None},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert result.exception is None
+
+    captured = DummyGromacsNPTJob.captured_direct_init
+    assert captured
+
+    assert captured["label"] == "nvt_npt"
+    assert captured["workflow"] == "prepared"
+
+    assert captured["mdp_file"] is None
+    assert captured["structure_file"] == structure_file
+    assert captured["top_file"] == top_file
+
+    assert captured["itp_files"] == []
+    assert captured["index_file"] is None
+    assert captured["molecule"] is None
+    assert captured["jobrunner"] is None

--- a/tests/test_gromacs_runner.py
+++ b/tests/test_gromacs_runner.py
@@ -1,9 +1,15 @@
 import os
 import subprocess
+from pathlib import Path
 
 import pytest
 
-from chemsmart.jobs.gromacs.job import GromacsEMJob, GromacsNVTJob
+from chemsmart.jobs.gromacs.job import (
+    GromacsEMJob,
+    GromacsNPTJob,
+    GromacsNVTJob,
+)
+
 from chemsmart.jobs.gromacs.runner import GromacsJobRunner
 from chemsmart.settings.executable import GromacsExecutable
 
@@ -26,6 +32,7 @@ def _make_runner(gmx_executable="gmx"):
 def test_gromacs_em_job_type_matches_runner_jobtypes():
     assert GromacsEMJob.TYPE in GromacsJobRunner.JOBTYPES
     assert GromacsNVTJob.TYPE in GromacsJobRunner.JOBTYPES
+    assert GromacsNPTJob.TYPE in GromacsJobRunner.JOBTYPES
 
 
 def test_gromacs_em_job_stores_file_attributes(tmp_path):
@@ -359,7 +366,6 @@ def test_gromacs_runner_get_commands_for_prepared_workflow(tmp_path):
         ],
     ]
 
-
 def test_gromacs_runner_get_commands_for_nvt_prepared_workflow(tmp_path):
     mdp_file = tmp_path / "nvt.mdp"
     structure_file = tmp_path / "em.gro"
@@ -401,7 +407,47 @@ def test_gromacs_runner_get_commands_for_nvt_prepared_workflow(tmp_path):
             str(tmp_path / "nvt"),
         ],
     ]
+def test_gromacs_runner_get_commands_for_npt_prepared_workflow(tmp_path):
+    mdp_file = tmp_path / "npt.mdp"
+    structure_file = tmp_path / "nvt.gro"
+    top_file = tmp_path / "topol.top"
+    tpr_file = tmp_path / "npt.tpr"
 
+    job = GromacsNPTJob(
+        molecule=None,
+        label="npt",
+        jobrunner=None,
+        mdp_file=mdp_file,
+        structure_file=structure_file,
+        top_file=top_file,
+        tpr_file=tpr_file,
+        workflow="prepared",
+    )
+
+    runner = _make_runner()
+
+    commands = runner._get_commands(job)
+
+    assert commands == [
+        [
+            "gmx",
+            "grompp",
+            "-f",
+            str(mdp_file),
+            "-c",
+            str(structure_file),
+            "-p",
+            str(top_file),
+            "-o",
+            str(tpr_file),
+        ],
+        [
+            "gmx",
+            "mdrun",
+            "-deffnm",
+            str(tmp_path / "npt"),
+        ],
+    ]
 
 def test_gromacs_runner_accepts_custom_gmx_executable(tmp_path):
     tpr_file = tmp_path / "em.tpr"
@@ -681,17 +727,6 @@ def test_gromacs_executable_uses_executable_folder(tmp_path):
     executable = GromacsExecutable(executable_folder=tmp_path)
 
     assert executable.get_executable() == os.path.join(str(tmp_path), "gmx")
-
-
-def test_gromacs_executable_from_servername_without_gromacs_section(
-    server_yaml_file,
-):
-    executable = GromacsExecutable.from_servername(server_yaml_file)
-
-    assert executable.get_executable() == "gmx"
-    assert executable.executable_folder is None
-
-
 def test_gromacs_writer_generates_em_mdp_when_missing(tmp_path):
     job = GromacsEMJob(
         molecule=None,
@@ -746,6 +781,36 @@ def test_gromacs_writer_generates_nvt_mdp_when_missing(tmp_path):
     assert "dt" in content
     assert "0.001" in content
 
+def test_gromacs_writer_generates_npt_mdp_when_missing(tmp_path):
+    job = GromacsNPTJob(
+        molecule=None,
+        label="npt",
+        jobrunner=None,
+        mdp_file=None,
+        structure_file=tmp_path / "nvt.gro",
+        top_file=tmp_path / "topol.top",
+        workflow="prepared",
+        temperature=300,
+        pressure=1.0,
+    )
+
+    job.set_folder(str(tmp_path))
+
+    runner = _make_runner()
+    runner._write_input(job)
+
+    assert job.mdp_file == tmp_path / "npt.mdp"
+    assert job.mdp_file.exists()
+
+    content = job.mdp_file.read_text(encoding="utf-8")
+    assert "integrator" in content
+    assert "md" in content
+    assert "pcoupl" in content
+    assert "Parrinello-Rahman" in content
+    assert "ref_p" in content
+    assert "1.0" in content
+    assert "gen_vel" in content
+    assert "no" in content
 
 def test_gromacs_writer_does_not_overwrite_user_mdp(tmp_path):
     mdp_file = tmp_path / "custom.mdp"
@@ -768,12 +833,8 @@ def test_gromacs_writer_does_not_overwrite_user_mdp(tmp_path):
     runner._write_input(job)
 
     assert job.mdp_file == mdp_file
-    assert (
-        mdp_file.read_text(encoding="utf-8")
-        == "integrator = md\n; custom file\n"
-    )
+    assert mdp_file.read_text(encoding="utf-8") == "integrator = md\n; custom file\n"
     assert not (tmp_path / "nvt.mdp").exists()
-
 
 def test_gromacs_prerun_generates_missing_mdp_before_validation(tmp_path):
     structure_file = tmp_path / "em.gro"

--- a/tests/test_gromacs_runner.py
+++ b/tests/test_gromacs_runner.py
@@ -4,7 +4,12 @@ from pathlib import Path
 
 import pytest
 
-from chemsmart.jobs.gromacs.job import GromacsEMJob, GromacsNVTJob
+from chemsmart.jobs.gromacs.job import (
+    GromacsEMJob,
+    GromacsNPTJob,
+    GromacsNVTJob,
+)
+
 from chemsmart.jobs.gromacs.runner import GromacsJobRunner
 from chemsmart.settings.executable import GromacsExecutable
 
@@ -27,6 +32,7 @@ def _make_runner(gmx_executable="gmx"):
 def test_gromacs_em_job_type_matches_runner_jobtypes():
     assert GromacsEMJob.TYPE in GromacsJobRunner.JOBTYPES
     assert GromacsNVTJob.TYPE in GromacsJobRunner.JOBTYPES
+    assert GromacsNPTJob.TYPE in GromacsJobRunner.JOBTYPES
 
 
 def test_gromacs_em_job_stores_file_attributes(tmp_path):
@@ -401,6 +407,47 @@ def test_gromacs_runner_get_commands_for_nvt_prepared_workflow(tmp_path):
             str(tmp_path / "nvt"),
         ],
     ]
+def test_gromacs_runner_get_commands_for_npt_prepared_workflow(tmp_path):
+    mdp_file = tmp_path / "npt.mdp"
+    structure_file = tmp_path / "nvt.gro"
+    top_file = tmp_path / "topol.top"
+    tpr_file = tmp_path / "npt.tpr"
+
+    job = GromacsNPTJob(
+        molecule=None,
+        label="npt",
+        jobrunner=None,
+        mdp_file=mdp_file,
+        structure_file=structure_file,
+        top_file=top_file,
+        tpr_file=tpr_file,
+        workflow="prepared",
+    )
+
+    runner = _make_runner()
+
+    commands = runner._get_commands(job)
+
+    assert commands == [
+        [
+            "gmx",
+            "grompp",
+            "-f",
+            str(mdp_file),
+            "-c",
+            str(structure_file),
+            "-p",
+            str(top_file),
+            "-o",
+            str(tpr_file),
+        ],
+        [
+            "gmx",
+            "mdrun",
+            "-deffnm",
+            str(tmp_path / "npt"),
+        ],
+    ]
 
 def test_gromacs_runner_accepts_custom_gmx_executable(tmp_path):
     tpr_file = tmp_path / "em.tpr"
@@ -733,6 +780,37 @@ def test_gromacs_writer_generates_nvt_mdp_when_missing(tmp_path):
     assert "310" in content
     assert "dt" in content
     assert "0.001" in content
+
+def test_gromacs_writer_generates_npt_mdp_when_missing(tmp_path):
+    job = GromacsNPTJob(
+        molecule=None,
+        label="npt",
+        jobrunner=None,
+        mdp_file=None,
+        structure_file=tmp_path / "nvt.gro",
+        top_file=tmp_path / "topol.top",
+        workflow="prepared",
+        temperature=300,
+        pressure=1.0,
+    )
+
+    job.set_folder(str(tmp_path))
+
+    runner = _make_runner()
+    runner._write_input(job)
+
+    assert job.mdp_file == tmp_path / "npt.mdp"
+    assert job.mdp_file.exists()
+
+    content = job.mdp_file.read_text(encoding="utf-8")
+    assert "integrator" in content
+    assert "md" in content
+    assert "pcoupl" in content
+    assert "Parrinello-Rahman" in content
+    assert "ref_p" in content
+    assert "1.0" in content
+    assert "gen_vel" in content
+    assert "no" in content
 
 def test_gromacs_writer_does_not_overwrite_user_mdp(tmp_path):
     mdp_file = tmp_path / "custom.mdp"


### PR DESCRIPTION
This PR adds GROMACS NPT equilibration support.

Changes:
- Add GromacsNPTJob
- Add `chemsmart run gromacs npt`
- Register NPT job type in CLI/job factories
- Add NPT MDP writer support
- Add tests for NPT command generation and MDP generation

Tests:
- python -m py_compile chemsmart/jobs/gromacs/job.py
- python -m py_compile chemsmart/jobs/gromacs/runner.py
- python -m py_compile chemsmart/jobs/gromacs/writer.py
- python -m py_compile chemsmart/settings/gromacs.py
- python -m pytest tests/test_gromacs_runner.py tests/test_gromacs_settings.py -q

Result:
46 passed