### PR TITLE
fix(orca): preserve jobrunner for inp submissions

### DIFF
--- a/chemsmart/cli/orca/inp.py
+++ b/chemsmart/cli/orca/inp.py
@@ -33,12 +33,16 @@ def inp(ctx, skip_completed, **kwargs):
     Only requires the file that is to be run.
     """
     filename = ctx.obj["filename"]
+    jobrunner = ctx.obj.get("jobrunner")
     logger.info(f"Creating ORCA input job from file: {filename}")
 
     from chemsmart.jobs.orca.job import ORCAInpJob
 
     job = ORCAInpJob.from_filename(
-        filename=filename, skip_completed=skip_completed, **kwargs
+        filename=filename,
+        jobrunner=jobrunner,
+        skip_completed=skip_completed,
+        **kwargs,
     )
     logger.debug(f"Created ORCA input job: {job}")
     return job


### PR DESCRIPTION
## Summary

Fix ORCA `inp` submissions so they preserve the job runner configured by the parent CLI command.

## Problem

Running a command such as:

```bash
chemsmart sub -s cu --delete-scratch orca -f input.inp -p test inp
could ignore the explicitly selected server and its ORCA scratch configuration. During job creation, ORCAInpJob.from_filename() created a new runner without the parent CLI context, causing it to fall back to Server.current() and potentially use an invalid user-level scratch directory.
Fix
Pass the parent CLI job runner from ctx.obj to ORCAInpJob.from_filename().
This preserves:
The server selected with -s / --server
Scratch configuration from the selected server
Other job runner options provided by the parent command
Scope
This change only affects the ORCA inp CLI command. No other job types or scratch resolution logic were modified.