### PR TITLE
Fix: turn off conda auto-update for Windows CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -283,7 +283,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
           environment-file: environment.yml
           activate-environment: chemsmart
-          channels: conda-forge,defaults
+          channels: defaults,conda-forge
+          channel-priority: strict
 
       - name: Show conda version
         if: steps.changed-files.outputs.only_changed != 'true'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -285,6 +285,14 @@ jobs:
           activate-environment: chemsmart
           channels: conda-forge,defaults
 
+      - name: Show conda version
+        if: steps.changed-files.outputs.only_changed != 'true'
+        shell: cmd
+        run: |
+          call "%CONDA%\Scripts\activate.bat" chemsmart
+          conda --version
+          conda info
+
       - name: Install make
         if: steps.changed-files.outputs.only_changed != 'true'
         shell: cmd

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -278,7 +278,8 @@ jobs:
         if: steps.changed-files.outputs.only_changed != 'true'
         uses: conda-incubator/setup-miniconda@v3
         with:
-          auto-update-conda: true
+          miniconda-version: "latest"
+          auto-update-conda: false
           python-version: ${{ matrix.python-version }}
           environment-file: environment.yml
           activate-environment: chemsmart


### PR DESCRIPTION
Issue #613 occurs because updating Conda on Windows rewrites `conda.bat` while the script is actively executing. On Linux and macOS, this isn't an issue because the shell handles active scripts differently, preventing the file corruption that happens when packages are replaced on Windows. More details are available in [Conda Issue #14322](https://github.com/conda/conda/issues/14322).

To work around this and use the latest version of Conda on Windows, we can install a fresh instance of the latest Miniconda and disable auto-updates. A `Show conda version` step has been added to the workflow to confirm the latest Miniconda is successfully installed, as verified in this [CI run log](https://github.com/liu-jing-yi/chemsmart/actions/runs/29649265599/job/88092996011):
<img width="450" height="101" alt="image" src="https://github.com/user-attachments/assets/0272d440-dda1-4064-a2d8-b86083cdf013" />

