### PR TITLE
feat: enhance output path resolution in file conversion CLI

### DIFF
--- a/chemsmart/cli/convert.py
+++ b/chemsmart/cli/convert.py
@@ -34,7 +34,8 @@ logger = logging.getLogger(__name__)
     type=click.Path(),
     default=None,
     help="Output file path (format is inferred from the extension). "
-    "Required when --input is used.",
+    "May be an extension only (e.g. .xyz or xyz) to keep the input "
+    "basename. When omitted with --input, writes {input_stem}.xyz.",
 )
 @click.option(
     "-d",
@@ -66,8 +67,8 @@ logger = logging.getLogger(__name__)
     type=str,
     default="xyz",
     show_default=True,
-    help="Output file type used in batch mode when --output is not "
-    "specified (e.g. xyz, com, pdb).",
+    help="Output file type when --output is not specified "
+    "(e.g. xyz, com, pdb). Used for single-file and batch conversion.",
 )
 @click.option(
     "-z/--no-z",
@@ -95,11 +96,12 @@ def convert(
     """
     Convert molecular structure files between formats.
 
-    Single-file conversion with an explicit output path:
+    Single-file conversion (defaults to {input_stem}.xyz):
 
     \b
+        chemsmart run convert -i molecule.pdb
+        chemsmart run convert -i molecule.pdb -o .mol2
         chemsmart run convert --input a.pdb --output a.xyz
-        chemsmart run convert -i molecule.log -o molecule.xyz
 
     Batch directory conversion:
 
@@ -111,18 +113,19 @@ def convert(
 
     if input_file is not None and directory is not None:
         raise click.UsageError(
-            "Provide either --input/--output (single-file) or "
+            "Provide either --input (single-file) or "
             "--directory/--filetype (batch), not both."
         )
 
     if input_file is not None:
-        if output_file is None:
-            raise click.UsageError(
-                "--output is required when --input is specified."
-            )
+        output_path = FileConverter.resolve_output_path(
+            input_file,
+            output=output_file,
+            output_filetype=output_filetype,
+        )
         FileConverter.convert_file(
             input_file,
-            output_file,
+            output_path,
             include_intermediate_structures=include_intermediate_structures,
         )
         return None
@@ -143,6 +146,6 @@ def convert(
         return None
 
     raise click.UsageError(
-        "Provide either --input/--output (single-file) or "
+        "Provide either --input (single-file) or "
         "--directory/--filetype (batch)."
     )

--- a/chemsmart/io/converter.py
+++ b/chemsmart/io/converter.py
@@ -87,13 +87,11 @@ class FileConverter:
                 # get filetype/extension from filename
                 self.type = self.filename.split(".")[-1]
                 logger.info(f"Converting file: {self.filename}")
-                output_path = self.output_filepath
-                if output_path is None:
-                    filedir, fname = os.path.split(self.filename)
-                    basename = os.path.splitext(fname)[0]
-                    output_path = os.path.join(
-                        filedir, f"{basename}.{self.output_filetype}"
-                    )
+                output_path = self.resolve_output_path(
+                    self.filename,
+                    output=self.output_filepath,
+                    output_filetype=self.output_filetype,
+                )
                 self.convert_file(
                     self.filename,
                     output_path,
@@ -253,6 +251,39 @@ class FileConverter:
             f"Open Babel (overwrite={overwrite})"
         )
         xyz_mol.write("pdb", pdb_filename, overwrite=overwrite)
+
+    @staticmethod
+    def resolve_output_path(input_path, output=None, output_filetype="xyz"):
+        """Resolve a single-file output path from input and output options.
+
+        When *output* is ``None``, returns ``{input_dir}/{input_stem}.{output_filetype}``.
+        When *output* is extension-only (no directory separators and either
+        starts with ``.`` or contains no ``.``), returns
+        ``{input_dir}/{input_stem}.{ext}``.
+        Otherwise *output* is treated as a full output path.
+
+        Args:
+            input_path (str): Path to the input file.
+            output (str | None): Output path or extension shorthand.
+            output_filetype (str): Default output extension when *output* is
+                ``None``. Defaults to ``xyz``.
+
+        Returns:
+            str: Resolved output file path.
+        """
+        filedir, fname = os.path.split(input_path)
+        basename = os.path.splitext(fname)[0]
+
+        if output is None:
+            return os.path.join(filedir, f"{basename}.{output_filetype}")
+
+        if os.path.sep not in output and (
+            output.startswith(".") or "." not in output
+        ):
+            ext = output.lstrip(".")
+            return os.path.join(filedir, f"{basename}.{ext}")
+
+        return output
 
     @staticmethod
     def convert_file(

--- a/docs/source/convert-cli-options.rst
+++ b/docs/source/convert-cli-options.rst
@@ -30,8 +30,12 @@ convert --help`` for the complete list.
       -  Input molecular structure file for single-file conversion
 
    -  -  ``-o, --output``
+
       -  string
-      -  Output file path (format is inferred from the extension). Required when ``--input`` is used
+
+      -  Output file path (format is inferred from the extension). Optional for single-file conversion; may be an
+         extension only (e.g. ``.xyz`` or ``xyz``) to keep the input basename. When omitted with ``--input``, writes
+         ``{input_stem}.xyz`` by default
 
    -  -  ``-d, --directory``
       -  string
@@ -49,7 +53,8 @@ convert --help`` for the complete list.
 
    -  -  ``--output-filetype``
       -  string
-      -  Output file type used in batch mode when ``--output`` is not specified (default: ``xyz``)
+      -  Output file type when ``--output`` is not specified (default: ``xyz``). Used for single-file and batch
+         conversion
 
    -  -  ``-z/--no-z, --include-intermediate-structures/--no-include-intermediate-structures``
       -  bool
@@ -57,16 +62,22 @@ convert --help`` for the complete list.
 
 .. note::
 
-   Provide either ``--input`` / ``--output`` (single-file) or ``--directory`` / ``--filetype`` (batch), not both.
+   Provide either ``--input`` (single-file) or ``--directory`` / ``--filetype`` (batch), not both.
 
 ************************
  Single-File Conversion
 ************************
 
-Single-file conversion infers the output format from the ``--output`` extension:
+When ``--output`` is omitted, the output path defaults to ``{input_stem}.xyz`` in the same directory as the input. Use
+``--output-filetype`` to change the default extension (e.g. ``com``). You may also pass only an extension to
+``--output`` (e.g. ``.mol2`` or ``mol2``) to keep the input basename.
+
+Single-file conversion infers the output format from the resolved output path extension:
 
 .. code:: bash
 
+   chemsmart run convert -i molecule.pdb
+   chemsmart run convert -i molecule.pdb -o .mol2
    chemsmart run convert -i molecule.pdb -o molecule.xyz
    chemsmart run convert -i molecule.log -o molecule.mol2
 

--- a/docs/source/scripts-data-management.rst
+++ b/docs/source/scripts-data-management.rst
@@ -96,7 +96,8 @@ Prefer the built-in CLI for structure conversion:
 
 .. code:: bash
 
-   chemsmart run convert -i molecule.pdb -o molecule.xyz
+   chemsmart run convert -i molecule.pdb
+   chemsmart run convert -i molecule.pdb -o .mol2
    chemsmart run convert -d /path/to/dir -t log --output-filetype xyz
 
 See :doc:`convert-cli-options` and :doc:`molecule-input-formats` for convert options, supported formats, and the Open

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1,11 +1,14 @@
+import inspect
 import os.path
 from shutil import copy, copytree, rmtree
 from unittest.mock import patch
 
+import click
 import numpy as np
 import pytest
 from click.testing import CliRunner
 
+from chemsmart.cli.convert import convert
 from chemsmart.cli.main import entry_point
 from chemsmart.io.converter import FileConverter
 from chemsmart.io.gaussian.folder import (
@@ -1416,6 +1419,92 @@ class TestConvertCLI:
         assert "either --input" in result.output.lower() or (
             "--directory/--filetype" in result.output.lower()
         )
+
+    def _call_convert_callback(self, **kwargs):
+        """Call the convert command function, bypassing Click wrapping."""
+        convert_fn = inspect.unwrap(convert.callback)
+        defaults = {
+            "ctx": click.Context(convert),
+            "input_file": None,
+            "output_file": None,
+            "directory": None,
+            "filetype": None,
+            "program": None,
+            "output_filetype": "xyz",
+            "include_intermediate_structures": False,
+            "debug": False,
+            "stream": False,
+        }
+        defaults.update(kwargs)
+        return convert_fn(**defaults)
+
+    def test_convert_callback_resolves_default_output(
+        self, single_model_pdb_file
+    ):
+        """Direct callback call covers resolve_output_path in convert.py."""
+        output_path = single_model_pdb_file.replace(".pdb", ".xyz")
+        result = self._call_convert_callback(
+            input_file=single_model_pdb_file,
+        )
+        assert result is None
+        assert os.path.exists(output_path)
+
+    def test_convert_callback_uses_output_file(self, single_model_pdb_file):
+        output_path = single_model_pdb_file.replace(".pdb", "_named.com")
+        result = self._call_convert_callback(
+            input_file=single_model_pdb_file,
+            output_file=output_path,
+        )
+        assert result is None
+        assert os.path.exists(output_path)
+
+    def test_convert_callback_rejects_input_and_directory(
+        self, single_model_pdb_file, tmpdir
+    ):
+        with pytest.raises(click.UsageError, match="not both"):
+            self._call_convert_callback(
+                input_file=single_model_pdb_file,
+                directory=str(tmpdir),
+            )
+
+    def test_convert_callback_directory_requires_filetype(self, tmpdir):
+        with pytest.raises(click.UsageError, match="--filetype is required"):
+            self._call_convert_callback(directory=str(tmpdir))
+
+    def test_convert_callback_requires_mode(self):
+        with pytest.raises(click.UsageError, match="either --input"):
+            self._call_convert_callback()
+
+    def test_convert_callback_batch_directory(self, tmpdir):
+        with patch("chemsmart.cli.convert.FileConverter") as mock_fc:
+            mock_fc.return_value.convert_files.return_value = None
+            result = self._call_convert_callback(
+                directory=str(tmpdir),
+                filetype="pdb",
+                program="gaussian",
+                output_filetype="xyz",
+                include_intermediate_structures=True,
+            )
+        assert result is None
+        mock_fc.assert_called_once_with(
+            directory=str(tmpdir),
+            type="pdb",
+            program="gaussian",
+            output_filetype="xyz",
+            include_intermediate_structures=True,
+        )
+        mock_fc.return_value.convert_files.assert_called_once_with()
+
+    def test_cli_convert_command_object_defaults_to_xyz(
+        self, single_model_pdb_file
+    ):
+        """Invoke convert directly, without going through ``run``."""
+        output_path = single_model_pdb_file.replace(".pdb", ".xyz")
+        result = CliRunner().invoke(
+            convert, ["--input", single_model_pdb_file]
+        )
+        assert result.exit_code == 0, result.output
+        assert os.path.exists(output_path)
 
 
 class TestOpenBabelWriteFallback:

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1109,6 +1109,54 @@ class TestConverterTwoWay:
         assert mol.num_atoms == 3
 
 
+class TestResolveOutputPath:
+    """Tests for ``FileConverter.resolve_output_path``."""
+
+    def test_resolve_output_path_default(self):
+        assert FileConverter.resolve_output_path(
+            "/path/to/molecule.pdb"
+        ) == os.path.join("/path/to", "molecule.xyz")
+
+    def test_resolve_output_path_output_filetype(self):
+        assert FileConverter.resolve_output_path(
+            "/path/to/molecule.pdb", output_filetype="com"
+        ) == os.path.join("/path/to", "molecule.com")
+
+    def test_resolve_output_path_extension_with_dot(self):
+        assert FileConverter.resolve_output_path(
+            "/path/to/molecule.pdb", output=".mol2"
+        ) == os.path.join("/path/to", "molecule.mol2")
+
+    def test_resolve_output_path_extension_without_dot(self):
+        assert FileConverter.resolve_output_path(
+            "/path/to/molecule.pdb", output="pdb"
+        ) == os.path.join("/path/to", "molecule.pdb")
+
+    def test_resolve_output_path_full_path(self):
+        assert (
+            FileConverter.resolve_output_path(
+                "/path/to/molecule.pdb", output="/tmp/foo.xyz"
+            )
+            == "/tmp/foo.xyz"
+        )
+
+    def test_resolve_output_path_relative_path_with_extension(self):
+        assert (
+            FileConverter.resolve_output_path(
+                "/path/to/molecule.pdb", output="othername.xyz"
+            )
+            == "othername.xyz"
+        )
+
+    def test_resolve_output_path_subdirectory_path(self):
+        assert (
+            FileConverter.resolve_output_path(
+                "/path/to/molecule.pdb", output="subdir/out.xyz"
+            )
+            == "subdir/out.xyz"
+        )
+
+
 class TestConvertCLI:
     """Tests for ``chemsmart run convert``."""
 
@@ -1258,18 +1306,99 @@ class TestConvertCLI:
             ],
         )
         assert result.exit_code != 0
-        assert "either --input/--output" in result.output.lower() or (
+        assert "either --input" in result.output.lower() or (
             "not both" in result.output.lower()
         )
 
-    def test_cli_convert_input_requires_output(self, single_model_pdb_file):
+    def test_cli_convert_input_defaults_to_xyz(self, single_model_pdb_file):
+        output_path = single_model_pdb_file.replace(".pdb", ".xyz")
+
         runner = CliRunner()
         result = runner.invoke(
             entry_point,
             ["run", "convert", "--input", single_model_pdb_file],
         )
-        assert result.exit_code != 0
-        assert "--output" in result.output
+        assert result.exit_code == 0, result.output
+        assert os.path.exists(output_path)
+
+        mol = Molecule.from_filepath(output_path)
+        assert mol.num_atoms == 3
+
+    def test_cli_convert_input_defaults_to_output_filetype(
+        self, single_model_pdb_file
+    ):
+        output_path = single_model_pdb_file.replace(".pdb", ".com")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            entry_point,
+            [
+                "run",
+                "convert",
+                "--input",
+                single_model_pdb_file,
+                "--output-filetype",
+                "com",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert os.path.exists(output_path)
+
+    def test_cli_convert_output_extension_only(self, single_model_pdb_file):
+        output_path = single_model_pdb_file.replace(".pdb", ".com")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            entry_point,
+            [
+                "run",
+                "convert",
+                "--input",
+                single_model_pdb_file,
+                "--output",
+                ".com",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert os.path.exists(output_path)
+
+    def test_cli_convert_output_extension_without_dot(
+        self, single_model_pdb_file
+    ):
+        output_path = single_model_pdb_file.replace(".pdb", ".pdb")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            entry_point,
+            [
+                "run",
+                "convert",
+                "--input",
+                single_model_pdb_file,
+                "--output",
+                "pdb",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert os.path.exists(output_path)
+
+    def test_cli_convert_output_full_path(self, single_model_pdb_file, tmpdir):
+        output_path = os.path.join(str(tmpdir), "othername.xyz")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            entry_point,
+            [
+                "run",
+                "convert",
+                "--input",
+                single_model_pdb_file,
+                "--output",
+                output_path,
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert os.path.exists(output_path)
 
     def test_cli_convert_directory_requires_filetype(self, tmpdir):
         runner = CliRunner()
@@ -1284,7 +1413,7 @@ class TestConvertCLI:
         runner = CliRunner()
         result = runner.invoke(entry_point, ["run", "convert"])
         assert result.exit_code != 0
-        assert "either --input/--output" in result.output.lower() or (
+        assert "either --input" in result.output.lower() or (
             "--directory/--filetype" in result.output.lower()
         )
 


### PR DESCRIPTION
- Updated the `--output` option to allow for extension-only inputs, defaulting to `{input_stem}.xyz` when omitted.
- Refactored output path handling in `FileConverter` to streamline resolution logic.
- Improved CLI documentation to reflect new behavior for single-file conversions.
- Added comprehensive tests for output path resolution scenarios.