### PR TITLE
fix(sub): preserve server resource overrides during submission

### DIFF
--- a/chemsmart/cli/sub.py
+++ b/chemsmart/cli/sub.py
@@ -81,7 +81,7 @@ def sub(
     logger.info("Entering main program")
 
     # Resolve one shared Server instance for both JobRunner and Submitter.
-    server = Server.from_servername(server)
+    server = Server.current() if server is None else Server.from_servername(server)
     if time_hours is not None:
         server.num_hours = time_hours
     if queue is not None:

--- a/chemsmart/cli/sub.py
+++ b/chemsmart/cli/sub.py
@@ -80,13 +80,18 @@ def sub(
         create_logger(debug=debug, stream=stream)
     logger.info("Entering main program")
 
-    # Instantiate the jobrunner with CLI options
-    if server is not None:
-        server = Server.from_servername(server)
-        if time_hours is not None:
-            server.num_hours = time_hours
-        if queue is not None:
-            server.queue_name = queue
+    # Resolve one shared Server instance for both JobRunner and Submitter.
+    server = Server.from_servername(server)
+    if time_hours is not None:
+        server.num_hours = time_hours
+    if queue is not None:
+        server.queue_name = queue
+    if num_cores is not None:
+        server.kwargs["NUM_CORES"] = num_cores
+    if num_gpus is not None:
+        server.kwargs["NUM_GPUS"] = num_gpus
+    if mem_gb is not None:
+        server.kwargs["MEM_GB"] = mem_gb
 
     jobrunner = JobRunner(
         server=server,
@@ -317,8 +322,11 @@ def process_pipeline(ctx, *args, **kwargs):  # noqa: PLR0915
 
         cli_args = _reconstruct_cli_args(ctx, job)
 
-        server = Server.from_servername(kwargs.get("server"))
-        server.submit(job=job, test=kwargs.get("test"), cli_args=cli_args)
+        jobrunner.server.submit(
+            job=job,
+            test=kwargs.get("test"),
+            cli_args=cli_args,
+        )
 
     ctx = _clean_command(ctx)
     jobrunner = ctx.obj["jobrunner"]

--- a/chemsmart/cli/sub.py
+++ b/chemsmart/cli/sub.py
@@ -81,7 +81,9 @@ def sub(
     logger.info("Entering main program")
 
     # Resolve one shared Server instance for both JobRunner and Submitter.
-    server = Server.current() if server is None else Server.from_servername(server)
+    server = (
+        Server.current() if server is None else Server.from_servername(server)
+    )
     if time_hours is not None:
         server.num_hours = time_hours
     if queue is not None:

--- a/tests/test_jobrunner.py
+++ b/tests/test_jobrunner.py
@@ -299,6 +299,8 @@ class TestSubResourceOverrides:
             NUM_CORES=2,
             NUM_GPUS=0,
             MEM_GB=8,
+            NUM_HOURS=1,
+            QUEUE_NAME="normal",
         )
         captured = {}
 
@@ -308,6 +310,8 @@ class TestSubResourceOverrides:
                 num_cores=self.num_cores,
                 num_gpus=self.num_gpus,
                 mem_gb=self.mem_gb,
+                num_hours=self.num_hours,
+                queue_name=self.queue_name,
             )
 
         monkeypatch.setattr(
@@ -336,6 +340,10 @@ class TestSubResourceOverrides:
                 "2",
                 "--mem-gb",
                 "23",
+                "--time-hours",
+                "12.5",
+                "--queue",
+                "debug",
                 "gaussian",
                 "-p",
                 "test",
@@ -354,6 +362,8 @@ class TestSubResourceOverrides:
         assert captured["num_cores"] == 7
         assert captured["num_gpus"] == 2
         assert captured["mem_gb"] == 23
+        assert captured["num_hours"] == 12.5
+        assert captured["queue_name"] == "debug"
 
 
 def _write_server_yaml(path, *, gaussian_scratch, orca_scratch):

--- a/tests/test_jobrunner.py
+++ b/tests/test_jobrunner.py
@@ -284,6 +284,78 @@ class TestScratchCLI:
         assert "--scratch" not in captured["cli_args"]
 
 
+class TestSubResourceOverrides:
+    def test_cli_resources_reach_submission_server(
+        self,
+        monkeypatch,
+        single_molecule_xyz_file,
+        gaussian_project_config_dir,
+    ):
+        monkeypatch.setenv(
+            "CHEMSMART_CONFIG_DIR", str(gaussian_project_config_dir)
+        )
+        fake_server = Server(
+            name="dummy",
+            NUM_CORES=2,
+            NUM_GPUS=0,
+            MEM_GB=8,
+        )
+        captured = {}
+
+        def _capture_script(self, job, cli_args, **kwargs):
+            captured.update(
+                server=self,
+                num_cores=self.num_cores,
+                num_gpus=self.num_gpus,
+                mem_gb=self.mem_gb,
+            )
+
+        monkeypatch.setattr(
+            Server,
+            "_check_running_jobs",
+            lambda self, job: None,
+        )
+        monkeypatch.setattr(
+            Server,
+            "_write_submission_script",
+            _capture_script,
+        )
+        monkeypatch.setattr(
+            Server,
+            "current",
+            classmethod(lambda cls: fake_server),
+        )
+
+        result = CliRunner().invoke(
+            sub,
+            [
+                "--test",
+                "--num-cores",
+                "7",
+                "--num-gpus",
+                "2",
+                "--mem-gb",
+                "23",
+                "gaussian",
+                "-p",
+                "test",
+                "-f",
+                single_molecule_xyz_file,
+                "-c",
+                "0",
+                "-m",
+                "1",
+                "opt",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert captured["server"] is fake_server
+        assert captured["num_cores"] == 7
+        assert captured["num_gpus"] == 2
+        assert captured["mem_gb"] == 23
+
+
 def _write_server_yaml(path, *, gaussian_scratch, orca_scratch):
     """Write a minimal server YAML with optional program SCRATCH keys."""
     gaussian_line = (


### PR DESCRIPTION
Previously, chemsmart/cli/sub.py resolved the submission Server in two different locations:

- sub() at the old line 85 configured a Server only when --server was explicitly provided.
- process_pipeline()._process_single_job() at the old line 320 resolved the Server again immediately before submission.

For an explicit server, the second lookup could return a different instance and lose the walltime or queue changes applied by sub(). For the default cached server, CLI resource values were stored on JobRunner without updating the Server used by Submitter. Generated scheduler scripts could therefore ignore CLI overrides for CPU, GPU, or memory.

The updated implementation resolves and configures the Server once in chemsmart/cli/sub.py:84-94, passes that instance to JobRunner, and submits through jobrunner.server in chemsmart/cli/sub.py:325-329. JobRunner and Submitter now share the same configured Server instance and use consistent resource values.

Refs #632