### PR TITLE
Standard name

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -155,16 +155,6 @@ jobs:
             htmlcov/**
           if-no-files-found: ignore
 
-      - name: Upload coverage to Codecov
-        if: >
-          steps.changed-files.outputs.only_changed != 'true' &&
-          hashFiles('coverage.xml') != ''
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: coverage.xml
-          fail_ci_if_error: true
-
       - name: Create coverage report
         if: >
           github.event_name == 'pull_request' &&
@@ -175,6 +165,16 @@ jobs:
         with:
           coverageFile: coverage.xml
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload coverage to Codecov
+        if: >
+          steps.changed-files.outputs.only_changed != 'true' &&
+          hashFiles('coverage.xml') != ''
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.xml
+          fail_ci_if_error: true
 
   tests_mac:
     needs: [pre-commit, build]

--- a/Makefile
+++ b/Makefile
@@ -215,7 +215,7 @@ endif
 test: lint coverage-clean ## Run tests and generate terminal, XML, and HTML coverage reports.
 	$(ENV_PREFIX)pytest \
 		-v \
-		--cov-config=.coveragerc \
+                --cov-config=pyproject.toml \
 		--cov=chemsmart \
 		--cov-branch \
 		--cov-report=term-missing \

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
 ---
-# chemsmart - Chemistry Simulation and Modeling Automation Toolkit
+# CHEMSMART - Chemistry Simulation and Modeling Automation Toolkit
 
 [![codecov](https://codecov.io/gh/xinglong-zhang/chemsmart/graph/badge.svg?token=L01DRALL5E)](https://codecov.io/gh/xinglong-zhang/chemsmart)
 [![CI](https://github.com/xinglong-zhang/chemsmart/actions/workflows/main.yml/badge.svg)](https://github.com/xinglong-zhang/chemsmart/actions/workflows/main.yml)
@@ -13,7 +13,7 @@
 ---
 Notice: If you have cloned this package before and find something that did not work, updating this repo via `git pull` will likely fix it. If you need additional features, please do not hesitate to get in touch!
 
-Chemsmart is a Python-based toolkit for the automatic creation of input and submission script files, the submission and the analysis of quantum chemistry simulation jobs.
+CHEMSMART is a Python-based toolkit for the automatic creation of input and submission script files, the submission and the analysis of quantum chemistry simulation jobs.
 
 It uses the same submission command regardless of the queueing systems (SLURM, Torque or SLF) used by any High Performance Computing (HPC) cluster. 
 

--- a/chemsmart/jobs/runner.py
+++ b/chemsmart/jobs/runner.py
@@ -11,10 +11,10 @@ from typing import Callable, Optional, Sequence
 
 from chemsmart.jobs.job import Job
 from chemsmart.settings.server import Server
-from chemsmart.settings.user import ChemsmartUserSettings
+from chemsmart.settings.user import CHEMSMARTUserSettings
 from chemsmart.utils.mixins import RegistryMixin
 
-user_settings = ChemsmartUserSettings()
+user_settings = CHEMSMARTUserSettings()
 
 
 logger = logging.getLogger(__name__)

--- a/chemsmart/scripts/get_thermochemistry.py
+++ b/chemsmart/scripts/get_thermochemistry.py
@@ -224,7 +224,7 @@ def entry_point(
             logger.error("Try 'get_thermochemistry.py --help' for help.")
             return
 
-    # Display ChemSmart ASCII banner
+    # Display CHEMSMART ASCII banner
     logger.info("\n")
     logger.info(
         "   "

--- a/chemsmart/settings/executable.py
+++ b/chemsmart/settings/executable.py
@@ -3,11 +3,11 @@ import os.path
 from typing import Optional
 
 from chemsmart.io.yaml import YAMLFile
-from chemsmart.settings.user import ChemsmartUserSettings
+from chemsmart.settings.user import CHEMSMARTUserSettings
 from chemsmart.utils.mixins import RegistryMixin
 from chemsmart.utils.utils import strip_out_comments
 
-user_settings = ChemsmartUserSettings()
+user_settings = CHEMSMARTUserSettings()
 
 logger = logging.getLogger(__name__)
 

--- a/chemsmart/settings/gaussian.py
+++ b/chemsmart/settings/gaussian.py
@@ -7,10 +7,10 @@ from chemsmart.jobs.gaussian.settings import (
     GaussianQMMMJobSettings,
     GaussianTDDFTJobSettings,
 )
-from chemsmart.settings.user import ChemsmartUserSettings
+from chemsmart.settings.user import CHEMSMARTUserSettings
 from chemsmart.utils.mixins import RegistryMixin
 
-user_settings = ChemsmartUserSettings()
+user_settings = CHEMSMARTUserSettings()
 
 logger = logging.getLogger(__name__)
 project_settings_registry: list[str] = []
@@ -238,7 +238,7 @@ class GaussianProjectSettings(RegistryMixin):
             settings instance if found, None otherwise.
         """
         project_name_yaml_path = os.path.join(
-            ChemsmartUserSettings().user_gaussian_settings_dir,
+            CHEMSMARTUserSettings().user_gaussian_settings_dir,
             f"{project_name}.yaml",
         )
         user_settings_manager = GaussianProjectSettingsManager(

--- a/chemsmart/settings/orca.py
+++ b/chemsmart/settings/orca.py
@@ -8,10 +8,10 @@ from chemsmart.jobs.orca.settings import (
     ORCAQMMMJobSettings,
     ORCATSJobSettings,
 )
-from chemsmart.settings.user import ChemsmartUserSettings
+from chemsmart.settings.user import CHEMSMARTUserSettings
 from chemsmart.utils.mixins import RegistryMixin
 
-user_settings = ChemsmartUserSettings()
+user_settings = CHEMSMARTUserSettings()
 
 
 logger = logging.getLogger(__name__)
@@ -295,7 +295,7 @@ class ORCAProjectSettings(RegistryMixin):
             loaded settings or None if not found.
         """
         project_name_yaml_path = os.path.join(
-            ChemsmartUserSettings().user_orca_settings_dir,
+            CHEMSMARTUserSettings().user_orca_settings_dir,
             f"{project_name}.yaml",
         )
         user_settings_manager = ORCAProjectSettingsManager(

--- a/chemsmart/settings/server.py
+++ b/chemsmart/settings/server.py
@@ -7,10 +7,10 @@ from functools import lru_cache
 
 from chemsmart.io.yaml import YAMLFile
 from chemsmart.settings.submitters import Submitter
-from chemsmart.settings.user import ChemsmartUserSettings
+from chemsmart.settings.user import CHEMSMARTUserSettings
 from chemsmart.utils.mixins import RegistryMixin, cached_property
 
-user_settings = ChemsmartUserSettings()
+user_settings = CHEMSMARTUserSettings()
 
 logger = logging.getLogger(__name__)
 

--- a/chemsmart/settings/submitters.py
+++ b/chemsmart/settings/submitters.py
@@ -8,10 +8,10 @@ from chemsmart.settings.executable import (
     NCIPLOTExecutable,
     ORCAExecutable,
 )
-from chemsmart.settings.user import ChemsmartUserSettings
+from chemsmart.settings.user import CHEMSMARTUserSettings
 from chemsmart.utils.mixins import RegistryMixin
 
-user_settings = ChemsmartUserSettings()
+user_settings = CHEMSMARTUserSettings()
 
 
 logger = logging.getLogger(__name__)

--- a/chemsmart/settings/user.py
+++ b/chemsmart/settings/user.py
@@ -10,7 +10,7 @@ for computational chemistry software
 Manages the ~/.chemsmart user configuration directory and associated files.
 
 Classes:
-    ChemsmartUserSettings: Main class for user configuration management
+    CHEMSMARTUserSettings: Main class for user configuration management
 
 Dependencies:
     - chemsmart.io.yaml: YAML file handling utilities
@@ -36,7 +36,7 @@ from chemsmart.io.yaml import YAMLFile
 logger = logging.getLogger(__name__)
 
 
-class ChemsmartUserSettings:
+class CHEMSMARTUserSettings:
     """
     User configuration settings manager for CHEMSMART.
 

--- a/chemsmart/settings/user.py
+++ b/chemsmart/settings/user.py
@@ -1,5 +1,5 @@
 """
-User configuration management for ChemSmart computational chemistry software.
+User configuration management for CHEMSMART computational chemistry software.
 
 This module provides comprehensive user
 settings management including configuration
@@ -38,7 +38,7 @@ logger = logging.getLogger(__name__)
 
 class ChemsmartUserSettings:
     """
-    User configuration settings manager for ChemSmart.
+    User configuration settings manager for CHEMSMART.
 
     Manages user-specific configuration files, directories, and settings for
     computational chemistry software. Provides access to configuration paths,

--- a/chemsmart/utils/cli.py
+++ b/chemsmart/utils/cli.py
@@ -1,7 +1,7 @@
 """
-CLI utilities for ChemSmart.
+CLI utilities for CHEMSMART.
 
-Provides helpers and Click integrations used by the ChemSmart command line
+Provides helpers and Click integrations used by the CHEMSMART command line
 tools, including:
 
 - Custom Click `Group`/`Command` that persist subcommand metadata on the

--- a/chemsmart/utils/cluster.py
+++ b/chemsmart/utils/cluster.py
@@ -2,7 +2,7 @@
 Cluster utilities for job monitoring and connectivity checks.
 
 Helpers for interacting with common HPC schedulers and network services
-used by ChemSmart workflows. Currently supports SLURM (via `squeue`/`sacct`)
+used by CHEMSMART workflows. Currently supports SLURM (via `squeue`/`sacct`)
 and PBS/Torque (via `qstat`) to discover running Gaussian jobs, along with a
 simple PubChem reachability check.
 

--- a/chemsmart/utils/logger.py
+++ b/chemsmart/utils/logger.py
@@ -1,5 +1,5 @@
 """
-Logging utilities for ChemSmart applications.
+Logging utilities for CHEMSMART applications.
 
 Provides customized logging functionality with deduplication capabilities
 and configurable output streams. Supports both file and console logging

--- a/chemsmart/utils/periodictable.py
+++ b/chemsmart/utils/periodictable.py
@@ -3,7 +3,7 @@ Periodic table utilities for element properties and conversions.
 
 Provides a comprehensive interface for accessing element data including
 atomic numbers, masses, radii, and isotope information. Integrates with
-ASE data sources and ChemSmart isotope data for complete element handling.
+ASE data sources and CHEMSMART isotope data for complete element handling.
 """
 
 import re

--- a/chemsmart/utils/references.py
+++ b/chemsmart/utils/references.py
@@ -2,7 +2,7 @@
 Reference strings and citations for computational chemistry methods.
 
 Contains formatted reference strings for various thermochemistry and
-quantum chemistry methods used in ChemSmart. Includes citations for
+quantum chemistry methods used in CHEMSMART. Includes citations for
 QRRHO approximations, damping functions, and entropy calculations.
 """
 

--- a/docs/source/gaussian-qmmm-jobs.rst
+++ b/docs/source/gaussian-qmmm-jobs.rst
@@ -5,7 +5,7 @@ contact our team if you have questions or feedback.
  Gaussian QM/MM ONIOM Calculations Guide
 #########################################
 
-ChemSmart provides comprehensive tools for multiscale QM/MM calculations using Gaussian's ONIOM (Our own N-layered
+CHEMSMART provides comprehensive tools for multiscale QM/MM calculations using Gaussian's ONIOM (Our own N-layered
 Integrated molecular Orbital and molecular Mechanics) methodology. This section covers various QM/MM schemes for
 accurate treatment of large molecular systems including enzymes, organometallic complexes, and materials.
 
@@ -14,7 +14,7 @@ accurate treatment of large molecular systems including enzymes, organometallic 
 **********
 
 Gaussian ONIOM calculations enable efficient treatment of large molecular systems by partitioning them into multiple
-layers with different levels of theory. ChemSmart supports flexible ONIOM calculation setups:
+layers with different levels of theory. CHEMSMART supports flexible ONIOM calculation setups:
 
 **2-Layer ONIOM**: High(QM):Low(MM) - **High level**: Quantum mechanics (DFT, ab initio, MP2, etc.) - **Low level**:
 Molecular mechanics force fields (AMBER, UFF, DREIDING)
@@ -456,4 +456,4 @@ Common Issues and Solutions
    -  Consider semi-empirical methods for large QM2 regions
    -  Balance QM region size with computational resources
 
-For additional support and examples, see the ChemSmart community forums and documentation repository.
+For additional support and examples, see the CHEMSMART community forums and documentation repository.

--- a/docs/source/gaussian_submitqmmmjobs.rst
+++ b/docs/source/gaussian_submitqmmmjobs.rst
@@ -5,7 +5,7 @@ contact our team if you have questions or feedback.
  Gaussian QM/MM ONIOM Calculations Guide
 #########################################
 
-ChemSmart provides comprehensive tools for multiscale QM/MM calculations using Gaussian's ONIOM (Our own N-layered
+CHEMSMART provides comprehensive tools for multiscale QM/MM calculations using Gaussian's ONIOM (Our own N-layered
 Integrated molecular Orbital and molecular Mechanics) methodology. This section covers various QM/MM schemes for
 accurate treatment of large molecular systems including enzymes, organometallic complexes, and materials.
 
@@ -14,7 +14,7 @@ accurate treatment of large molecular systems including enzymes, organometallic 
 **********
 
 Gaussian ONIOM calculations enable efficient treatment of large molecular systems by partitioning them into multiple
-layers with different levels of theory. ChemSmart supports flexible ONIOM calculation setups:
+layers with different levels of theory. CHEMSMART supports flexible ONIOM calculation setups:
 
 **2-Layer ONIOM**: High(QM):Low(MM) - **High level**: Quantum mechanics (DFT, ab initio, MP2, etc.) - **Low level**:
 Molecular mechanics force fields (AMBER, UFF, DREIDING)

--- a/docs/source/grouper-cli-options.rst
+++ b/docs/source/grouper-cli-options.rst
@@ -258,7 +258,7 @@ For Gaussian and ORCA output files, the program can extract various types of ene
 
 .. note::
 
-   For Gaussian or ORCA output files, if the energy cannot be extracted correctly, ChemSmart will skip that molecule.
+   For Gaussian or ORCA output files, if the energy cannot be extracted correctly, CHEMSMART will skip that molecule.
    The XYZ file will still be saved, but it cannot be used with the energy grouper strategy.
 
 Supported energy types:

--- a/docs/source/molecule-input-formats.rst
+++ b/docs/source/molecule-input-formats.rst
@@ -192,10 +192,10 @@ For full details on organometallic complex support and its restrictions, see :do
  Molecular Databases
 *********************
 
-Chemsmart Database Files (.db)
+CHEMSMART Database Files (.db)
 ==============================
 
-Chemsmart ``.db`` files are produced by the database workflow, typically with ``chemsmart run database assemble`` (see
+CHEMSMART ``.db`` files are produced by the database workflow, typically with ``chemsmart run database assemble`` (see
 :doc:`database-assemble`). When a chemsmart database is used as molecular input, chemsmart first selects the requested
 record, molecule, or structure, then passes the selected geometry, charge, and multiplicity to Gaussian, ORCA, or PyMOL
 (see :doc:`database-workflow`).
@@ -379,7 +379,7 @@ CHEMSMART automatically detects file formats based on extensions:
 -  ``.inp`` → ORCA input
 -  ``.out`` → ORCA/Gaussian output (auto-detected by reading file header)
 -  ``.cdx``, ``.cdxml`` → ChemDraw format
--  ``.db`` → Chemsmart/ASE database (auto-detected by validating the database schema)
+-  ``.db`` → CHEMSMART/ASE database (auto-detected by validating the database schema)
 -  ``.traj`` → ASE trajectory
 
 .. note::

--- a/docs/source/orca-multiscale-calculations.rst
+++ b/docs/source/orca-multiscale-calculations.rst
@@ -5,7 +5,7 @@ contact our team if you have questions or feedback.
  ORCA QM/MM Multiscale Calculations Guide
 ##########################################
 
-ChemSmart provides comprehensive tools for multiscale QM/MM calculations using ORCA. This section covers various QM/MM
+CHEMSMART provides comprehensive tools for multiscale QM/MM calculations using ORCA. This section covers various QM/MM
 schemes including additive, subtractive ONIOM, and crystal QM/MM methods for large molecular systems.
 
 **********
@@ -13,7 +13,7 @@ schemes including additive, subtractive ONIOM, and crystal QM/MM methods for lar
 **********
 
 ORCA QM/MM calculations allow you to treat large systems by combining quantum mechanical (QM) methods for chemically
-important regions with molecular mechanical (MM) force fields for the environment. ChemSmart supports five types of
+important regions with molecular mechanical (MM) force fields for the environment. CHEMSMART supports five types of
 multiscale calculations:
 
 #. **Additive QM/MM** - Traditional QM/MM with electrostatic embedding
@@ -849,4 +849,4 @@ Common Issues and Solutions
    -  Balance QM region size with available computational resources
    -  Use mechanical embedding for very large systems to reduce computational cost
 
-For additional support and examples, see the ChemSmart community forums and documentation repository.
+For additional support and examples, see the CHEMSMART community forums and documentation repository.

--- a/docs/source/orca_submitqmmmjobs.rst
+++ b/docs/source/orca_submitqmmmjobs.rst
@@ -5,7 +5,7 @@ contact our team if you have questions or feedback.
  ORCA QM/MM Multiscale Calculations Guide
 ##########################################
 
-ChemSmart provides comprehensive tools for multiscale QM/MM calculations using ORCA. This section covers various QM/MM
+CHEMSMART provides comprehensive tools for multiscale QM/MM calculations using ORCA. This section covers various QM/MM
 schemes including additive, subtractive ONIOM, and crystal QM/MM methods for large molecular systems.
 
 **********
@@ -13,7 +13,7 @@ schemes including additive, subtractive ONIOM, and crystal QM/MM methods for lar
 **********
 
 ORCA QM/MM calculations allow you to treat large systems by combining quantum mechanical (QM) methods for chemically
-important regions with molecular mechanical (MM) force fields for the environment. ChemSmart supports five types of
+important regions with molecular mechanical (MM) force fields for the environment. CHEMSMART supports five types of
 multiscale calculations:
 
 #. **Additive QM/MM** - Traditional QM/MM with electrostatic embedding

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -371,14 +371,14 @@ def chemsmart_templates_config(mocker):
 
     # Patch the Class attribute
     mocker.patch(
-        "chemsmart.settings.user.ChemsmartUserSettings.USER_CONFIG_DIR",
+        "chemsmart.settings.user.CHEMSMARTUserSettings.USER_CONFIG_DIR",
         str(template_dir),
     )
 
     # Patch the global instance in runner.py
-    from chemsmart.settings.user import ChemsmartUserSettings
+    from chemsmart.settings.user import CHEMSMARTUserSettings
 
-    new_settings = ChemsmartUserSettings()
+    new_settings = CHEMSMARTUserSettings()
     mocker.patch("chemsmart.jobs.runner.user_settings", new_settings)
     # Patch other module-level user_settings singletons used by the CLI path
     mocker.patch("chemsmart.settings.server.user_settings", new_settings)

--- a/tests/data/IterateTests/configs/iterate_template.toml
+++ b/tests/data/IterateTests/configs/iterate_template.toml
@@ -1,4 +1,4 @@
-# Chemsmart Iterate Configuration Template
+# CHEMSMART Iterate Configuration Template
 # =========================================
 # This template defines skeletons and
 # substituents for iterative structure generation.


### PR DESCRIPTION
Standardize program name as `CHEMSMART` and command as `chemsmart` - leave `CHANGELOG.md` untouched.