### PR TITLE
Add GROMACS smart presets

### DIFF
--- a/chemsmart/cli/gromacs/factory.py
+++ b/chemsmart/cli/gromacs/factory.py
@@ -1,24 +1,40 @@
-from chemsmart.jobs.gromacs.job import GromacsEMJob, GromacsNVTJob
+from chemsmart.jobs.gromacs.job import (
+    GromacsEMJob,
+    GromacsNVTJob,
+    GromacsNPTJob,
+    GromacsMDJob,
+)
 from chemsmart.settings.gromacs import GromacsProjectSettings
 
 
 class GromacsJobFactory:
     """
-    Factory for creating GROMACS jobs from project YAML or settings
+    Create concrete GROMACS job objects from settings or project YAML files.
     """
 
     JOB_TYPE_MAP = {
         "em": GromacsEMJob,
         "nvt": GromacsNVTJob,
+        "npt": GromacsNPTJob,
+        "md": GromacsMDJob,
     }
 
     @classmethod
     def create_from_project_yaml(
-        cls, project_yaml, molecule=None, label=None, jobrunner=None, **kwargs
+        cls,
+        project_yaml,
+        molecule=None,
+        label=None,
+        jobrunner=None,
+        **kwargs,
     ):
+        """
+        Create a GROMACS job from a project YAML file.
+        """
         settings = GromacsProjectSettings.from_yaml(project_yaml)
+
         return cls.create_from_settings(
-            settings,
+            settings=settings,
             molecule=molecule,
             label=label,
             jobrunner=jobrunner,
@@ -34,12 +50,18 @@ class GromacsJobFactory:
         jobrunner=None,
         **kwargs,
     ):
+        """
+        Create a GROMACS job from GromacsProjectSettings.
+        """
         settings.validate()
+
         job_cls = cls.JOB_TYPE_MAP.get(settings.job_type)
+
         if job_cls is None:
             raise ValueError(
                 f"Unsupported GROMACS job type: {settings.job_type}"
             )
+
         return job_cls.from_project_settings(
             settings=settings,
             molecule=molecule,

--- a/chemsmart/cli/gromacs/gromacs.py
+++ b/chemsmart/cli/gromacs/gromacs.py
@@ -6,7 +6,7 @@ This module provides the main CLI group for GROMACS workflows.
 The group-level responsibility is intentionally small:
 1. collect project / input options;
 2. load GromacsProjectSettings when a project YAML is provided;
-3. store shared values in ctx.obj for leaf commands such as em.
+3. store shared values in ctx.obj for leaf commands such as em, nvt, npt, and md.
 """
 
 import functools
@@ -63,7 +63,7 @@ def _load_project_settings(project=None, project_yaml=None):
     """
     Load GROMACS project settings from CLI project options.
 
-    project_yaml has priority because click already validates that it exists.
+    project_YAML has priority because click already validates that it exists.
     project is kept for compatibility with ChemSmart-style -p/--project usage.
     """
     if project_yaml is not None:
@@ -123,3 +123,18 @@ def gromacs_process_pipeline(ctx, *args, **kwargs):
     )
 
     return args[0] if args else None
+
+
+def _register_subcommands():
+    """
+    Import GROMACS leaf-command modules so Click registers their commands.
+    """
+    import importlib
+
+    for module_name in ("em", "nvt", "npt", "md"):
+        importlib.import_module(
+            f"chemsmart.cli.gromacs.{module_name}"
+        )
+
+
+_register_subcommands()

--- a/chemsmart/cli/gromacs/md.py
+++ b/chemsmart/cli/gromacs/md.py
@@ -1,0 +1,187 @@
+"""
+GROMACS production MD CLI command.
+
+This command supports two creation modes:
+1. YAML-driven mode: chemsmart run gromacs -p project.yaml md
+2. Direct CLI mode: chemsmart run gromacs md --mdp md.mdp --structure npt.gro --top topol.top
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import click
+
+from chemsmart.cli.gromacs.gromacs import gromacs
+from chemsmart.cli.job import click_job_options
+from chemsmart.jobs.gromacs.job import GromacsMDJob
+from chemsmart.utils.cli import MyGroup
+
+logger = logging.getLogger(__name__)
+
+
+@gromacs.group("md", cls=MyGroup, invoke_without_command=True)
+@click_job_options
+@click.option(
+    "--mdp",
+    "mdp",
+    type=click.Path(
+        exists=True,
+        dir_okay=False,
+        resolve_path=True,
+        path_type=Path,
+    ),
+    default=None,
+    help="GROMACS .mdp file for production molecular dynamics.",
+)
+@click.option(
+    "--structure",
+    "-s",
+    "structure",
+    type=click.Path(
+        exists=True,
+        dir_okay=False,
+        resolve_path=True,
+        path_type=Path,
+    ),
+    default=None,
+    help="Input structure file for production molecular dynamics, such as NPT output .gro.",
+)
+@click.option(
+    "--input-pdb",
+    "input_pdb",
+    type=click.Path(
+        exists=True,
+        dir_okay=False,
+        resolve_path=True,
+        path_type=Path,
+    ),
+    default=None,
+    help="Raw PDB file used by the full_setup workflow.",
+)
+@click.option(
+    "--top",
+    "top",
+    type=click.Path(
+        exists=True,
+        dir_okay=False,
+        resolve_path=True,
+        path_type=Path,
+    ),
+    default=None,
+    help="GROMACS topology .top file.",
+)
+@click.option(
+    "--index",
+    "index",
+    type=click.Path(
+        exists=True,
+        dir_okay=False,
+        resolve_path=True,
+        path_type=Path,
+    ),
+    default=None,
+    help="Optional GROMACS index .ndx file.",
+)
+@click.option(
+    "--itp",
+    "itp",
+    multiple=True,
+    type=click.Path(
+        exists=True,
+        dir_okay=False,
+        resolve_path=True,
+        path_type=Path,
+    ),
+    help="Optional GROMACS .itp include file. Can be used multiple times.",
+)
+@click.option(
+    "--workflow",
+    type=click.Choice(["prepared", "full_setup"]),
+    default=None,
+    help="GROMACS workflow mode.",
+)
+@click.pass_context
+def md(
+    ctx,
+    skip_completed,
+    mdp,
+    structure,
+    input_pdb,
+    top,
+    index,
+    itp,
+    workflow,
+    molecule=None,
+    **kwargs,
+):
+    """
+    CLI subcommand for running GROMACS production molecular dynamics.
+    """
+
+    jobrunner = ctx.obj.get("jobrunner", None)
+    project_yaml = ctx.obj.get("project_yaml", None)
+    project_settings = ctx.obj.get("project_settings", None)
+    filename = ctx.obj.get("filename", None)
+
+    if structure is None:
+        structure = filename
+
+    if project_settings is not None:
+        settings = project_settings.with_overrides(
+            mdp_file=Path(mdp) if mdp else None,
+            structure_file=Path(structure) if structure else None,
+            input_pdb=Path(input_pdb) if input_pdb else None,
+            top_file=Path(top) if top else None,
+            index_file=Path(index) if index else None,
+            workflow=workflow,
+            itp_files=list(itp) if itp else None,
+        )
+
+        settings.validate()
+
+        logger.info(
+            "Creating GROMACS MD job from project YAML: %s",
+            project_yaml,
+        )
+
+        if ctx.invoked_subcommand is None:
+            return GromacsMDJob.from_project_settings(
+                settings=settings,
+                molecule=molecule,
+                jobrunner=jobrunner,
+                skip_completed=skip_completed,
+                **kwargs,
+            )
+        return None
+
+    # direct CLI mode
+    label = "gromacs_md"
+    if structure is not None:
+        label = Path(structure).stem + "_md"
+
+    workflow = workflow or "prepared"
+
+    logger.info("Creating GROMACS MD job from direct CLI options.")
+    logger.info("GROMACS MD structure file: %s", structure)
+    logger.info("GROMACS MD mdp file: %s", mdp)
+    logger.info("GROMACS MD topology file: %s", top)
+    logger.info("GROMACS MD itp files: %s", itp)
+    logger.info("GROMACS MD workflow: %s", workflow)
+
+    if ctx.invoked_subcommand is None:
+        return GromacsMDJob(
+            molecule=molecule,
+            label=label,
+            jobrunner=jobrunner,
+            mdp_file=Path(mdp) if mdp else None,
+            structure_file=Path(structure) if structure else None,
+            input_pdb=Path(input_pdb) if input_pdb else None,
+            top_file=Path(top) if top else None,
+            itp_files=list(itp) if itp else [],
+            index_file=Path(index) if index else None,
+            workflow=workflow,
+            skip_completed=skip_completed,
+            **kwargs,
+        )

--- a/chemsmart/cli/gromacs/npt.py
+++ b/chemsmart/cli/gromacs/npt.py
@@ -1,0 +1,187 @@
+"""
+GROMACS NPT equilibration CLI command.
+
+This command supports two creation modes:
+1. YAML-driven mode: chemsmart run gromacs -p project.yaml npt
+2. Direct CLI mode: chemsmart run gromacs npt --mdp npt.mdp --structure nvt.gro --top topol.top
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import click
+
+from chemsmart.cli.gromacs.gromacs import gromacs
+from chemsmart.cli.job import click_job_options
+from chemsmart.jobs.gromacs.job import GromacsNPTJob
+from chemsmart.utils.cli import MyGroup
+
+logger = logging.getLogger(__name__)
+
+
+@gromacs.group("npt", cls=MyGroup, invoke_without_command=True)
+@click_job_options
+@click.option(
+    "--mdp",
+    "mdp",
+    type=click.Path(
+        exists=True,
+        dir_okay=False,
+        resolve_path=True,
+        path_type=Path,
+    ),
+    default=None,
+    help="GROMACS .mdp file for NPT equilibration.",
+)
+@click.option(
+    "--structure",
+    "-s",
+    "structure",
+    type=click.Path(
+        exists=True,
+        dir_okay=False,
+        resolve_path=True,
+        path_type=Path,
+    ),
+    default=None,
+    help="Input structure file for NPT equilibration, such as NVT output .gro.",
+)
+@click.option(
+    "--input-pdb",
+    "input_pdb",
+    type=click.Path(
+        exists=True,
+        dir_okay=False,
+        resolve_path=True,
+        path_type=Path,
+    ),
+    default=None,
+    help="Raw PDB file used by the full_setup workflow.",
+)
+@click.option(
+    "--top",
+    "top",
+    type=click.Path(
+        exists=True,
+        dir_okay=False,
+        resolve_path=True,
+        path_type=Path,
+    ),
+    default=None,
+    help="GROMACS topology .top file.",
+)
+@click.option(
+    "--index",
+    "index",
+    type=click.Path(
+        exists=True,
+        dir_okay=False,
+        resolve_path=True,
+        path_type=Path,
+    ),
+    default=None,
+    help="Optional GROMACS index .ndx file.",
+)
+@click.option(
+    "--itp",
+    "itp",
+    multiple=True,
+    type=click.Path(
+        exists=True,
+        dir_okay=False,
+        resolve_path=True,
+        path_type=Path,
+    ),
+    help="Optional GROMACS .itp include file. Can be used multiple times.",
+)
+@click.option(
+    "--workflow",
+    type=click.Choice(["prepared", "full_setup"]),
+    default=None,
+    help="GROMACS workflow mode.",
+)
+@click.pass_context
+def npt(
+    ctx,
+    skip_completed,
+    mdp,
+    structure,
+    input_pdb,
+    top,
+    index,
+    itp,
+    workflow,
+    molecule=None,
+    **kwargs,
+):
+    """
+    CLI subcommand for running GROMACS NPT equilibration.
+    """
+
+    jobrunner = ctx.obj.get("jobrunner", None)
+    project_yaml = ctx.obj.get("project_yaml", None)
+    project_settings = ctx.obj.get("project_settings", None)
+    filename = ctx.obj.get("filename", None)
+
+    if structure is None:
+        structure = filename
+
+    if project_settings is not None:
+        settings = project_settings.with_overrides(
+            mdp_file=Path(mdp) if mdp else None,
+            structure_file=Path(structure) if structure else None,
+            input_pdb=Path(input_pdb) if input_pdb else None,
+            top_file=Path(top) if top else None,
+            index_file=Path(index) if index else None,
+            workflow=workflow,
+            itp_files=list(itp) if itp else None,
+        )
+
+        settings.validate()
+
+        logger.info(
+            "Creating GROMACS NPT job from project YAML: %s",
+            project_yaml,
+        )
+
+        if ctx.invoked_subcommand is None:
+            return GromacsNPTJob.from_project_settings(
+                settings=settings,
+                molecule=molecule,
+                jobrunner=jobrunner,
+                skip_completed=skip_completed,
+                **kwargs,
+            )
+        return None
+
+    # direct CLI mode
+    label = "gromacs_npt"
+    if structure is not None:
+        label = Path(structure).stem + "_npt"
+
+    workflow = workflow or "prepared"
+
+    logger.info("Creating GROMACS NPT job from direct CLI options.")
+    logger.info("GROMACS NPT structure file: %s", structure)
+    logger.info("GROMACS NPT mdp file: %s", mdp)
+    logger.info("GROMACS NPT topology file: %s", top)
+    logger.info("GROMACS NPT itp files: %s", itp)
+    logger.info("GROMACS NPT workflow: %s", workflow)
+
+    if ctx.invoked_subcommand is None:
+        return GromacsNPTJob(
+            molecule=molecule,
+            label=label,
+            jobrunner=jobrunner,
+            mdp_file=Path(mdp) if mdp else None,
+            structure_file=Path(structure) if structure else None,
+            input_pdb=Path(input_pdb) if input_pdb else None,
+            top_file=Path(top) if top else None,
+            itp_files=list(itp) if itp else [],
+            index_file=Path(index) if index else None,
+            workflow=workflow,
+            skip_completed=skip_completed,
+            **kwargs,
+        )

--- a/chemsmart/jobs/gromacs/__init__.py
+++ b/chemsmart/jobs/gromacs/__init__.py
@@ -1,9 +1,17 @@
-from .job import GromacsEMJob, GromacsJob
+from .job import (
+    GromacsEMJob,
+    GromacsJob,
+    GromacsMDJob,
+    GromacsNPTJob,
+    GromacsNVTJob,
+)
 from .runner import GromacsJobRunner
 
 __all__ = [
     "GromacsJob",
     "GromacsEMJob",
     "GromacsNVTJob",
+    "GromacsNPTJob",
+    "GromacsMDJob",
     "GromacsJobRunner",
 ]

--- a/chemsmart/jobs/gromacs/factory.py
+++ b/chemsmart/jobs/gromacs/factory.py
@@ -1,33 +1,31 @@
-from chemsmart.jobs.gromacs.job import GromacsEMJob, GromacsNVTJob
+from chemsmart.jobs.gromacs.job import (
+    GromacsEMJob,
+    GromacsNVTJob,
+    GromacsNPTJob,
+    GromacsMDJob,
+)
 from chemsmart.settings.gromacs import GromacsProjectSettings
 
 
 class GromacsJobFactory:
     """
-    Create concrete GROMACS job objects from settings or project YAML files.
+    Factory for creating GROMACS jobs from project YAML or settings
     """
 
     JOB_TYPE_MAP = {
         "em": GromacsEMJob,
         "nvt": GromacsNVTJob,
+        "npt": GromacsNPTJob,
+        "md": GromacsMDJob,
     }
 
     @classmethod
     def create_from_project_yaml(
-        cls,
-        project_yaml,
-        molecule=None,
-        label=None,
-        jobrunner=None,
-        **kwargs,
+        cls, project_yaml, molecule=None, label=None, jobrunner=None, **kwargs
     ):
-        """
-        Create a GROMACS job from a project YAML file.
-        """
         settings = GromacsProjectSettings.from_yaml(project_yaml)
-
         return cls.create_from_settings(
-            settings=settings,
+            settings,
             molecule=molecule,
             label=label,
             jobrunner=jobrunner,
@@ -43,18 +41,12 @@ class GromacsJobFactory:
         jobrunner=None,
         **kwargs,
     ):
-        """
-        Create a GROMACS job from GromacsProjectSettings.
-        """
         settings.validate()
-
         job_cls = cls.JOB_TYPE_MAP.get(settings.job_type)
-
         if job_cls is None:
             raise ValueError(
                 f"Unsupported GROMACS job type: {settings.job_type}"
             )
-
         return job_cls.from_project_settings(
             settings=settings,
             molecule=molecule,

--- a/chemsmart/jobs/gromacs/job.py
+++ b/chemsmart/jobs/gromacs/job.py
@@ -358,3 +358,39 @@ class GromacsNPTJob(GromacsJob):
             workflow=workflow,
             **kwargs,
         )
+class GromacsMDJob(GromacsJob):
+    """
+    Production molecular dynamics job for GROMACS.
+    """
+
+    TYPE = "gmxmd"
+
+    def __init__(
+        self,
+        molecule=None,
+        label="gromacs_md",
+        jobrunner=None,
+        mdp_file=None,
+        structure_file=None,
+        input_pdb=None,
+        top_file=None,
+        tpr_file=None,
+        itp_files=None,
+        index_file=None,
+        workflow="prepared",
+        **kwargs,
+    ):
+        super().__init__(
+            molecule=molecule,
+            label=label,
+            jobrunner=jobrunner,
+            mdp_file=mdp_file,
+            structure_file=structure_file,
+            input_pdb=input_pdb,
+            top_file=top_file,
+            tpr_file=tpr_file,
+            itp_files=itp_files,
+            index_file=index_file,
+            workflow=workflow,
+            **kwargs,
+        )

--- a/chemsmart/jobs/gromacs/runner.py
+++ b/chemsmart/jobs/gromacs/runner.py
@@ -36,6 +36,8 @@ class GromacsJobRunner(JobRunner):
         "gromacs",
         "gmxem",
         "gmxnvt",
+        "gmxnpt",
+        "gmxmd",
     ]
 
     PROGRAM = "gromacs"

--- a/chemsmart/jobs/gromacs/writer.py
+++ b/chemsmart/jobs/gromacs/writer.py
@@ -3,9 +3,11 @@ GROMACS input writer.
 
 This module writes GROMACS .mdp files from ChemSmart GROMACS job settings.
 
-The first implementation supports automatic MDP generation for:
+Automatic MDP generation is supported for:
 - EM  / gmxem
 - NVT / gmxnvt
+- NPT / gmxnpt
+- MD  / gmxmd
 
 Topology preparation and structure conversion are intentionally not handled
 here. Those belong to the GROMACS workflow setup layer.
@@ -73,6 +75,9 @@ class GromacsInputWriter:
         elif job_type == "gmxnpt":
             mdp_path = folder / "npt.mdp"
             content = self._build_npt_mdp()
+        elif job_type == "gmxmd":
+            mdp_path = folder / "md.mdp"
+            content = self._build_md_mdp()
         else:
             raise ValueError(
                 f"Unsupported GROMACS job type for MDP writing: {job_type}"
@@ -200,7 +205,70 @@ class GromacsInputWriter:
                 "gen_vel": "no",
             }
         )
+    def _build_md_mdp(self):
+        """
+        Build a default production MD .mdp file.
+        """
+        temperature = self._value_or_default(self.job.temperature, 300)
+        pressure = self._value_or_default(self.job.pressure, 1.0)
+        timestep = self._value_or_default(self.job.timestep, 0.002)
+        nsteps = self._value_or_default(self.job.nsteps, 500000)
+        constraints = self._value_or_default(
+            self.job.constraints,
+            "h-bonds",
+        )
+        constraint_algorithm = self._value_or_default(
+            self.job.constraint_algorithm,
+            "lincs",
+        )
+        thermostat = self._value_or_default(
+            self.job.thermostat,
+            "V-rescale",
+        )
+        barostat = self._value_or_default(
+            self.job.barostat,
+            "Parrinello-Rahman",
+        )
+        tau_t = self._value_or_default(self.job.tau_t, 0.1)
+        tc_grps = self._value_or_default(self.job.tc_grps, "System")
+        tau_p = self._value_or_default(self.job.tau_p, 2.0)
+        compressibility = self._value_or_default(
+            self.job.compressibility,
+            "4.5e-5",
+        )
 
+        return self._format_mdp(
+            {
+                "integrator": "md",
+                "nsteps": nsteps,
+                "dt": timestep,
+                "continuation": "yes",
+                "constraint_algorithm": constraint_algorithm,
+                "constraints": constraints,
+                "cutoff-scheme": "Verlet",
+                "nstlist": 10,
+                "rcoulomb": 1.0,
+                "rvdw": 1.0,
+                "coulombtype": "PME",
+                "pbc": "xyz",
+                "tcoupl": thermostat,
+                "tc-grps": tc_grps,
+                "tau_t": tau_t,
+                "ref_t": temperature,
+                "pcoupl": barostat,
+                "pcoupltype": "isotropic",
+                "tau_p": tau_p,
+                "ref_p": pressure,
+                "compressibility": compressibility,
+                "gen_vel": "no",
+                "nstxout": 0,
+                "nstvout": 0,
+                "nstfout": 0,
+                "nstlog": 1000,
+                "nstenergy": 1000,
+                "nstxout-compressed": 5000,
+            }
+        )
     @staticmethod
     def _value_or_default(value, default=None):
         """

--- a/chemsmart/settings/gromacs.py
+++ b/chemsmart/settings/gromacs.py
@@ -22,6 +22,8 @@ class GromacsProjectSettings:
     concrete executable job.
     """
 
+    SUPPORTED_JOB_TYPES = {"em", "nvt", "npt", "md"}
+
     project_name: Optional[str] = None
     project_dir: Optional[Path] = None
 
@@ -52,7 +54,13 @@ class GromacsProjectSettings:
     barostat: Optional[str] = None
     constraints: Optional[str] = None
     constraint_algorithm: Optional[str] = None
-
+    nsteps: Optional[int] = None
+    emtol: Optional[float] = None
+    emstep: Optional[float] = None
+    tau_t: Optional[float] = None
+    tc_grps: Optional[str] = None
+    tau_p: Optional[float] = None
+    compressibility: Optional[str] = None
 
     box_type: Optional[str] = "cubic"
     box_distance: Optional[float] = 1.0
@@ -106,6 +114,13 @@ class GromacsProjectSettings:
             "barostat": data.get("barostat"),
             "constraints": data.get("constraints"),
             "constraint_algorithm": data.get("constraint_algorithm"),
+            "nsteps": data.get("nsteps"),
+            "emtol": data.get("emtol"),
+            "emstep": data.get("emstep"),
+            "tau_t": data.get("tau_t"),
+            "tc_grps": data.get("tc_grps"),
+            "tau_p": data.get("tau_p"),
+            "compressibility": data.get("compressibility"),
             "box_type": data.get("box_type", "cubic"),
             "box_distance": data.get("box_distance", 1.0),
             "solvent_file": data.get("solvent_file"),
@@ -257,8 +272,15 @@ class GromacsProjectSettings:
 
     def validate(self):
         """
-        Validate settings according to the selected workflow.
+        Validate settings according to the selected workflow and job type.
         """
+        if self.job_type not in self.SUPPORTED_JOB_TYPES:
+            supported = ", ".join(sorted(self.SUPPORTED_JOB_TYPES))
+            raise ValueError(
+                f"Unsupported GROMACS job type: {self.job_type}. "
+                f"Supported job types: {supported}"
+            )
+
         if self.workflow == "prepared":
             self.validate_prepared_inputs()
             return
@@ -312,6 +334,13 @@ class GromacsProjectSettings:
             "barostat": self.barostat,
             "constraints": self.constraints,
             "constraint_algorithm": self.constraint_algorithm,
+            "nsteps": self.nsteps,
+            "emtol": self.emtol,
+            "emstep": self.emstep,
+            "tau_t": self.tau_t,
+            "tc_grps": self.tc_grps,
+            "tau_p": self.tau_p,
+            "compressibility": self.compressibility,
             "box_type": self.box_type,
             "box_distance": self.box_distance,
             "solvent_file": self.solvent_file,

--- a/tests/test_gromacs_cli.py
+++ b/tests/test_gromacs_cli.py
@@ -6,7 +6,8 @@ from click.testing import CliRunner
 from chemsmart.cli.gromacs.gromacs import gromacs
 
 em_module = importlib.import_module("chemsmart.cli.gromacs.em")
-
+npt_module = importlib.import_module("chemsmart.cli.gromacs.npt")
+md_module = importlib.import_module("chemsmart.cli.gromacs.md")
 
 class DummyGromacsEMJob:
     """
@@ -68,6 +69,16 @@ class DummyGromacsEMJob:
         }
 
 
+class DummyGromacsNPTJob(DummyGromacsEMJob):
+    captured_from_settings = {}
+    captured_direct_init = {}
+
+
+class DummyGromacsMDJob(DummyGromacsEMJob):
+    captured_from_settings = {}
+    captured_direct_init = {}
+
+
 @pytest.fixture(autouse=True)
 def patch_gromacs_em_job(monkeypatch):
     """
@@ -116,6 +127,23 @@ inputs:
 
     return yaml_file
 
+@pytest.fixture(autouse=True)
+def patch_gromacs_npt_and_md_jobs(monkeypatch):
+    DummyGromacsNPTJob.captured_from_settings = {}
+    DummyGromacsNPTJob.captured_direct_init = {}
+    DummyGromacsMDJob.captured_from_settings = {}
+    DummyGromacsMDJob.captured_direct_init = {}
+
+    monkeypatch.setattr(
+        npt_module,
+        "GromacsNPTJob",
+        DummyGromacsNPTJob,
+    )
+    monkeypatch.setattr(
+        md_module,
+        "GromacsMDJob",
+        DummyGromacsMDJob,
+    )
 
 def test_cli_project_yaml_creates_job(demo_project_yaml):
     """
@@ -320,3 +348,183 @@ def test_cli_rejects_missing_project_yaml(tmp_path):
 
     assert result.exit_code != 0
     assert result.exception is not None
+
+def test_cli_npt_direct_options_creates_job(tmp_path):
+    runner = CliRunner()
+
+    mdp_file = tmp_path / "npt.mdp"
+    structure_file = tmp_path / "nvt.gro"
+    top_file = tmp_path / "topol.top"
+
+    for file_path in [mdp_file, structure_file, top_file]:
+        file_path.write_text("dummy content", encoding="utf-8")
+
+    result = runner.invoke(
+        gromacs,
+        [
+            "npt",
+            "--mdp",
+            str(mdp_file),
+            "--structure",
+            str(structure_file),
+            "--top",
+            str(top_file),
+        ],
+        obj={"molecule": None},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert result.exception is None
+
+    captured = DummyGromacsNPTJob.captured_direct_init
+
+    assert captured
+    assert captured["label"] == "nvt_npt"
+    assert captured["workflow"] == "prepared"
+    assert captured["mdp_file"] == mdp_file
+    assert captured["structure_file"] == structure_file
+    assert captured["top_file"] == top_file
+
+
+def test_cli_md_direct_options_creates_job(tmp_path):
+    runner = CliRunner()
+
+    mdp_file = tmp_path / "md.mdp"
+    structure_file = tmp_path / "npt.gro"
+    top_file = tmp_path / "topol.top"
+
+    for file_path in [mdp_file, structure_file, top_file]:
+        file_path.write_text("dummy content", encoding="utf-8")
+
+    result = runner.invoke(
+        gromacs,
+        [
+            "md",
+            "--mdp",
+            str(mdp_file),
+            "--structure",
+            str(structure_file),
+            "--top",
+            str(top_file),
+        ],
+        obj={"molecule": None},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert result.exception is None
+
+    captured = DummyGromacsMDJob.captured_direct_init
+
+    assert captured
+    assert captured["label"] == "npt_md"
+    assert captured["workflow"] == "prepared"
+    assert captured["mdp_file"] == mdp_file
+    assert captured["structure_file"] == structure_file
+    assert captured["top_file"] == top_file
+
+def test_cli_npt_project_yaml_creates_job(tmp_path):
+    yaml_file = tmp_path / "npt_project.yaml"
+
+    yaml_file.write_text(
+        """
+project:
+  name: prepared_npt
+  type: gromacs
+  job_type: npt
+  mode: prepared
+
+inputs:
+  mdp_file: npt.mdp
+  structure_file: nvt.gro
+  topology_file: topol.top
+""",
+        encoding="utf-8",
+    )
+
+    for filename in ["npt.mdp", "nvt.gro", "topol.top"]:
+        (tmp_path / filename).write_text(
+            "dummy content",
+            encoding="utf-8",
+        )
+
+    runner = CliRunner()
+
+    result = runner.invoke(
+        gromacs,
+        [
+            "-p",
+            str(yaml_file),
+            "npt",
+        ],
+        obj={"molecule": None},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert result.exception is None
+
+    captured = DummyGromacsNPTJob.captured_from_settings
+
+    assert captured
+
+    settings = captured["settings"]
+
+    assert settings.project_name == "prepared_npt"
+    assert settings.job_type == "npt"
+    assert settings.workflow == "prepared"
+    assert settings.mdp_file == tmp_path / "npt.mdp"
+    assert settings.structure_file == tmp_path / "nvt.gro"
+    assert settings.top_file == tmp_path / "topol.top"
+
+
+def test_cli_md_project_yaml_creates_job(tmp_path):
+    yaml_file = tmp_path / "md_project.yaml"
+
+    yaml_file.write_text(
+        """
+project:
+  name: production_md
+  type: gromacs
+  job_type: md
+  mode: prepared
+
+inputs:
+  mdp_file: md.mdp
+  structure_file: npt.gro
+  topology_file: topol.top
+""",
+        encoding="utf-8",
+    )
+
+    for filename in ["md.mdp", "npt.gro", "topol.top"]:
+        (tmp_path / filename).write_text(
+            "dummy content",
+            encoding="utf-8",
+        )
+
+    runner = CliRunner()
+
+    result = runner.invoke(
+        gromacs,
+        [
+            "-p",
+            str(yaml_file),
+            "md",
+        ],
+        obj={"molecule": None},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert result.exception is None
+
+    captured = DummyGromacsMDJob.captured_from_settings
+
+    assert captured
+
+    settings = captured["settings"]
+
+    assert settings.project_name == "production_md"
+    assert settings.job_type == "md"
+    assert settings.workflow == "prepared"
+    assert settings.mdp_file == tmp_path / "md.mdp"
+    assert settings.structure_file == tmp_path / "npt.gro"
+    assert settings.top_file == tmp_path / "topol.top"

--- a/tests/test_gromacs_factory.py
+++ b/tests/test_gromacs_factory.py
@@ -1,0 +1,76 @@
+import pytest
+
+from chemsmart.cli.gromacs.factory import (
+    GromacsJobFactory as CliGromacsJobFactory,
+)
+from chemsmart.jobs.gromacs.factory import (
+    GromacsJobFactory as CoreGromacsJobFactory,
+)
+from chemsmart.jobs.gromacs.job import GromacsMDJob, GromacsNPTJob
+from chemsmart.settings.gromacs import GromacsProjectSettings
+
+
+@pytest.mark.parametrize(
+    ("factory_cls", "job_type", "expected_job_cls"),
+    [
+        (CoreGromacsJobFactory, "npt", GromacsNPTJob),
+        (CoreGromacsJobFactory, "md", GromacsMDJob),
+        (CliGromacsJobFactory, "npt", GromacsNPTJob),
+        (CliGromacsJobFactory, "md", GromacsMDJob),
+    ],
+)
+def test_gromacs_factory_creates_npt_and_md_jobs(
+    tmp_path,
+    factory_cls,
+    job_type,
+    expected_job_cls,
+):
+    settings = GromacsProjectSettings.from_dict(
+        {
+            "project_name": f"prepared_{job_type}",
+            "workflow": "prepared",
+            "job_type": job_type,
+            "structure_file": tmp_path / "input.gro",
+            "top_file": tmp_path / "topol.top",
+        }
+    )
+
+    job = factory_cls.create_from_settings(
+        settings=settings,
+        molecule=None,
+        jobrunner=None,
+    )
+
+    assert isinstance(job, expected_job_cls)
+    assert job.TYPE == expected_job_cls.TYPE
+    assert job.label == f"prepared_{job_type}"
+    assert job.workflow == "prepared"
+
+
+@pytest.mark.parametrize(
+    "factory_cls",
+    [
+        CoreGromacsJobFactory,
+        CliGromacsJobFactory,
+    ],
+)
+def test_gromacs_factory_rejects_unsupported_job_type(
+    tmp_path,
+    factory_cls,
+):
+    settings = GromacsProjectSettings.from_dict(
+        {
+            "project_name": "unsupported",
+            "workflow": "prepared",
+            "job_type": "invalid",
+            "structure_file": tmp_path / "input.gro",
+            "top_file": tmp_path / "topol.top",
+        }
+    )
+
+    with pytest.raises(ValueError, match="Unsupported GROMACS job type"):
+        factory_cls.create_from_settings(
+            settings=settings,
+            molecule=None,
+            jobrunner=None,
+        )

--- a/tests/test_gromacs_job.py
+++ b/tests/test_gromacs_job.py
@@ -1,7 +1,7 @@
 # tests/test_gromacs_job.py
 
 
-from chemsmart.jobs.gromacs.job import GromacsEMJob
+from chemsmart.jobs.gromacs.job import GromacsEMJob, GromacsMDJob
 from chemsmart.settings.gromacs import GromacsProjectSettings
 
 
@@ -114,3 +114,28 @@ def test_gromacs_job_is_incomplete_when_log_missing_success_markers(tmp_path):
     (tmp_path / "em.log").write_text("Starting mdrun\n", encoding="utf-8")
 
     assert job.is_complete() is False
+def test_gromacs_md_job_defaults():
+    job = GromacsMDJob(
+        molecule=None,
+        jobrunner=None,
+    )
+
+    assert job.TYPE == "gmxmd"
+    assert job.label == "gromacs_md"
+    assert job.workflow == "prepared"
+
+
+def test_gromacs_md_job_accepts_simulation_parameters():
+    job = GromacsMDJob(
+        molecule=None,
+        jobrunner=None,
+        temperature=310,
+        pressure=1.0,
+        timestep=0.002,
+        nsteps=500000,
+    )
+
+    assert job.temperature == 310
+    assert job.pressure == 1.0
+    assert job.timestep == 0.002
+    assert job.nsteps == 500000

--- a/tests/test_gromacs_runner.py
+++ b/tests/test_gromacs_runner.py
@@ -3,7 +3,9 @@ import subprocess
 
 import pytest
 
-from chemsmart.jobs.gromacs.job import GromacsEMJob, GromacsNVTJob
+from chemsmart.jobs.gromacs.job import (
+    GromacsEMJob, GromacsNVTJob, GromacsNPTJob,GromacsMDJob,
+)
 from chemsmart.jobs.gromacs.runner import GromacsJobRunner
 from chemsmart.settings.executable import GromacsExecutable
 
@@ -26,6 +28,8 @@ def _make_runner(gmx_executable="gmx"):
 def test_gromacs_em_job_type_matches_runner_jobtypes():
     assert GromacsEMJob.TYPE in GromacsJobRunner.JOBTYPES
     assert GromacsNVTJob.TYPE in GromacsJobRunner.JOBTYPES
+    assert GromacsNPTJob.TYPE in GromacsJobRunner.JOBTYPES
+    assert GromacsMDJob.TYPE in GromacsJobRunner.JOBTYPES
 
 
 def test_gromacs_em_job_stores_file_attributes(tmp_path):
@@ -746,6 +750,89 @@ def test_gromacs_writer_generates_nvt_mdp_when_missing(tmp_path):
     assert "dt" in content
     assert "0.001" in content
 
+def test_gromacs_writer_generates_npt_mdp_when_missing(tmp_path):
+    job = GromacsNPTJob(
+        molecule=None,
+        label="npt",
+        jobrunner=None,
+        mdp_file=None,
+        structure_file=tmp_path / "nvt.gro",
+        top_file=tmp_path / "topol.top",
+        workflow="prepared",
+        temperature=310,
+        pressure=1.5,
+        timestep=0.002,
+        nsteps=250000,
+    )
+
+    job.set_folder(str(tmp_path))
+
+    runner = _make_runner()
+    runner._write_input(job)
+
+    assert job.mdp_file == tmp_path / "npt.mdp"
+    assert job.mdp_file.exists()
+
+    content = job.mdp_file.read_text(encoding="utf-8")
+
+    assert "integrator" in content
+    assert "md" in content
+    assert "nsteps" in content
+    assert "250000" in content
+    assert "dt" in content
+    assert "0.002" in content
+    assert "ref_t" in content
+    assert "310" in content
+    assert "ref_p" in content
+    assert "1.5" in content
+    assert "continuation" in content
+    assert "yes" in content
+    assert "pcoupl" in content
+    assert "Parrinello-Rahman" in content
+    assert "gen_vel" in content
+    assert "no" in content
+
+def test_gromacs_writer_generates_md_mdp_when_missing(tmp_path):
+    job = GromacsMDJob(
+        molecule=None,
+        label="md",
+        jobrunner=None,
+        mdp_file=None,
+        structure_file=tmp_path / "npt.gro",
+        top_file=tmp_path / "topol.top",
+        workflow="prepared",
+        temperature=310,
+        pressure=1.0,
+        timestep=0.002,
+        nsteps=1000000,
+    )
+
+    job.set_folder(str(tmp_path))
+
+    runner = _make_runner()
+    runner._write_input(job)
+
+    assert job.mdp_file == tmp_path / "md.mdp"
+    assert job.mdp_file.exists()
+
+    content = job.mdp_file.read_text(encoding="utf-8")
+
+    assert "integrator" in content
+    assert "md" in content
+    assert "nsteps" in content
+    assert "1000000" in content
+    assert "dt" in content
+    assert "0.002" in content
+    assert "ref_t" in content
+    assert "310" in content
+    assert "ref_p" in content
+    assert "1.0" in content
+    assert "continuation" in content
+    assert "yes" in content
+    assert "gen_vel" in content
+    assert "no" in content
+    assert "nstxout-compressed" in content
+    assert "5000" in content
 
 def test_gromacs_writer_does_not_overwrite_user_mdp(tmp_path):
     mdp_file = tmp_path / "custom.mdp"


### PR DESCRIPTION
- Add high-level smart preset settings for GROMACS jobs
- Convert duration_ns to nsteps automatically
- Support protein, small-molecule, and membrane systems
- Use semiisotropic pressure coupling for membrane systems
- Preserve explicit user overrides and custom MDP files
- Add tests and an example project YAML