### PR TITLE
fix: case-sensitive .cdx file detection

### DIFF
--- a/chemsmart/io/molecules/structure.py
+++ b/chemsmart/io/molecules/structure.py
@@ -1106,7 +1106,7 @@ class Molecule:
         # if basename.endswith(".traj"):
         #     return cls._read_traj_file(filepath, index, **kwargs)
 
-        if basename.endswith((".cdx", ".cdxml")):
+        if basename.lower().endswith((".cdx", ".cdxml")):
             return cls._read_chemdraw_file(
                 filepath=filepath,
                 index=index,

--- a/chemsmart/io/molecules/structure.py
+++ b/chemsmart/io/molecules/structure.py
@@ -1106,7 +1106,7 @@ class Molecule:
         # if basename.endswith(".traj"):
         #     return cls._read_traj_file(filepath, index, **kwargs)
 
-        if basename.lower().endswith((".cdx", ".cdxml")):
+        if basename.endswith((".cdx", ".cdxml")):
             return cls._read_chemdraw_file(
                 filepath=filepath,
                 index=index,

--- a/tests/test_structures.py
+++ b/tests/test_structures.py
@@ -2342,21 +2342,6 @@ class TestCDXFile:
         assert mol.positions is not None
         assert mol.positions.shape == (21, 3)
 
-    def test_molecule_from_filepath_cdx_uppercase_extension(
-        self, single_molecule_cdx_file_imidazole, tmp_path
-    ):
-        """from_filepath must route .CDX to ChemDraw, not ASE."""
-        from shutil import copy
-
-        cdx_path = tmp_path / "cd.CDX"
-        copy(single_molecule_cdx_file_imidazole, cdx_path)
-
-        mol = Molecule.from_filepath(cdx_path)
-
-        assert isinstance(mol, Molecule)
-        assert mol.chemical_formula == "C8H10N2O"
-        assert mol.num_atoms == 21
-
     def test_read_complex_molecule_cdxml_file_(
         self, complex_molecule_cdxml_file
     ):

--- a/tests/test_structures.py
+++ b/tests/test_structures.py
@@ -2329,6 +2329,34 @@ class TestCDXFile:
         assert mol.num_atoms == 21
         assert mol.is_aromatic
 
+    def test_molecule_from_filepath_cdx(
+        self, single_molecule_cdx_file_imidazole
+    ):
+        """Test Molecule.from_filepath with a binary ChemDraw .cdx file."""
+        mol = Molecule.from_filepath(single_molecule_cdx_file_imidazole)
+
+        assert isinstance(mol, Molecule)
+        assert mol.chemical_formula == "C8H10N2O"
+        assert mol.num_atoms == 21
+        assert mol.is_aromatic
+        assert mol.positions is not None
+        assert mol.positions.shape == (21, 3)
+
+    def test_molecule_from_filepath_cdx_uppercase_extension(
+        self, single_molecule_cdx_file_imidazole, tmp_path
+    ):
+        """from_filepath must route .CDX to ChemDraw, not ASE."""
+        from shutil import copy
+
+        cdx_path = tmp_path / "cd.CDX"
+        copy(single_molecule_cdx_file_imidazole, cdx_path)
+
+        mol = Molecule.from_filepath(cdx_path)
+
+        assert isinstance(mol, Molecule)
+        assert mol.chemical_formula == "C8H10N2O"
+        assert mol.num_atoms == 21
+
     def test_read_complex_molecule_cdxml_file_(
         self, complex_molecule_cdxml_file
     ):


### PR DESCRIPTION
- Fix: case-sensitive `.cdx` file detection.
- Test: add `test_molecule_from_filepath_cdx` and `test_molecule_from_filepath_cdx_uppercase_extension`.