### PR TITLE
Revert "show grouper RTD"

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -113,17 +113,24 @@ chemistry software.
    pymol-electronic-structure
    pymol-interaction-analysis
 
+..
    .. toctree::
 
+..
    :maxdepth: 2
 
+..
    :caption: Grouper Tool
 
+..
 
+..
    grouper-cli-options
 
+..
    grouper-strategies
 
+..
    grouper-crest-or-traj-workflow
 
 .. toctree::


### PR DESCRIPTION
This reverts commit 2fcc6d915be75fb57a20fefcdeae1f3eb0e9c55b. Many tests are failing even though only RTD docs/source/index.rst file is modified.