### PR TITLE
fix: CI error triggered by pymol import

### DIFF
--- a/chemsmart/jobs/mol/templates/zhang_group_scientific_styles.py
+++ b/chemsmart/jobs/mol/templates/zhang_group_scientific_styles.py
@@ -18,7 +18,11 @@ In PyMOL directly::
 """
 
 import numpy as np
-from pymol import cmd  # type: ignore
+
+try:
+    from pymol import cmd  # type: ignore
+except ImportError:
+    cmd = None
 
 from chemsmart.utils.geometry import get_coordinating_atoms
 from chemsmart.utils.periodictable import is_metal, metal_element_symbols
@@ -1557,4 +1561,5 @@ def _make_style_wrapper(style_cls):
 for _style_cls in SCIENTIFIC_STYLE_CLASSES:
     _wrapper = _make_style_wrapper(_style_cls)
     globals()[_style_cls.command] = _wrapper
-    cmd.extend(_style_cls.command, _wrapper)
+    if cmd is not None:
+        cmd.extend(_style_cls.command, _wrapper)

--- a/tests/test_PyMOLJobs.py
+++ b/tests/test_PyMOLJobs.py
@@ -1027,6 +1027,18 @@ class TestPyMOLStyleCommands:
             wrapper = getattr(zhang_group_scientific_styles, style_cls.command)
             assert wrapper.__name__ == style_cls.command
 
+    def test_zhang_group_scientific_styles_import_without_pymol(self):
+        """Style template sets cmd=None when PyMOL is not installed."""
+        import importlib.util
+
+        if importlib.util.find_spec("pymol") is not None:
+            pytest.skip("PyMOL installed; ImportError path not exercised here")
+        assert zhang_group_scientific_styles.cmd is None
+        assert hasattr(
+            zhang_group_scientific_styles,
+            SCIENTIFIC_STYLE_CLASSES[0].command,
+        )
+
     def test_select_coordination_uses_command_as_prefix(self, mocker):
         style = StericSurfaceStyle()
         mock_build = mocker.patch.object(

--- a/tests/test_PyMOLJobs.py
+++ b/tests/test_PyMOLJobs.py
@@ -1027,17 +1027,21 @@ class TestPyMOLStyleCommands:
             wrapper = getattr(zhang_group_scientific_styles, style_cls.command)
             assert wrapper.__name__ == style_cls.command
 
-    def test_zhang_group_scientific_styles_import_without_pymol(self):
+    def test_zhang_group_scientific_styles_import_without_pymol(self, mocker):
         """Style template sets cmd=None when PyMOL is not installed."""
         import importlib.util
+        import sys
 
-        if importlib.util.find_spec("pymol") is not None:
-            pytest.skip("PyMOL installed; ImportError path not exercised here")
-        assert zhang_group_scientific_styles.cmd is None
-        assert hasattr(
-            zhang_group_scientific_styles,
-            SCIENTIFIC_STYLE_CLASSES[0].command,
+        spec = importlib.util.spec_from_file_location(
+            "zhang_group_scientific_styles_without_pymol",
+            zhang_group_scientific_styles.__file__,
         )
+        module = importlib.util.module_from_spec(spec)
+        mocker.patch.dict(sys.modules, {"pymol": None, "pymol.cmd": None})
+        spec.loader.exec_module(module)
+
+        assert module.cmd is None
+        assert hasattr(module, SCIENTIFIC_STYLE_CLASSES[0].command)
 
     def test_select_coordination_uses_command_as_prefix(self, mocker):
         style = StericSurfaceStyle()


### PR DESCRIPTION
## **Summary**
Stop CHEMSMART from requiring PyMOL just to import. `zhang_group_scientific_styles.py` used to import pymol at module load, so any import of CHEMSMART failed in environments (e.g., the CI workflow environment) without PyMOL, even when visualization was unused.

PyMOL is now an optional import, so packages like Conflow can import CHEMSMART without it.

## **Changes**
Wrap `from pymol import cmd` in a `try/except ImportError` block and `set cmd = None` when PyMOL is missing.
