### PR TITLE
Fix: duplicate suffixes appended for ORCA jobs

### DIFF
--- a/chemsmart/cli/gaussian/gaussian.py
+++ b/chemsmart/cli/gaussian/gaussian.py
@@ -780,7 +780,10 @@ def gaussian(
                 label = f"{label}_RI-{record_index}"
         label = f"{label}_{append_label}"
     if label is None and append_label is None:
-        label = os.path.splitext(os.path.basename(filename))[0]
+        if filename:
+            label = os.path.splitext(os.path.basename(filename))[0]
+        else:
+            label = "output"
         if is_chemsmart_db:
             if structure_id is not None:
                 label = f"{label}_SID-{structure_id}"
@@ -788,12 +791,7 @@ def gaussian(
                 label = f"{label}_RID-{record_id}"
             elif record_index is not None:
                 label = f"{label}_RI-{record_index}"
-        if filename:
-            label = os.path.splitext(os.path.basename(filename))[0]
-        else:
-            label = "output"
-        if ctx.invoked_subcommand:
-            label = f"{label}_{ctx.invoked_subcommand}"
+        label = f"{label}_{ctx.invoked_subcommand}"
     label = clean_label(label)
 
     # if user has specified an index to use to access particular structure

--- a/chemsmart/cli/orca/orca.py
+++ b/chemsmart/cli/orca/orca.py
@@ -751,13 +751,10 @@ def orca(
         label = f"{label}_{append_label}"
         logger.debug(f"Created label with append: {label}")
     if label is None and append_label is None:
-        label = os.path.splitext(os.path.basename(filename))[0]
         if filename:
             label = os.path.splitext(os.path.basename(filename))[0]
         else:
             label = "output"
-        if ctx.invoked_subcommand:
-            label = f"{label}_{ctx.invoked_subcommand}"
         if is_chemsmart_db:
             if structure_id is not None:
                 label = f"{label}_SID-{structure_id}"

--- a/tests/test_gaussian_cli.py
+++ b/tests/test_gaussian_cli.py
@@ -21,7 +21,7 @@ from unittest.mock import MagicMock, patch
 
 
 class TestGaussianCLIPubChemOptCommand:
-    """CLI tests for ``--pubchem`` structure loading without ``-f``."""
+    """CLI tests for PubChem / database label paths without an explicit ``-l``."""
 
     def test_pubchem_only_opt_passes_molecule_to_job(
         self,
@@ -59,6 +59,91 @@ class TestGaussianCLIPubChemOptCommand:
             identifier="222", return_list=True
         )
         assert settings is not None, "GaussianOptJob was never instantiated"
+
+    def test_pubchem_default_label_uses_output_prefix(
+        self,
+        gaussian_jobrunner_no_scratch,
+        make_cli_ctx_obj,
+    ):
+        from click.testing import CliRunner
+
+        from chemsmart.cli.gaussian.gaussian import gaussian as gaussian_cli
+
+        runner = CliRunner()
+        pubchem_molecule = MagicMock(name="pubchem_molecule")
+        with (
+            patch(
+                "chemsmart.io.molecules.structure.Molecule.from_pubchem",
+                return_value=[pubchem_molecule],
+            ),
+            patch("chemsmart.jobs.gaussian.opt.GaussianOptJob") as mock,
+        ):
+            mock.return_value = MagicMock()
+            result = runner.invoke(
+                gaussian_cli,
+                [
+                    "-p",
+                    "gas_solv",
+                    "--pubchem",
+                    "222",
+                    "-c",
+                    "0",
+                    "-m",
+                    "1",
+                    "opt",
+                ],
+                obj=make_cli_ctx_obj(gaussian_jobrunner_no_scratch),
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0, result.output
+        assert mock.call_args.kwargs["label"] == "output_opt"
+
+    def test_database_sid_preserved_in_default_label(
+        self,
+        database_chemsmart_file,
+        gaussian_jobrunner_no_scratch,
+        make_cli_ctx_obj,
+    ):
+        from os.path import basename, splitext
+
+        from click.testing import CliRunner
+
+        from chemsmart.cli.gaussian.gaussian import gaussian as gaussian_cli
+        from chemsmart.database.database import Database
+
+        db = Database(database_chemsmart_file)
+        structure_id = db.get_record(record_index=1)["molecules"][0][
+            "structure_id"
+        ]
+
+        runner = CliRunner()
+        with patch("chemsmart.jobs.gaussian.opt.GaussianOptJob") as mock:
+            mock.return_value = MagicMock()
+            result = runner.invoke(
+                gaussian_cli,
+                [
+                    "-p",
+                    "gas_solv",
+                    "-f",
+                    database_chemsmart_file,
+                    "--sid",
+                    structure_id,
+                    "-c",
+                    "0",
+                    "-m",
+                    "1",
+                    "opt",
+                ],
+                obj=make_cli_ctx_obj(gaussian_jobrunner_no_scratch),
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0, result.output
+        base = splitext(basename(database_chemsmart_file))[0]
+        assert (
+            mock.call_args.kwargs["label"] == f"{base}_SID-{structure_id}_opt"
+        )
 
 
 class TestGaussianSolventCLIOptCommand:

--- a/tests/test_orca_cli.py
+++ b/tests/test_orca_cli.py
@@ -571,6 +571,40 @@ class TestORCACpcmBlockOptions:
 
 
 class TestORCALabelAndAuxBasisOptions:
+    def test_default_label_appends_subcommand_once(
+        self, single_molecule_xyz_file
+    ):
+        from os.path import basename, splitext
+        from unittest.mock import MagicMock, patch
+
+        from click.testing import CliRunner
+
+        from chemsmart.cli.orca.orca import orca as orca_cli
+
+        runner = CliRunner()
+        with patch("chemsmart.jobs.orca.opt.ORCAOptJob") as mock:
+            mock.return_value = MagicMock()
+            result = runner.invoke(
+                orca_cli,
+                [
+                    "-p",
+                    "gas_solv",
+                    "-f",
+                    single_molecule_xyz_file,
+                    "-c",
+                    "0",
+                    "-m",
+                    "1",
+                    "opt",
+                ],
+                obj={},
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0, result.output
+        base = splitext(basename(single_molecule_xyz_file))[0]
+        assert mock.call_args.kwargs["label"] == f"{base}_opt"
+
     def test_short_a_sets_append_label(self, single_molecule_xyz_file):
         from os.path import basename, splitext
         from unittest.mock import MagicMock, patch


### PR DESCRIPTION
In chemsmart/cli/orca/orca.py,when neither `-l` nor `-a` is given, ctx.invoked_subcommand (opt / sp / …) is appended twice:
```
    if label is None and append_label is None:
        label = os.path.splitext(os.path.basename(filename))[0]
        if filename:
            label = os.path.splitext(os.path.basename(filename))[0]
        else:
            label = "output"
        if ctx.invoked_subcommand:
            label = f"{label}_{ctx.invoked_subcommand}" # duplicate appending ctx.invoked_subcommand 
```

Also, Gaussian DB tags are wiped so default Gaussian DB jobs get bare `db_opt`, not `db_SID-…_opt` (ORCA/mol jobs keep the correct labels):

```
        if is_chemsmart_db:
            if structure_id is not None:
                label = f"{label}_SID-{structure_id}"
            elif record_id is not None:
                label = f"{label}_RID-{record_id}"
            elif record_index is not None:
                label = f"{label}_RI-{record_index}"
        if filename:
            label = os.path.splitext(os.path.basename(filename))[0]  # label is overwritten here.
        else:
            label = "output"

```
Both bugs were introduced accidentally by a merge commit e7773084, and is fixed in this PR. Thanks @Huiwen-Tan for spotting this!