### PR TITLE
Standardize CHEMSMART in docs

### DIFF
--- a/docs/source/configuration-project-settings.rst
+++ b/docs/source/configuration-project-settings.rst
@@ -238,7 +238,7 @@ This configuration:
    -  MDCI (Modified Davidson Configuration Interaction) cutoff parameters
 
 This workflow is efficient for obtaining highly accurate energies on DFT-optimized geometries, commonly used for
-thermochemistry and reaction energetics. One can simply use Gaussian .log file as input for chemsmart to automatically
+thermochemistry and reaction energetics. One can simply use Gaussian .log file as input for CHEMSMART to automatically
 create ORCA single-point .inp file in a single command (see later examples).
 
 Key ORCA-Specific Parameters
@@ -394,7 +394,7 @@ This produces:
 
    **ORCA 6.1 duplicate-keyword guard:** When ``solvent_id`` is set, ``COSMORS(solvent_id)`` already encodes the solvent
    in the route line. Writing ``solvent "name"`` inside the ``%cosmors`` block too would cause ORCA to raise an ``INPUT
-   ERROR: DUPLICATED KEYWORD``. chemsmart automatically filters out any ``solvent "..."`` lines from the ``%cosmors``
+   ERROR: DUPLICATED KEYWORD``. CHEMSMART automatically filters out any ``solvent "..."`` lines from the ``%cosmors``
    block when ``solvent_id`` is set.
 
    ``solventfilename "..."`` is a **different** keyword (it points to a ``.cosmorsxyz`` file) and is **never** filtered.
@@ -419,7 +419,7 @@ listed.
           -sm cosmors -si mysolvent -sf /path/to/mysolvent.cosmorsxyz sp
 
    The file is copied to the running directory (scratch or job folder) and ``solventfilename "mysolvent"`` is injected
-   into the ``%cosmors`` block automatically. If scratch is enabled, chemsmart also detects ``solventfilename "..."``
+   into the ``%cosmors`` block automatically. If scratch is enabled, CHEMSMART also detects ``solventfilename "..."``
    entries in the written input and copies the corresponding ``.cosmorsxyz`` file to scratch so ORCA can locate it.
 
 **SMD with named solvent and extra parameters:**

--- a/docs/source/crest-cli-options.rst
+++ b/docs/source/crest-cli-options.rst
@@ -54,20 +54,20 @@ Project and File Options
 
    -  -  ``--ri, --record-index``
       -  int
-      -  Select a record from a chemsmart database by its 1-based index
+      -  Select a record from a CHEMSMART database by its 1-based index
 
    -  -  ``--rid, --record-id``
       -  string
-      -  Select a record from a chemsmart database by its ID
+      -  Select a record from a CHEMSMART database by its ID
 
    -  -  ``--sid, --structure-id``
       -  string
-      -  Select a structure from a chemsmart database by its ID
+      -  Select a structure from a CHEMSMART database by its ID
 
 .. note::
 
    -  ``-p`` uses the project name without the ``.yaml`` extension.
-   -  ``-f`` accepts various formats: ``.xyz``, ``.com``, ``.gjf``, ``.log``, ``.inp``, ``.out``, or a chemsmart
+   -  ``-f`` accepts various formats: ``.xyz``, ``.com``, ``.gjf``, ``.log``, ``.inp``, ``.out``, or a CHEMSMART
       database ``.db`` file.
 
 Specifying Output Filenames
@@ -270,7 +270,7 @@ Examples:
 Database Input
 ==============
 
-CREST jobs can take geometries from a chemsmart ``.db`` file using the selectors:
+CREST jobs can take geometries from a CHEMSMART ``.db`` file using the selectors:
 
 .. code:: bash
 

--- a/docs/source/database-export.rst
+++ b/docs/source/database-export.rst
@@ -209,7 +209,7 @@ from the extension of the output file specified with ``-o/--output``.
    **Hartree/Bohr**. These units are written explicitly in the header. Structures that do not have both energy and
    forces at the chosen level of theory are skipped, and a warning summarizing the skipped structures is logged.
 
-   When ``-x``/``--method-basis`` is omitted for extended XYZ export with ``--mid``, chemsmart automatically picks the
+   When ``-x``/``--method-basis`` is omitted for extended XYZ export with ``--mid``, CHEMSMART automatically picks the
    ``(method, basis)`` pair that covers the most structures with both energy and forces stored. With ``--sid``,
-   chemsmart picks an available ``(method, basis)`` pair with both energy and forces for that structure. With
+   CHEMSMART picks an available ``(method, basis)`` pair with both energy and forces for that structure. With
    ``--ri``/``--rid``, the selected record's own ``method/basis`` is used.

--- a/docs/source/gaussian-cli-options.rst
+++ b/docs/source/gaussian-cli-options.rst
@@ -58,20 +58,20 @@ Project and File Options
 
    -  -  ``--ri, --record-index``
       -  int
-      -  Select a record from a chemsmart database by its 1-based index
+      -  Select a record from a CHEMSMART database by its 1-based index
 
    -  -  ``--rid, --record-id``
       -  string
-      -  Select a record from a chemsmart database by its ID
+      -  Select a record from a CHEMSMART database by its ID
 
    -  -  ``--sid, --structure-id``
       -  string
-      -  Select a structure from a chemsmart database by its ID
+      -  Select a structure from a CHEMSMART database by its ID
 
 .. note::
 
    -  ``-p`` uses the project name without the ``.yaml`` extension.
-   -  ``-f`` accepts various formats: ``.xyz``, ``.com``, ``.gjf``, ``.log``, ``.inp``, ``.out``, or a chemsmart
+   -  ``-f`` accepts various formats: ``.xyz``, ``.com``, ``.gjf``, ``.log``, ``.inp``, ``.out``, or a CHEMSMART
       database ``.db`` file.
 
 Specifying Output Filenames

--- a/docs/source/grouper-cli-options.rst
+++ b/docs/source/grouper-cli-options.rst
@@ -272,7 +272,7 @@ Supported energy types:
 
 **Thermochemistry corrections:**
 
-When using ``qhH``, ``qhG``, or ``sp_qhG``, chemsmart leverages the internal thermochemistry module to compute corrected
+When using ``qhH``, ``qhG``, or ``sp_qhG``, CHEMSMART leverages the internal thermochemistry module to compute corrected
 thermodynamic values. Additional thermochemistry CLI options (e.g., temperature, concentration, frequency cutoffs,
 entropy method) become available.
 

--- a/docs/source/grouper-strategies.rst
+++ b/docs/source/grouper-strategies.rst
@@ -2,7 +2,7 @@
  Grouping Strategies
 #####################
 
-This page provides detailed documentation for each molecular structure grouping strategy available in chemsmart.
+This page provides detailed documentation for each molecular structure grouping strategy available in CHEMSMART.
 
 ***********************
  RMSD-based Strategies

--- a/docs/source/installation-linux-macos.rst
+++ b/docs/source/installation-linux-macos.rst
@@ -105,7 +105,7 @@ What ``make configure`` does on Linux and macOS:
 
 #. **Automatically sources your shell config** — after writing the ``export`` lines, ``make configure`` sources every
    shell rc file that exists (``~/.bashrc``, ``~/.zshrc``, ``~/.profile``) so that ``chemsmart`` is active for the rest
-   of the current make session, regardless of which file chemsmart wrote to.
+   of the current make session, regardless of which file CHEMSMART wrote to.
 
 .. note::
 
@@ -138,5 +138,5 @@ or
 
 .. note::
 
-   If ``~/.bashrc`` (or ``~/.zshrc``) already contains a chemsmart section (i.e. ``make configure`` has been run
+   If ``~/.bashrc`` (or ``~/.zshrc``) already contains a CHEMSMART section (i.e. ``make configure`` has been run
    before), it will *not* be modified again to avoid duplicate entries.

--- a/docs/source/installation-windows-gitbash.rst
+++ b/docs/source/installation-windows-gitbash.rst
@@ -143,7 +143,7 @@ or
 
 .. note::
 
-   If ``~/.bashrc`` already contains a chemsmart section (i.e. ``make configure`` has been run before), it will *not* be
+   If ``~/.bashrc`` already contains a CHEMSMART section (i.e. ``make configure`` has been run before), it will *not* be
    modified again to avoid duplicate entries.
 
 .. tip::

--- a/docs/source/nciplot-tutorial.rst
+++ b/docs/source/nciplot-tutorial.rst
@@ -33,9 +33,9 @@ wavefunction data.
 
 -  ``.xyz`` - Cartesian coordinates
 -  ``.log`` - Gaussian output files (coordinates only)
--  Any other geometry file format supported by chemsmart's file converter
+-  Any other geometry file format supported by CHEMSMART's file converter
 
-**Behavior:** When you provide these file types, chemsmart automatically:
+**Behavior:** When you provide these file types, CHEMSMART automatically:
 
 #. Appends ``_promolecular`` to the job label (unless already present)
 #. Converts non-XYZ files to XYZ format with ``_promolecular.xyz`` suffix
@@ -52,7 +52,7 @@ accurate calculations.
 -  ``.wfn`` - Gaussian wavefunction file
 -  ``.wfx`` - Extended wavefunction format
 
-**Behavior:** When you provide these file types, chemsmart:
+**Behavior:** When you provide these file types, CHEMSMART:
 
 #. Uses the original file label without modification
 #. Directly uses the wavefunction data for density calculations
@@ -60,7 +60,7 @@ accurate calculations.
 
 .. warning::
 
-   After the required files have been generated with NCIPLOT, they can be loaded using chemsmart's built-in :doc:`PyMOL
+   After the required files have been generated with NCIPLOT, they can be loaded using CHEMSMART's built-in :doc:`PyMOL
    visualization commands <pymol-interaction-analysis>`. However, the same molecular structure may yield different NCI
    plots depending on whether NCIPLOT uses **promolecular density** or **wavefunction density**.
 

--- a/docs/source/orca-cli-options.rst
+++ b/docs/source/orca-cli-options.rst
@@ -62,20 +62,20 @@ Project and File Options
 
    -  -  ``--ri, --record-index``
       -  int
-      -  Select a record from a chemsmart database by its 1-based index
+      -  Select a record from a CHEMSMART database by its 1-based index
 
    -  -  ``--rid, --record-id``
       -  string
-      -  Select a record from a chemsmart database by its ID
+      -  Select a record from a CHEMSMART database by its ID
 
    -  -  ``--sid, --structure-id``
       -  string
-      -  Select a structure from a chemsmart database by its ID
+      -  Select a structure from a CHEMSMART database by its ID
 
 .. note::
 
    -  ``-p`` uses the project name without the ``.yaml`` extension.
-   -  ``-f`` accepts various formats: ``.xyz``, ``.com``, ``.gjf``, ``.log``, ``.inp``, ``.out``, or a chemsmart
+   -  ``-f`` accepts various formats: ``.xyz``, ``.com``, ``.gjf``, ``.log``, ``.inp``, ``.out``, or a CHEMSMART
       database ``.db`` file.
 
 Molecular Properties Options
@@ -261,7 +261,7 @@ They can also be specified at the **subcommand level** to override the group-lev
 
       -  Path to a solvent file for the ``cosmors`` model. Any file format is accepted — it does **not** have to be a
          ``.cosmorsxyz`` file. If the path points to a Gaussian output file (e.g. ``basename.log``) or an ORCA output
-         file (e.g. ``basename.out``), chemsmart automatically converts it to ``basename.cosmorsxyz`` (via
+         file (e.g. ``basename.out``), CHEMSMART automatically converts it to ``basename.cosmorsxyz`` (via
          ``Molecule.write_cosmorsxyz()``) before use. The ``.cosmorsxyz`` file is then copied to the running directory
          (scratch or job folder) and its basename (without the ``.cosmorsxyz`` extension) is written as
          ``solventfilename "name"`` inside the ``%cosmors`` block.
@@ -283,7 +283,7 @@ They can also be specified at the **subcommand level** to override the group-lev
 
          **ORCA 6.1 duplicate-keyword guard (openCOSMO-RS only):** ORCA raises an ``INPUT ERROR`` if
          ``COSMORS(solvent_id)`` is on the route line *and* ``solvent "solvent_id"`` also appears in the ``%cosmors``
-         block. When ``-si`` / ``solvent_id`` is set, chemsmart automatically filters out any ``solvent "..."`` lines
+         block. When ``-si`` / ``solvent_id`` is set, CHEMSMART automatically filters out any ``solvent "..."`` lines
          from the ``%cosmors`` block to prevent this error. Note that ``solventfilename "..."`` is a **different**
          keyword (it specifies the path to a ``.cosmorsxyz`` file) and is **not** filtered.
 

--- a/docs/source/pymol-cli-options.rst
+++ b/docs/source/pymol-cli-options.rst
@@ -61,15 +61,15 @@ This page documents the CLI options for molecular visualization and analysis usi
 
    -  -  ``--ri, --record-index``
       -  int
-      -  Select a record from a chemsmart database by its 1-based index
+      -  Select a record from a CHEMSMART database by its 1-based index
 
    -  -  ``--rid, --record-id``
       -  string
-      -  Select a record from a chemsmart database by its ID
+      -  Select a record from a CHEMSMART database by its ID
 
    -  -  ``--sid, --structure-id``
       -  string
-      -  Select a structure from a chemsmart database by its ID
+      -  Select a structure from a CHEMSMART database by its ID
 
    -  -  ``--mid, --molecule-id``
       -  string

--- a/docs/source/scripts-data-management.rst
+++ b/docs/source/scripts-data-management.rst
@@ -106,7 +106,7 @@ Babel write fallback for non-native output types.
 The legacy ``file_converter.py`` script remains available for the same workflow.
 
 For directory-based conversion, ``-t/--filetype`` selects files by extension, while ``-p/--program`` is only needed when
-chemsmart must know which program-specific parser to use.
+CHEMSMART must know which program-specific parser to use.
 
 Usage
 =====

--- a/docs/source/thermochemistry-analysis.rst
+++ b/docs/source/thermochemistry-analysis.rst
@@ -12,7 +12,7 @@ xTB output files.
 The ``thermochemistry`` command parses output files and calculates thermochemical properties including enthalpy,
 entropy, and Gibbs free energy.
 
-When processing a directory, use ``-p/--program`` when chemsmart needs to identify the program from the file content,
+When processing a directory, use ``-p/--program`` when CHEMSMART needs to identify the program from the file content,
 and use ``-t/--filetype`` when you only want to filter by filename suffix such as ``.log`` or ``.out``.
 
 Usage

--- a/docs/source/xtb-cli-options.rst
+++ b/docs/source/xtb-cli-options.rst
@@ -53,20 +53,20 @@ Project and File Options
 
    -  -  ``--ri, --record-index``
       -  int
-      -  Select a record from a chemsmart database by its 1-based index
+      -  Select a record from a CHEMSMART database by its 1-based index
 
    -  -  ``--rid, --record-id``
       -  string
-      -  Select a record from a chemsmart database by its ID
+      -  Select a record from a CHEMSMART database by its ID
 
    -  -  ``--sid, --structure-id``
       -  string
-      -  Select a structure from a chemsmart database by its ID
+      -  Select a structure from a CHEMSMART database by its ID
 
 .. note::
 
    -  ``-p`` uses the project name without the ``.yaml`` extension.
-   -  ``-f`` accepts various formats: ``.xyz``, ``.com``, ``.gjf``, ``.log``, ``.inp``, ``.out``, or a chemsmart
+   -  ``-f`` accepts various formats: ``.xyz``, ``.com``, ``.gjf``, ``.log``, ``.inp``, ``.out``, or a CHEMSMART
       database ``.db`` file.
 
 Specifying Output Filenames
@@ -259,7 +259,7 @@ Examples:
 Database Input
 ==============
 
-xTB jobs can take geometries from a chemsmart ``.db`` file using the selectors:
+xTB jobs can take geometries from a CHEMSMART ``.db`` file using the selectors:
 
 .. code:: bash
 
@@ -312,4 +312,4 @@ arguments provided via ``-r`` are appended at the end.
 -  :doc:`configuration-project-settings` — ``~/.chemsmart/xtb/*.yaml``
 -  :doc:`pymol-visualization` — visualize xTB structures and trajectories
 -  :doc:`thermochemistry-analysis` — post-process xTB calculations
--  :doc:`database-assemble` — assemble xTB folders into a chemsmart database
+-  :doc:`database-assemble` — assemble xTB folders into a CHEMSMART database


### PR DESCRIPTION
Use CHEMSMART for the program and chemsmart for the CLI command in Read the Docs files.

Fixes #576
