### PR TITLE
Add Gaussian-MECP optimization with Harvey BFGS

### DIFF
--- a/chemsmart/cli/chemsmart
+++ b/chemsmart/cli/chemsmart
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+import re
+import sys
+
+from chemsmart.cli.main import main
+
+if __name__ == '__main__':
+    sys.argv[0] = re.sub(r'(-script\.pyw?|\.exe)?$', '', sys.argv[0])
+    sys.exit(main())

--- a/chemsmart/cli/chemsmart
+++ b/chemsmart/cli/chemsmart
@@ -1,9 +1,0 @@
-#!/usr/bin/env python
-import re
-import sys
-
-from chemsmart.cli.main import main
-
-if __name__ == '__main__':
-    sys.argv[0] = re.sub(r'(-script\.pyw?|\.exe)?$', '', sys.argv[0])
-    sys.exit(main())

--- a/chemsmart/cli/gaussian/link.py
+++ b/chemsmart/cli/gaussian/link.py
@@ -8,11 +8,15 @@ from chemsmart.cli.gaussian.gaussian import (
     click_gaussian_solvent_options,
     gaussian,
 )
+<<<<<<< Updated upstream
 from chemsmart.cli.gaussian.mecp_options import (
     add_mecp_method_suffix,
     click_mecp_restart_option,
     click_mecp_step_size_method_option,
 )
+=======
+from chemsmart.cli.gaussian.mecp_options import click_gaussian_mecp_state_options
+>>>>>>> Stashed changes
 from chemsmart.cli.job import click_job_options
 from chemsmart.utils.cli import (
     MyCommand,
@@ -49,6 +53,7 @@ logger = logging.getLogger(__name__)
     "--route", type=str, default=None, help="Route for the link section."
 )
 # MECP-specific options (used when --jobtype mecp)
+<<<<<<< Updated upstream
 @click.option(
     "--multiplicity-1",
     "-m1",
@@ -81,6 +86,9 @@ logger = logging.getLogger(__name__)
     default=None,
     help="[MECP] Charge for state 2. Defaults to charge-1.",
 )
+=======
+@click_gaussian_mecp_state_options
+>>>>>>> Stashed changes
 @click.option(
     "--max-steps",
     type=int,
@@ -400,7 +408,11 @@ def _link_mecp(
     if mecp_settings.multiplicity_a is None:
         raise ValueError(
             "State A multiplicity is not set. "
+<<<<<<< Updated upstream
             "Use gaussian -m/--multiplicity or link -j mecp --multiplicity-1/-m1."
+=======
+            "Use gaussian -m/--multiplicity or link -j mecp --multiplicity1."
+>>>>>>> Stashed changes
         )
 
     if multiplicity2 is None:
@@ -415,7 +427,11 @@ def _link_mecp(
     if mecp_settings.charge_a is None:
         raise ValueError(
             "State A charge is not set. "
+<<<<<<< Updated upstream
             "Use gaussian -c/--charge or link -j mecp --charge-1/-c1."
+=======
+            "Use gaussian -c/--charge or link -j mecp --charge1."
+>>>>>>> Stashed changes
         )
 
     if charge2 is None:

--- a/chemsmart/cli/gaussian/link.py
+++ b/chemsmart/cli/gaussian/link.py
@@ -124,16 +124,15 @@ logger = logging.getLogger(__name__)
 @click.option(
     "--step-size-method",
     type=click.Choice(
-        ["bb", "grow_shrink", "harvey", "harvey_bfgs"],
+        ["bb", "grow_shrink", "harvey"],
         case_sensitive=False,
     ),
     default=None,
     help=(
         "[MECP] Step size adaptation algorithm when adaptive is enabled. "
-        "'bb' uses the Barzilai-Borwein secant rule (default). "
-        "'grow_shrink' uses a merit-based grow/shrink rule; 'harvey' uses "
-        "Harvey's energy-based heuristic; 'harvey_bfgs' uses the full "
-        "Harvey quasi-Newton optimizer."
+        "'harvey' uses the Harvey inverse-BFGS optimizer (default). "
+        "'bb' uses the Barzilai-Borwein secant rule; 'grow_shrink' uses "
+        "a merit-based grow/shrink rule."
     ),
 )
 @click.option(

--- a/chemsmart/cli/gaussian/link.py
+++ b/chemsmart/cli/gaussian/link.py
@@ -50,36 +50,36 @@ logger = logging.getLogger(__name__)
 )
 # MECP-specific options (used when --jobtype mecp)
 @click.option(
-    "--multiplicity1",
-    "--m1",
+    "--multiplicity-1",
+    "-m1",
     "multiplicity1",
     type=int,
     default=None,
     help="[MECP] Spin multiplicity for state 1.",
 )
 @click.option(
-    "--multiplicity2",
-    "--m2",
+    "--multiplicity-2",
+    "-m2",
     "multiplicity2",
     type=int,
     default=None,
-    help="[MECP] Spin multiplicity for state 2. Defaults to multiplicity1 + 2.",
+    help="[MECP] Spin multiplicity for state 2. Defaults to multiplicity-1 + 2.",
 )
 @click.option(
-    "--charge1",
-    "--c1",
+    "--charge-1",
+    "-c1",
     "charge1",
     type=int,
     default=None,
     help="[MECP] Charge for state 1.",
 )
 @click.option(
-    "--charge2",
-    "--c2",
+    "--charge-2",
+    "-c2",
     "charge2",
     type=int,
     default=None,
-    help="[MECP] Charge for state 2. Defaults to charge1.",
+    help="[MECP] Charge for state 2. Defaults to charge-1.",
 )
 @click.option(
     "--max-steps",
@@ -400,7 +400,7 @@ def _link_mecp(
     if mecp_settings.multiplicity_a is None:
         raise ValueError(
             "State A multiplicity is not set. "
-            "Use gaussian -m/--multiplicity or link -j mecp --multiplicity1/--m1."
+            "Use gaussian -m/--multiplicity or link -j mecp --multiplicity-1/-m1."
         )
 
     if multiplicity2 is None:
@@ -415,7 +415,7 @@ def _link_mecp(
     if mecp_settings.charge_a is None:
         raise ValueError(
             "State A charge is not set. "
-            "Use gaussian -c/--charge or link -j mecp --charge1/--c1."
+            "Use gaussian -c/--charge or link -j mecp --charge-1/-c1."
         )
 
     if charge2 is None:
@@ -472,9 +472,12 @@ def _link_mecp(
         mecp_settings.functional = "u" + mecp_settings.functional
 
     molecule = ctx.obj["molecules"][-1]
-    label = add_mecp_method_suffix(
-        ctx.obj["label"], mecp_settings.step_size_method
-    ) + "_link"
+    label = (
+        add_mecp_method_suffix(
+            ctx.obj["label"], mecp_settings.step_size_method
+        )
+        + "_link"
+    )
 
     logger.info(
         f"Link MECP job settings from project: {mecp_settings.__dict__}"

--- a/chemsmart/cli/gaussian/link.py
+++ b/chemsmart/cli/gaussian/link.py
@@ -52,7 +52,7 @@ logger = logging.getLogger(__name__)
 @click.option(
     "--multiplicity1",
     "--m1",
-    "multiplicity_a",
+    "multiplicity1",
     type=int,
     default=None,
     help="[MECP] Spin multiplicity for state 1.",
@@ -60,7 +60,7 @@ logger = logging.getLogger(__name__)
 @click.option(
     "--multiplicity2",
     "--m2",
-    "multiplicity_b",
+    "multiplicity2",
     type=int,
     default=None,
     help="[MECP] Spin multiplicity for state 2. Defaults to multiplicity1 + 2.",
@@ -68,7 +68,7 @@ logger = logging.getLogger(__name__)
 @click.option(
     "--charge1",
     "--c1",
-    "charge_a",
+    "charge1",
     type=int,
     default=None,
     help="[MECP] Charge for state 1.",
@@ -76,7 +76,7 @@ logger = logging.getLogger(__name__)
 @click.option(
     "--charge2",
     "--c2",
-    "charge_b",
+    "charge2",
     type=int,
     default=None,
     help="[MECP] Charge for state 2. Defaults to charge1.",
@@ -183,10 +183,10 @@ def link(
     stepsize,
     direction,
     # MECP options
-    multiplicity_a,
-    multiplicity_b,
-    charge_a,
-    charge_b,
+    multiplicity1,
+    multiplicity2,
+    charge1,
+    charge2,
     max_steps,
     energy_diff_tol,
     force_max_tol,
@@ -214,10 +214,10 @@ def link(
             solvent_model=solvent_model,
             solvent_id=solvent_id,
             solvent_options=solvent_options,
-            multiplicity_a=multiplicity_a,
-            multiplicity_b=multiplicity_b,
-            charge_a=charge_a,
-            charge_b=charge_b,
+            multiplicity1=multiplicity1,
+            multiplicity2=multiplicity2,
+            charge1=charge1,
+            charge2=charge2,
             max_steps=max_steps,
             step_size=step_size,
             energy_diff_tol=energy_diff_tol,
@@ -341,10 +341,10 @@ def _link_mecp(
     solvent_model,
     solvent_id,
     solvent_options,
-    multiplicity_a,
-    multiplicity_b,
-    charge_a,
-    charge_b,
+    multiplicity1,
+    multiplicity2,
+    charge1,
+    charge2,
     max_steps,
     step_size,
     energy_diff_tol,
@@ -393,35 +393,35 @@ def _link_mecp(
     )
 
     # --- state A charge / multiplicity ---
-    if multiplicity_a is None:
+    if multiplicity1 is None:
         mecp_settings.multiplicity_a = mecp_project_settings.multiplicity
     else:
-        mecp_settings.multiplicity_a = multiplicity_a
+        mecp_settings.multiplicity_a = multiplicity1
     if mecp_settings.multiplicity_a is None:
         raise ValueError(
             "State A multiplicity is not set. "
             "Use gaussian -m/--multiplicity or link -j mecp --multiplicity1/--m1."
         )
 
-    if multiplicity_b is None:
+    if multiplicity2 is None:
         mecp_settings.multiplicity_b = mecp_settings.multiplicity_a + 2
     else:
-        mecp_settings.multiplicity_b = multiplicity_b
+        mecp_settings.multiplicity_b = multiplicity2
 
-    if charge_a is None:
+    if charge1 is None:
         mecp_settings.charge_a = mecp_settings.charge
     else:
-        mecp_settings.charge_a = charge_a
+        mecp_settings.charge_a = charge1
     if mecp_settings.charge_a is None:
         raise ValueError(
             "State A charge is not set. "
             "Use gaussian -c/--charge or link -j mecp --charge1/--c1."
         )
 
-    if charge_b is None:
+    if charge2 is None:
         mecp_settings.charge_b = mecp_settings.charge_a
     else:
-        mecp_settings.charge_b = charge_b
+        mecp_settings.charge_b = charge2
 
     # --- broken-symmetry (link) settings ---
     mecp_settings.use_link = True

--- a/chemsmart/cli/gaussian/link.py
+++ b/chemsmart/cli/gaussian/link.py
@@ -8,6 +8,11 @@ from chemsmart.cli.gaussian.gaussian import (
     click_gaussian_solvent_options,
     gaussian,
 )
+from chemsmart.cli.gaussian.mecp_options import (
+    add_mecp_method_suffix,
+    click_mecp_restart_option,
+    click_mecp_step_size_method_option,
+)
 from chemsmart.cli.job import click_job_options
 from chemsmart.utils.cli import (
     MyCommand,
@@ -45,28 +50,36 @@ logger = logging.getLogger(__name__)
 )
 # MECP-specific options (used when --jobtype mecp)
 @click.option(
-    "--multiplicity-a",
+    "--multiplicity1",
+    "--m1",
+    "multiplicity_a",
     type=int,
     default=None,
-    help="[MECP] Spin multiplicity for state A.",
+    help="[MECP] Spin multiplicity for state 1.",
 )
 @click.option(
-    "--multiplicity-b",
+    "--multiplicity2",
+    "--m2",
+    "multiplicity_b",
     type=int,
     default=None,
-    help="[MECP] Spin multiplicity for state B. Defaults to multiplicity-a + 2.",
+    help="[MECP] Spin multiplicity for state 2. Defaults to multiplicity1 + 2.",
 )
 @click.option(
-    "--charge-a",
+    "--charge1",
+    "--c1",
+    "charge_a",
     type=int,
     default=None,
-    help="[MECP] Charge for state A.",
+    help="[MECP] Charge for state 1.",
 )
 @click.option(
-    "--charge-b",
+    "--charge2",
+    "--c2",
+    "charge_b",
     type=int,
     default=None,
-    help="[MECP] Charge for state B. Defaults to charge-a.",
+    help="[MECP] Charge for state 2. Defaults to charge1.",
 )
 @click.option(
     "--max-steps",
@@ -119,22 +132,9 @@ logger = logging.getLogger(__name__)
 @click.option(
     "--adaptive-step-size/--no-adaptive-step-size",
     default=None,
-    help="[MECP] Enable adaptive step size scaling (default: enabled).",
+    help="[MECP] Enable adaptive scaling for bb/grow_shrink (default: enabled).",
 )
-@click.option(
-    "--step-size-method",
-    type=click.Choice(
-        ["bb", "grow_shrink", "harvey"],
-        case_sensitive=False,
-    ),
-    default=None,
-    help=(
-        "[MECP] Step size adaptation algorithm when adaptive is enabled. "
-        "'harvey' uses the Harvey inverse-BFGS optimizer (default). "
-        "'bb' uses the Barzilai-Borwein secant rule; 'grow_shrink' uses "
-        "a merit-based grow/shrink rule."
-    ),
-)
+@click_mecp_step_size_method_option
 @click.option(
     "--step-size-grow",
     type=float,
@@ -159,6 +159,7 @@ logger = logging.getLogger(__name__)
     default=None,
     help="[MECP] Maximum allowed adaptive step size in Bohr^2/Hartree (default: 1.0).",
 )
+@click_mecp_restart_option
 @click.pass_context
 def link(
     ctx,
@@ -198,6 +199,7 @@ def link(
     step_size_shrink,
     step_size_min,
     step_size_max,
+    restart,
     **kwargs,
 ):
     """CLI subcommand for running Gaussian link jobs."""
@@ -229,6 +231,7 @@ def link(
             step_size_shrink=step_size_shrink,
             step_size_min=step_size_min,
             step_size_max=step_size_max,
+            restart=restart,
             **kwargs,
         )
 
@@ -355,6 +358,7 @@ def _link_mecp(
     step_size_shrink,
     step_size_min,
     step_size_max,
+    restart,
     **kwargs,
 ):
     """
@@ -396,7 +400,7 @@ def _link_mecp(
     if mecp_settings.multiplicity_a is None:
         raise ValueError(
             "State A multiplicity is not set. "
-            "Use gaussian -m/--multiplicity or link -j mecp --multiplicity-a."
+            "Use gaussian -m/--multiplicity or link -j mecp --multiplicity1/--m1."
         )
 
     if multiplicity_b is None:
@@ -411,7 +415,7 @@ def _link_mecp(
     if mecp_settings.charge_a is None:
         raise ValueError(
             "State A charge is not set. "
-            "Use gaussian -c/--charge or link -j mecp --charge-a."
+            "Use gaussian -c/--charge or link -j mecp --charge1/--c1."
         )
 
     if charge_b is None:
@@ -461,13 +465,16 @@ def _link_mecp(
         mecp_settings.step_size_min = step_size_min
     if step_size_max is not None:
         mecp_settings.step_size_max = step_size_max
+    mecp_settings.restart = restart
 
     # automatically use unrestricted DFT for broken-symmetry calculations
     if not mecp_settings.functional.lower().startswith("u"):
         mecp_settings.functional = "u" + mecp_settings.functional
 
     molecule = ctx.obj["molecules"][-1]
-    label = ctx.obj["label"] + "_mecp_link"
+    label = add_mecp_method_suffix(
+        ctx.obj["label"], mecp_settings.step_size_method
+    ) + "_link"
 
     logger.info(
         f"Link MECP job settings from project: {mecp_settings.__dict__}"

--- a/chemsmart/cli/gaussian/link.py
+++ b/chemsmart/cli/gaussian/link.py
@@ -8,15 +8,12 @@ from chemsmart.cli.gaussian.gaussian import (
     click_gaussian_solvent_options,
     gaussian,
 )
-<<<<<<< Updated upstream
 from chemsmart.cli.gaussian.mecp_options import (
     add_mecp_method_suffix,
     click_mecp_restart_option,
+    click_mecp_state_options,
     click_mecp_step_size_method_option,
 )
-=======
-from chemsmart.cli.gaussian.mecp_options import click_gaussian_mecp_state_options
->>>>>>> Stashed changes
 from chemsmart.cli.job import click_job_options
 from chemsmart.utils.cli import (
     MyCommand,
@@ -53,42 +50,7 @@ logger = logging.getLogger(__name__)
     "--route", type=str, default=None, help="Route for the link section."
 )
 # MECP-specific options (used when --jobtype mecp)
-<<<<<<< Updated upstream
-@click.option(
-    "--multiplicity-1",
-    "-m1",
-    "multiplicity1",
-    type=int,
-    default=None,
-    help="[MECP] Spin multiplicity for state 1.",
-)
-@click.option(
-    "--multiplicity-2",
-    "-m2",
-    "multiplicity2",
-    type=int,
-    default=None,
-    help="[MECP] Spin multiplicity for state 2. Defaults to multiplicity-1 + 2.",
-)
-@click.option(
-    "--charge-1",
-    "-c1",
-    "charge1",
-    type=int,
-    default=None,
-    help="[MECP] Charge for state 1.",
-)
-@click.option(
-    "--charge-2",
-    "-c2",
-    "charge2",
-    type=int,
-    default=None,
-    help="[MECP] Charge for state 2. Defaults to charge-1.",
-)
-=======
-@click_gaussian_mecp_state_options
->>>>>>> Stashed changes
+@click_mecp_state_options
 @click.option(
     "--max-steps",
     type=int,
@@ -408,11 +370,7 @@ def _link_mecp(
     if mecp_settings.multiplicity_a is None:
         raise ValueError(
             "State A multiplicity is not set. "
-<<<<<<< Updated upstream
-            "Use gaussian -m/--multiplicity or link -j mecp --multiplicity-1/-m1."
-=======
             "Use gaussian -m/--multiplicity or link -j mecp --multiplicity1."
->>>>>>> Stashed changes
         )
 
     if multiplicity2 is None:
@@ -427,11 +385,7 @@ def _link_mecp(
     if mecp_settings.charge_a is None:
         raise ValueError(
             "State A charge is not set. "
-<<<<<<< Updated upstream
-            "Use gaussian -c/--charge or link -j mecp --charge-1/-c1."
-=======
             "Use gaussian -c/--charge or link -j mecp --charge1."
->>>>>>> Stashed changes
         )
 
     if charge2 is None:

--- a/chemsmart/cli/gaussian/link.py
+++ b/chemsmart/cli/gaussian/link.py
@@ -123,12 +123,17 @@ logger = logging.getLogger(__name__)
 )
 @click.option(
     "--step-size-method",
-    type=click.Choice(["bb", "grow_shrink"], case_sensitive=False),
+    type=click.Choice(
+        ["bb", "grow_shrink", "harvey", "harvey_bfgs"],
+        case_sensitive=False,
+    ),
     default=None,
     help=(
         "[MECP] Step size adaptation algorithm when adaptive is enabled. "
         "'bb' uses the Barzilai-Borwein secant rule (default). "
-        "'grow_shrink' uses a merit-based grow/shrink rule."
+        "'grow_shrink' uses a merit-based grow/shrink rule; 'harvey' uses "
+        "Harvey's energy-based heuristic; 'harvey_bfgs' uses the full "
+        "Harvey quasi-Newton optimizer."
     ),
 )
 @click.option(

--- a/chemsmart/cli/gaussian/mecp.py
+++ b/chemsmart/cli/gaussian/mecp.py
@@ -1,4 +1,4 @@
-import logging
+﻿import logging
 
 import click
 
@@ -118,7 +118,7 @@ logger = logging.getLogger(__name__)
 )
 @click.option(
     "--step-size-method",
-    type=click.Choice(["bb", "grow_shrink"], case_sensitive=False),
+    type=click.Choice(["bb", "grow_shrink", "harvey"], case_sensitive=False),
     default=None,
     help=(
         "Step size adaptation algorithm when adaptive is enabled. "

--- a/chemsmart/cli/gaussian/mecp.py
+++ b/chemsmart/cli/gaussian/mecp.py
@@ -19,36 +19,36 @@ logger = logging.getLogger(__name__)
 @gaussian.command("mecp", cls=MyCommand)
 @click_job_options
 @click.option(
-    "--multiplicity1",
-    "--m1",
+    "--multiplicity-1",
+    "-m1",
     "multiplicity1",
     type=int,
     default=None,
     help="Spin multiplicity for state 1.",
 )
 @click.option(
-    "--multiplicity2",
-    "--m2",
+    "--multiplicity-2",
+    "-m2",
     "multiplicity2",
     type=int,
     default=None,
-    help="Spin multiplicity for state 2. Defaults to multiplicity1 + 2.",
+    help="Spin multiplicity for state 2. Defaults to multiplicity-1 + 2.",
 )
 @click.option(
-    "--charge1",
-    "--c1",
+    "--charge-1",
+    "-c1",
     "charge1",
     type=int,
     default=None,
     help="Charge for state 1.",
 )
 @click.option(
-    "--charge2",
-    "--c2",
+    "--charge-2",
+    "-c2",
     "charge2",
     type=int,
     default=None,
-    help="Charge for state 2. Defaults to charge1.",
+    help="Charge for state 2. Defaults to charge-1.",
 )
 @click.option(
     "--title-a",
@@ -243,7 +243,7 @@ def mecp(
     if mecp_settings.multiplicity_a is None:
         raise ValueError(
             "State A multiplicity is not set. "
-            "Use gaussian -m/--multiplicity or mecp --multiplicity1/--m1."
+            "Use gaussian -m/--multiplicity or mecp --multiplicity-1/-m1."
         )
 
     if multiplicity2 is None:
@@ -260,7 +260,7 @@ def mecp(
     if mecp_settings.charge_a is None:
         raise ValueError(
             "State A charge is not set. "
-            "Use gaussian -c/--charge or mecp --charge1/--c1."
+            "Use gaussian -c/--charge or mecp --charge-1/-c1."
         )
     if charge2 is None:
         mecp_settings.charge_b = mecp_settings.charge_a

--- a/chemsmart/cli/gaussian/mecp.py
+++ b/chemsmart/cli/gaussian/mecp.py
@@ -119,14 +119,15 @@ logger = logging.getLogger(__name__)
 @click.option(
     "--step-size-method",
     type=click.Choice(
-        ["bb", "grow_shrink", "harvey", "harvey_bfgs"],
+        ["bb", "grow_shrink", "harvey"],
         case_sensitive=False,
     ),
     default=None,
     help=(
         "Step size adaptation algorithm when adaptive is enabled. "
-        "'bb' uses the Barzilai-Borwein secant rule (default, faster). "
-        "'grow_shrink' uses a merit-based grow/shrink rule."
+        "'harvey' uses the Harvey inverse-BFGS optimizer (default). "
+        "'bb' uses the Barzilai-Borwein secant rule; 'grow_shrink' uses "
+        "a merit-based grow/shrink rule."
     ),
 )
 @click.option(

--- a/chemsmart/cli/gaussian/mecp.py
+++ b/chemsmart/cli/gaussian/mecp.py
@@ -3,6 +3,11 @@ import logging
 import click
 
 from chemsmart.cli.gaussian.gaussian import gaussian
+from chemsmart.cli.gaussian.mecp_options import (
+    add_mecp_method_suffix,
+    click_mecp_restart_option,
+    click_mecp_step_size_method_option,
+)
 from chemsmart.cli.job import click_job_options
 from chemsmart.jobs.gaussian.settings import GaussianMECPJobSettings
 from chemsmart.utils.cli import MyCommand
@@ -14,28 +19,36 @@ logger = logging.getLogger(__name__)
 @gaussian.command("mecp", cls=MyCommand)
 @click_job_options
 @click.option(
-    "--multiplicity-a",
+    "--multiplicity1",
+    "--m1",
+    "multiplicity_a",
     type=int,
     default=None,
-    help="Spin multiplicity for state A.",
+    help="Spin multiplicity for state 1.",
 )
 @click.option(
-    "--multiplicity-b",
+    "--multiplicity2",
+    "--m2",
+    "multiplicity_b",
     type=int,
     default=None,
-    help="Spin multiplicity for state B. Defaults to multiplicity-a + 2.",
+    help="Spin multiplicity for state 2. Defaults to multiplicity1 + 2.",
 )
 @click.option(
-    "--charge-a",
+    "--charge1",
+    "--c1",
+    "charge_a",
     type=int,
     default=None,
-    help="Charge for state A.",
+    help="Charge for state 1.",
 )
 @click.option(
-    "--charge-b",
+    "--charge2",
+    "--c2",
+    "charge_b",
     type=int,
     default=None,
-    help="Charge for state B. Defaults to charge-a.",
+    help="Charge for state 2. Defaults to charge1.",
 )
 @click.option(
     "--title-a",
@@ -114,22 +127,9 @@ logger = logging.getLogger(__name__)
 @click.option(
     "--adaptive-step-size/--no-adaptive-step-size",
     default=None,
-    help="Enable adaptive step size scaling (default: enabled).",
+    help="Enable adaptive scaling for bb/grow_shrink (default: enabled).",
 )
-@click.option(
-    "--step-size-method",
-    type=click.Choice(
-        ["bb", "grow_shrink", "harvey"],
-        case_sensitive=False,
-    ),
-    default=None,
-    help=(
-        "Step size adaptation algorithm when adaptive is enabled. "
-        "'harvey' uses the Harvey inverse-BFGS optimizer (default). "
-        "'bb' uses the Barzilai-Borwein secant rule; 'grow_shrink' uses "
-        "a merit-based grow/shrink rule."
-    ),
-)
+@click_mecp_step_size_method_option
 @click.option(
     "--step-size-grow",
     type=float,
@@ -174,6 +174,7 @@ logger = logging.getLogger(__name__)
     help="Finite-difference step size (Bohr) for the numerical Hessian used in "
     "--verify-seam-minimum (default: 1e-3).",
 )
+@click_mecp_restart_option
 @click.pass_context
 def mecp(
     ctx,
@@ -200,6 +201,7 @@ def mecp(
     step_size_max,
     verify_seam_minimum,
     hess_step_size,
+    restart,
     skip_completed,
     **kwargs,
 ):
@@ -241,7 +243,7 @@ def mecp(
     if mecp_settings.multiplicity_a is None:
         raise ValueError(
             "State A multiplicity is not set. "
-            "Use gaussian -m/--multiplicity or mecp --multiplicity-a."
+            "Use gaussian -m/--multiplicity or mecp --multiplicity1/--m1."
         )
 
     if multiplicity_b is None:
@@ -258,7 +260,7 @@ def mecp(
     if mecp_settings.charge_a is None:
         raise ValueError(
             "State A charge is not set. "
-            "Use gaussian -c/--charge or mecp --charge-a."
+            "Use gaussian -c/--charge or mecp --charge1/--c1."
         )
     if charge_b is None:
         mecp_settings.charge_b = mecp_settings.charge_a
@@ -310,6 +312,7 @@ def mecp(
     if step_size_max is not None:
         mecp_settings.step_size_max = step_size_max
     mecp_settings.verify_seam_minimum = verify_seam_minimum
+    mecp_settings.restart = restart
     if hess_step_size is not None:
         mecp_settings.hess_step_size = hess_step_size
 
@@ -321,6 +324,7 @@ def mecp(
 
     # get label for the job
     label = ctx.obj["label"]
+    label = add_mecp_method_suffix(label, mecp_settings.step_size_method)
 
     logger.debug(f"Label for job: {label}")
 

--- a/chemsmart/cli/gaussian/mecp.py
+++ b/chemsmart/cli/gaussian/mecp.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 @click.option(
     "--multiplicity1",
     "--m1",
-    "multiplicity_a",
+    "multiplicity1",
     type=int,
     default=None,
     help="Spin multiplicity for state 1.",
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 @click.option(
     "--multiplicity2",
     "--m2",
-    "multiplicity_b",
+    "multiplicity2",
     type=int,
     default=None,
     help="Spin multiplicity for state 2. Defaults to multiplicity1 + 2.",
@@ -37,7 +37,7 @@ logger = logging.getLogger(__name__)
 @click.option(
     "--charge1",
     "--c1",
-    "charge_a",
+    "charge1",
     type=int,
     default=None,
     help="Charge for state 1.",
@@ -45,7 +45,7 @@ logger = logging.getLogger(__name__)
 @click.option(
     "--charge2",
     "--c2",
-    "charge_b",
+    "charge2",
     type=int,
     default=None,
     help="Charge for state 2. Defaults to charge1.",
@@ -178,10 +178,10 @@ logger = logging.getLogger(__name__)
 @click.pass_context
 def mecp(
     ctx,
-    multiplicity_a,
-    multiplicity_b,
-    charge_a,
-    charge_b,
+    multiplicity1,
+    multiplicity2,
+    charge1,
+    charge2,
     title_a,
     title_b,
     max_steps,
@@ -235,37 +235,37 @@ def mecp(
     )
 
     # update mecp_settings if any attribute is specified in cli options
-    if multiplicity_a is None:
+    if multiplicity1 is None:
         # if not given, then takes value from gaussian project settings or input file
         mecp_settings.multiplicity_a = mecp_project_settings.multiplicity
     else:
-        mecp_settings.multiplicity_a = multiplicity_a
+        mecp_settings.multiplicity_a = multiplicity1
     if mecp_settings.multiplicity_a is None:
         raise ValueError(
             "State A multiplicity is not set. "
             "Use gaussian -m/--multiplicity or mecp --multiplicity1/--m1."
         )
 
-    if multiplicity_b is None:
+    if multiplicity2 is None:
         # if not given, then defaults to multiplicity_a + 2
         mecp_settings.multiplicity_b = mecp_settings.multiplicity_a + 2
     else:
-        mecp_settings.multiplicity_b = multiplicity_b
+        mecp_settings.multiplicity_b = multiplicity2
 
-    if charge_a is None:
+    if charge1 is None:
         mecp_settings.charge_a = mecp_settings.charge
     else:
-        mecp_settings.charge_a = charge_a
+        mecp_settings.charge_a = charge1
 
     if mecp_settings.charge_a is None:
         raise ValueError(
             "State A charge is not set. "
             "Use gaussian -c/--charge or mecp --charge1/--c1."
         )
-    if charge_b is None:
+    if charge2 is None:
         mecp_settings.charge_b = mecp_settings.charge_a
     else:
-        mecp_settings.charge_b = charge_b
+        mecp_settings.charge_b = charge2
 
     if title_a is not None:
         mecp_settings.title_a = title_a

--- a/chemsmart/cli/gaussian/mecp.py
+++ b/chemsmart/cli/gaussian/mecp.py
@@ -118,7 +118,7 @@ logger = logging.getLogger(__name__)
 )
 @click.option(
     "--step-size-method",
-    type=click.Choice(["bb", "grow_shrink", "harvey"], case_sensitive=False),
+    type=click.Choice(["bb", "grow_shrink", "harvey", "harvey_bfgs"], case_sensitive=False),
     default=None,
     help=(
         "Step size adaptation algorithm when adaptive is enabled. "

--- a/chemsmart/cli/gaussian/mecp.py
+++ b/chemsmart/cli/gaussian/mecp.py
@@ -3,15 +3,12 @@ import logging
 import click
 
 from chemsmart.cli.gaussian.gaussian import gaussian
-<<<<<<< Updated upstream
 from chemsmart.cli.gaussian.mecp_options import (
     add_mecp_method_suffix,
     click_mecp_restart_option,
+    click_mecp_state_options,
     click_mecp_step_size_method_option,
 )
-=======
-from chemsmart.cli.gaussian.mecp_options import click_gaussian_mecp_state_options
->>>>>>> Stashed changes
 from chemsmart.cli.job import click_job_options
 from chemsmart.jobs.gaussian.settings import GaussianMECPJobSettings
 from chemsmart.utils.cli import MyCommand
@@ -22,42 +19,7 @@ logger = logging.getLogger(__name__)
 
 @gaussian.command("mecp", cls=MyCommand)
 @click_job_options
-<<<<<<< Updated upstream
-@click.option(
-    "--multiplicity-1",
-    "-m1",
-    "multiplicity1",
-    type=int,
-    default=None,
-    help="Spin multiplicity for state 1.",
-)
-@click.option(
-    "--multiplicity-2",
-    "-m2",
-    "multiplicity2",
-    type=int,
-    default=None,
-    help="Spin multiplicity for state 2. Defaults to multiplicity-1 + 2.",
-)
-@click.option(
-    "--charge-1",
-    "-c1",
-    "charge1",
-    type=int,
-    default=None,
-    help="Charge for state 1.",
-)
-@click.option(
-    "--charge-2",
-    "-c2",
-    "charge2",
-    type=int,
-    default=None,
-    help="Charge for state 2. Defaults to charge-1.",
-)
-=======
-@click_gaussian_mecp_state_options
->>>>>>> Stashed changes
+@click_mecp_state_options
 @click.option(
     "--title-a",
     type=str,
@@ -251,11 +213,7 @@ def mecp(
     if mecp_settings.multiplicity_a is None:
         raise ValueError(
             "State A multiplicity is not set. "
-<<<<<<< Updated upstream
-            "Use gaussian -m/--multiplicity or mecp --multiplicity-1/-m1."
-=======
             "Use gaussian -m/--multiplicity or mecp --multiplicity1."
->>>>>>> Stashed changes
         )
 
     if multiplicity2 is None:
@@ -272,11 +230,7 @@ def mecp(
     if mecp_settings.charge_a is None:
         raise ValueError(
             "State A charge is not set. "
-<<<<<<< Updated upstream
-            "Use gaussian -c/--charge or mecp --charge-1/-c1."
-=======
             "Use gaussian -c/--charge or mecp --charge1."
->>>>>>> Stashed changes
         )
     if charge2 is None:
         mecp_settings.charge_b = mecp_settings.charge_a

--- a/chemsmart/cli/gaussian/mecp.py
+++ b/chemsmart/cli/gaussian/mecp.py
@@ -1,4 +1,4 @@
-﻿import logging
+import logging
 
 import click
 
@@ -118,7 +118,10 @@ logger = logging.getLogger(__name__)
 )
 @click.option(
     "--step-size-method",
-    type=click.Choice(["bb", "grow_shrink", "harvey", "harvey_bfgs"], case_sensitive=False),
+    type=click.Choice(
+        ["bb", "grow_shrink", "harvey", "harvey_bfgs"],
+        case_sensitive=False,
+    ),
     default=None,
     help=(
         "Step size adaptation algorithm when adaptive is enabled. "

--- a/chemsmart/cli/gaussian/mecp.py
+++ b/chemsmart/cli/gaussian/mecp.py
@@ -3,11 +3,15 @@ import logging
 import click
 
 from chemsmart.cli.gaussian.gaussian import gaussian
+<<<<<<< Updated upstream
 from chemsmart.cli.gaussian.mecp_options import (
     add_mecp_method_suffix,
     click_mecp_restart_option,
     click_mecp_step_size_method_option,
 )
+=======
+from chemsmart.cli.gaussian.mecp_options import click_gaussian_mecp_state_options
+>>>>>>> Stashed changes
 from chemsmart.cli.job import click_job_options
 from chemsmart.jobs.gaussian.settings import GaussianMECPJobSettings
 from chemsmart.utils.cli import MyCommand
@@ -18,6 +22,7 @@ logger = logging.getLogger(__name__)
 
 @gaussian.command("mecp", cls=MyCommand)
 @click_job_options
+<<<<<<< Updated upstream
 @click.option(
     "--multiplicity-1",
     "-m1",
@@ -50,6 +55,9 @@ logger = logging.getLogger(__name__)
     default=None,
     help="Charge for state 2. Defaults to charge-1.",
 )
+=======
+@click_gaussian_mecp_state_options
+>>>>>>> Stashed changes
 @click.option(
     "--title-a",
     type=str,
@@ -243,7 +251,11 @@ def mecp(
     if mecp_settings.multiplicity_a is None:
         raise ValueError(
             "State A multiplicity is not set. "
+<<<<<<< Updated upstream
             "Use gaussian -m/--multiplicity or mecp --multiplicity-1/-m1."
+=======
+            "Use gaussian -m/--multiplicity or mecp --multiplicity1."
+>>>>>>> Stashed changes
         )
 
     if multiplicity2 is None:
@@ -260,7 +272,11 @@ def mecp(
     if mecp_settings.charge_a is None:
         raise ValueError(
             "State A charge is not set. "
+<<<<<<< Updated upstream
             "Use gaussian -c/--charge or mecp --charge-1/-c1."
+=======
+            "Use gaussian -c/--charge or mecp --charge1."
+>>>>>>> Stashed changes
         )
     if charge2 is None:
         mecp_settings.charge_b = mecp_settings.charge_a

--- a/chemsmart/cli/gaussian/mecp_options.py
+++ b/chemsmart/cli/gaussian/mecp_options.py
@@ -3,6 +3,39 @@
 import click
 
 
+def click_mecp_state_options(function):
+    """Apply the common charge and multiplicity options for two MECP states."""
+    options = (
+        click.option(
+            "--multiplicity1",
+            type=int,
+            default=None,
+            help="Spin multiplicity for state 1.",
+        ),
+        click.option(
+            "--multiplicity2",
+            type=int,
+            default=None,
+            help="Spin multiplicity for state 2. Defaults to multiplicity1 + 2.",
+        ),
+        click.option(
+            "--charge1",
+            type=int,
+            default=None,
+            help="Charge for state 1.",
+        ),
+        click.option(
+            "--charge2",
+            type=int,
+            default=None,
+            help="Charge for state 2. Defaults to charge1.",
+        ),
+    )
+    for option in reversed(options):
+        function = option(function)
+    return function
+
+
 def add_mecp_method_suffix(label, method):
     """Return a MECP label ending in ``_<method>_mecp``."""
     suffix = f"_{method}_mecp"

--- a/chemsmart/cli/gaussian/mecp_options.py
+++ b/chemsmart/cli/gaussian/mecp_options.py
@@ -1,0 +1,39 @@
+"""Shared Click options for MECP entry points."""
+
+import click
+
+
+def add_mecp_method_suffix(label, method):
+    """Return a MECP label ending in ``_<method>_mecp``."""
+    suffix = f"_{method}_mecp"
+    if label.lower().endswith(suffix.lower()):
+        return label
+    if label.lower().endswith("_mecp"):
+        return f"{label[:-5]}{suffix}"
+    return f"{label}{suffix}"
+
+
+def click_mecp_step_size_method_option(function):
+    """Apply the common MECP optimizer-selection option."""
+    return click.option(
+        "--step-size-method",
+        type=click.Choice(
+            ["bb", "grow_shrink", "harvey"], case_sensitive=False
+        ),
+        default=None,
+        help=(
+            "MECP optimizer. 'harvey' uses the Harvey inverse-BFGS optimizer "
+            "(default); 'bb' uses the Barzilai-Borwein secant rule; "
+            "'grow_shrink' uses a merit-based grow/shrink rule."
+        ),
+    )(function)
+
+
+def click_mecp_restart_option(function):
+    """Apply the common interrupted-optimization restart option."""
+    return click.option(
+        "--restart/--no-restart",
+        default=True,
+        show_default=True,
+        help="Resume an interrupted MECP optimization from its saved state.",
+    )(function)

--- a/chemsmart/io/gaussian/output.py
+++ b/chemsmart/io/gaussian/output.py
@@ -174,21 +174,6 @@ class Gaussian16Output(GaussianFileMixin):
                 return spin
         return None
 
-<<<<<<< Updated upstream
-    @property
-    def spin_squared(self):
-        """Return the final post-annihilation ``<S^2>`` value, if printed."""
-        pattern = re.compile(
-            r"S\*\*2 before annihilation\s+[-+0-9.DEde]+,\s+after\s+"
-            r"([-+0-9.DEde]+)"
-        )
-        value = None
-        for line in self.contents:
-            match = pattern.search(line)
-            if match:
-                value = float(match.group(1).replace("D", "E").replace("d", "e"))
-        return value
-=======
     def _final_spin_squared_values(self):
         """Return the final printed S**2 values before and after annihilation."""
         values = None
@@ -196,7 +181,10 @@ class Gaussian16Output(GaussianFileMixin):
         for line in self.contents:
             match = pattern.search(line)
             if match:
-                values = tuple(float(value) for value in match.groups())
+                values = tuple(
+                    float(value.replace("D", "E").replace("d", "e"))
+                    for value in match.groups()
+                )
         return values
 
     @property
@@ -210,7 +198,6 @@ class Gaussian16Output(GaussianFileMixin):
         """Return the final post-annihilation S**2 value, if printed."""
         values = self._final_spin_squared_values()
         return None if values is None else values[1]
->>>>>>> Stashed changes
 
     @cached_property
     def input_coordinates_block(self):

--- a/chemsmart/io/gaussian/output.py
+++ b/chemsmart/io/gaussian/output.py
@@ -173,6 +173,20 @@ class Gaussian16Output(GaussianFileMixin):
                 return spin
         return None
 
+    @property
+    def spin_squared(self):
+        """Return the final post-annihilation ``<S^2>`` value, if printed."""
+        pattern = re.compile(
+            r"S\*\*2 before annihilation\s+[-+0-9.DEde]+,\s+after\s+"
+            r"([-+0-9.DEde]+)"
+        )
+        value = None
+        for line in self.contents:
+            match = pattern.search(line)
+            if match:
+                value = float(match.group(1).replace("D", "E").replace("d", "e"))
+        return value
+
     @cached_property
     def input_coordinates_block(self):
         """Obtain the coordinate block from the

--- a/chemsmart/io/gaussian/output.py
+++ b/chemsmart/io/gaussian/output.py
@@ -20,6 +20,7 @@ from chemsmart.utils.repattern import (
     oniom_energy_pattern,
     oniom_gridpoint_pattern,
     scf_energy_pattern,
+    spin_squared_pattern,
 )
 from chemsmart.utils.utils import (
     get_range_from_list,
@@ -173,6 +174,7 @@ class Gaussian16Output(GaussianFileMixin):
                 return spin
         return None
 
+<<<<<<< Updated upstream
     @property
     def spin_squared(self):
         """Return the final post-annihilation ``<S^2>`` value, if printed."""
@@ -186,6 +188,29 @@ class Gaussian16Output(GaussianFileMixin):
             if match:
                 value = float(match.group(1).replace("D", "E").replace("d", "e"))
         return value
+=======
+    def _final_spin_squared_values(self):
+        """Return the final printed S**2 values before and after annihilation."""
+        values = None
+        pattern = re.compile(spin_squared_pattern)
+        for line in self.contents:
+            match = pattern.search(line)
+            if match:
+                values = tuple(float(value) for value in match.groups())
+        return values
+
+    @property
+    def spin_squared_before_annihilation(self):
+        """Return the final pre-annihilation S**2 value, if printed."""
+        values = self._final_spin_squared_values()
+        return None if values is None else values[0]
+
+    @property
+    def spin_squared_after_annihilation(self):
+        """Return the final post-annihilation S**2 value, if printed."""
+        values = self._final_spin_squared_values()
+        return None if values is None else values[1]
+>>>>>>> Stashed changes
 
     @cached_property
     def input_coordinates_block(self):

--- a/chemsmart/jobs/gaussian/job.py
+++ b/chemsmart/jobs/gaussian/job.py
@@ -46,7 +46,14 @@ class GaussianJob(Job):
     PROGRAM = "Gaussian"
 
     def __init__(
-        self, molecule, settings=None, label=None, jobrunner=None, **kwargs
+        self,
+        molecule,
+        settings=None,
+        label=None,
+        jobrunner=None,
+        checkpoint_filename=None,
+        scratch_parent_folder=None,
+        **kwargs,
     ):
         """
         Initialize a Gaussian job with molecule and calculation settings.
@@ -60,6 +67,8 @@ class GaussianJob(Job):
             settings (GaussianJobSettings): Job configuration (required).
             label (str, optional): Job identifier for file naming.
             jobrunner (JobRunner, optional): Job execution handler.
+            checkpoint_filename (str, optional): Explicit checkpoint filename.
+            scratch_parent_folder (str, optional): Scratch grouping folder.
             **kwargs: Additional keyword arguments for parent class.
 
         Raises:
@@ -81,6 +90,8 @@ class GaussianJob(Job):
 
         self.molecule = molecule.copy() if molecule is not None else None
         self.settings = settings.copy()
+        self.checkpoint_filename = checkpoint_filename
+        self.scratch_parent_folder = scratch_parent_folder
 
         if label is None:
             label = molecule.get_chemical_formula(empirical=True)
@@ -138,7 +149,7 @@ class GaussianJob(Job):
         Returns:
             str: Full path to the Gaussian checkpoint file.
         """
-        chkfile = getattr(self, "checkpoint_filename", self.label + ".chk")
+        chkfile = self.checkpoint_filename or self.label + ".chk"
         return os.path.join(self.folder, chkfile)
 
     @property

--- a/chemsmart/jobs/gaussian/job.py
+++ b/chemsmart/jobs/gaussian/job.py
@@ -138,7 +138,7 @@ class GaussianJob(Job):
         Returns:
             str: Full path to the Gaussian checkpoint file.
         """
-        chkfile = self.label + ".chk"
+        chkfile = getattr(self, "checkpoint_filename", self.label + ".chk")
         return os.path.join(self.folder, chkfile)
 
     @property

--- a/chemsmart/jobs/gaussian/mecp.py
+++ b/chemsmart/jobs/gaussian/mecp.py
@@ -815,6 +815,7 @@ class GaussianMECPJob(GaussianJob):
 
                 energy_diff = ea - eb
 
+<<<<<<< Updated upstream
                 if self.settings.step_size_method == "harvey":
                     (
                         displacement,
@@ -845,6 +846,16 @@ class GaussianMECPJob(GaussianJob):
                         )
                     )
                     optimizer_gradient = projected_grad
+=======
+                displacement, projected_grad, seam_correction = (
+                    self._mecp_displacement(
+                        energy_diff=energy_diff,
+                        grad_a=grad_a,
+                        grad_b=grad_b,
+                        step_size=current_step_size,
+                    )
+                )
+>>>>>>> Stashed changes
 
                 if self.settings.step_size_method != "harvey":
                     displacement = self._apply_trust_radius(displacement)

--- a/chemsmart/jobs/gaussian/mecp.py
+++ b/chemsmart/jobs/gaussian/mecp.py
@@ -7,6 +7,7 @@ Minimum Energy Cross Point calculations using Gaussian.
 
 import logging
 import os
+import re
 from typing import Type
 
 import numpy as np
@@ -42,6 +43,29 @@ class GaussianMECPJob(GaussianJob):
 
     TYPE = "g16mecp"
     MIN_DIFF_GRAD_NORM_SQ = 1.0e-20
+
+    @staticmethod
+    def _without_unavailable_guess_read(route):
+        """Remove ``read`` from a Gaussian guess option for the first step."""
+
+        def strip_parenthesized_read(match):
+            options = [
+                option.strip()
+                for option in match.group(1).split(",")
+                if option.strip().lower() != "read"
+            ]
+            return f"guess=({','.join(options)})" if options else ""
+
+        route = re.sub(
+            r"\bguess\s*=\s*\(([^)]*)\)",
+            strip_parenthesized_read,
+            route,
+            flags=re.IGNORECASE,
+        )
+        route = re.sub(
+            r"\bguess\s*=\s*read\b", "", route, flags=re.IGNORECASE
+        )
+        return " ".join(route.split())
 
     # MECP-specific attribute names that must be stripped when building
     # a GaussianLinkJobSettings for each sub-job (broken-symmetry mode).
@@ -203,12 +227,11 @@ class GaussianMECPJob(GaussianJob):
 
         checkpoint_key = (checkpoint_tag, state)
         oldchkfile = self._state_checkpoint_files.get(checkpoint_key)
-        if oldchkfile and not self.settings.use_link:
+        if not oldchkfile and not self.settings.use_link:
             route = settings.additional_route_parameters or ""
-            if "guess=" not in route.lower():
-                settings.additional_route_parameters = (
-                    f"{route} guess=read".strip()
-                )
+            settings.additional_route_parameters = (
+                self._without_unavailable_guess_read(route)
+            )
 
         if self.settings.use_link:
             from chemsmart.jobs.gaussian.link import GaussianLinkJob
@@ -229,6 +252,7 @@ class GaussianMECPJob(GaussianJob):
                 skip_completed=False,
             )
         job.set_folder(self.steps_folder)
+        job.scratch_parent_folder = f"{self.label}_steps"
         checkpoint_part = f"{checkpoint_tag}_" if checkpoint_tag else ""
         job.checkpoint_filename = (
             f"{self.label}_{checkpoint_part}{state}.chk"

--- a/chemsmart/jobs/gaussian/mecp.py
+++ b/chemsmart/jobs/gaussian/mecp.py
@@ -815,7 +815,6 @@ class GaussianMECPJob(GaussianJob):
 
                 energy_diff = ea - eb
 
-<<<<<<< Updated upstream
                 if self.settings.step_size_method == "harvey":
                     (
                         displacement,
@@ -846,16 +845,6 @@ class GaussianMECPJob(GaussianJob):
                         )
                     )
                     optimizer_gradient = projected_grad
-=======
-                displacement, projected_grad, seam_correction = (
-                    self._mecp_displacement(
-                        energy_diff=energy_diff,
-                        grad_a=grad_a,
-                        grad_b=grad_b,
-                        step_size=current_step_size,
-                    )
-                )
->>>>>>> Stashed changes
 
                 if self.settings.step_size_method != "harvey":
                     displacement = self._apply_trust_radius(displacement)

--- a/chemsmart/jobs/gaussian/mecp.py
+++ b/chemsmart/jobs/gaussian/mecp.py
@@ -27,9 +27,8 @@ class GaussianMECPJob(GaussianJob):
     for a molecular species.
 
     At each iteration (step 1, 2, …, max_steps) two Gaussian sub-jobs are
-    executed, labelled ``<label>_step<NNNNNN>_A`` and
-    ``<label>_step<NNNNNN>_B`` where ``<NNNNNN>`` is the **1-indexed**
-    six-digit zero-padded step number (e.g. ``000001`` for the first step),
+    executed, labelled ``<label>_step<N>_A`` and
+    ``<label>_step<N>_B`` where ``<N>`` is the **1-indexed** step number,
     supporting up to 999 999 steps.
 
     Attributes:
@@ -179,7 +178,9 @@ class GaussianMECPJob(GaussianJob):
         state_settings.title = title
         return state_settings
 
-    def _run_state(self, positions_bohr, step_idx, state):
+    def _run_state(
+        self, positions_bohr, step_idx, state, checkpoint_tag=None
+    ):
         if state == "A":
             charge = self.settings.charge_a
             multiplicity = self.settings.multiplicity_a
@@ -194,10 +195,20 @@ class GaussianMECPJob(GaussianJob):
         settings = self._state_settings(
             charge=charge,
             multiplicity=multiplicity,
-            title=f"{title} step {step_idx:06d}",
+            title=f"{title} step {step_idx}",
             state=state,
         )
-        state_label = f"{self.label}_step{step_idx:06d}_{state}"
+        job_tag = f"{checkpoint_tag}_" if checkpoint_tag else ""
+        state_label = f"{self.label}_{job_tag}step{step_idx}_{state}"
+
+        checkpoint_key = (checkpoint_tag, state)
+        oldchkfile = self._state_checkpoint_files.get(checkpoint_key)
+        if oldchkfile and not self.settings.use_link:
+            route = settings.additional_route_parameters or ""
+            if "guess=" not in route.lower():
+                settings.additional_route_parameters = (
+                    f"{route} guess=read".strip()
+                )
 
         if self.settings.use_link:
             from chemsmart.jobs.gaussian.link import GaussianLinkJob
@@ -217,6 +228,12 @@ class GaussianMECPJob(GaussianJob):
                 jobrunner=self.jobrunner,
                 skip_completed=False,
             )
+        job.set_folder(self.steps_folder)
+        checkpoint_part = f"{checkpoint_tag}_" if checkpoint_tag else ""
+        job.checkpoint_filename = (
+            f"{self.label}_{checkpoint_part}{state}.chk"
+        )
+        job.oldchkfile = oldchkfile
         job.run()
         output = job._output()
         if output is None or output.energies is None or not output.energies:
@@ -234,6 +251,8 @@ class GaussianMECPJob(GaussianJob):
                 f"coordinate shape {np.array(mol.positions).shape}."
             )
         gradient = -forces
+        if os.path.isfile(job.chkfile):
+            self._state_checkpoint_files[checkpoint_key] = job.chkfile
         return energy, gradient
 
     def _write_trajectory_frame(self, positions_bohr, step_idx):
@@ -305,22 +324,26 @@ class GaussianMECPJob(GaussianJob):
         )
 
     @staticmethod
-    def _update_inverse_hessian(inv_hessian, delta_x, delta_g):
-        """Return a curvature-safe inverse-BFGS update.
+    def _update_inverse_hessian(
+        inv_hessian, delta_x, delta_g, return_diagnostics=False
+    ):
+        """Return Harvey/easyMECP's inverse-BFGS update.
 
-        The rank-three form used by Harvey is algebraically equivalent to
-        the conventional inverse-BFGS formula.  If the secant pair does not
-        have positive curvature, retain the previous approximation.
+        easyMECP applies the rank-three update even for negative curvature.
+        This implementation does the same and only skips a numerically
+        singular or non-finite update.
         """
         h_del_g = inv_hessian @ delta_g
         fac = float(np.dot(delta_g, delta_x))
         fae = float(np.dot(delta_g, h_del_g))
-        curvature_tol = 1.0e-8 * np.linalg.norm(delta_x) * np.linalg.norm(
-            delta_g
+        scale = max(
+            float(np.linalg.norm(delta_x) * np.linalg.norm(delta_g)), 1.0
         )
+        singular_tol = np.finfo(float).eps * scale
 
-        if fac <= curvature_tol or fae <= 1.0e-30:
-            return inv_hessian
+        if abs(fac) <= singular_tol or abs(fae) <= singular_tol:
+            result = (inv_hessian, "SKIP_SINGULAR", fac, fae)
+            return result if return_diagnostics else result[0]
 
         w = delta_x / fac - h_del_g / fae
         updated = (
@@ -329,7 +352,13 @@ class GaussianMECPJob(GaussianJob):
             - np.outer(h_del_g, h_del_g) / fae
             + fae * np.outer(w, w)
         )
-        return 0.5 * (updated + updated.T)
+        if not np.all(np.isfinite(updated)):
+            result = (inv_hessian, "SKIP_NONFINITE", fac, fae)
+            return result if return_diagnostics else result[0]
+
+        updated = 0.5 * (updated + updated.T)
+        result = (updated, "UPDATE", fac, fae)
+        return result if return_diagnostics else result[0]
 
     def _bfgs_displacement(
         self,
@@ -397,25 +426,24 @@ class GaussianMECPJob(GaussianJob):
             # 第一步: 用对角逆 Hessian (Harvey Initialize 子程序)
             inv_hess = initial_hi_val * np.eye(n)
             displacement_flat = -inv_hess @ eff_grad_flat
+            update_status = "INITIAL"
+            fac = float("nan")
+            fae = float("nan")
         else:
             # BFGS 更新 (Harvey UpdateX 子程序)
             delta_x = (curr_positions - prev_positions).ravel()  # DelX
             delta_g = (eff_grad_flat - prev_eff_grad)  # DelG
 
-            inv_hess = self._update_inverse_hessian(
-                inv_hessian, delta_x, delta_g
+            inv_hess, update_status, fac, fae = self._update_inverse_hessian(
+                inv_hessian,
+                delta_x,
+                delta_g,
+                return_diagnostics=True,
             )
 
             displacement_flat = -inv_hess @ eff_grad_flat
-
-            # A finite positive-definite inverse Hessian should always yield a
-            # descent direction.  Reset defensively if accumulated numerical
-            # error or noisy electronic gradients violate that invariant.
-            if not np.all(np.isfinite(displacement_flat)) or float(
-                np.dot(eff_grad_flat, displacement_flat)
-            ) >= 0.0:
-                inv_hess = initial_hi_val * np.eye(n)
-                displacement_flat = -inv_hess @ eff_grad_flat
+            if not np.all(np.isfinite(displacement_flat)):
+                raise RuntimeError("Harvey BFGS produced a non-finite step.")
 
         # 3. 位移限制 (Harvey UpdateX 中的 STPMX 逻辑)
         # STPMX = 0.1 Å -> 0.1 * (1/Bohr) Bohr
@@ -435,7 +463,15 @@ class GaussianMECPJob(GaussianJob):
         # seam_correction: 精确线性 seam 修正 (用于日志对比)
         seam_correction = -(ea - eb) / diff_norm_sq * diff_grad
 
-        return displacement, eff_grad, seam_correction, inv_hess
+        return (
+            displacement,
+            eff_grad,
+            seam_correction,
+            inv_hess,
+            update_status,
+            fac,
+            fae,
+        )
 
     def _adapt_step_size(self, current_step_size, prev_merit, current_merit):
         """
@@ -537,7 +573,7 @@ class GaussianMECPJob(GaussianJob):
         seam_max = float(np.max(np.abs(seam_correction)))
         seam_rms = self._rms(seam_correction)
         f.write(
-            f"step={step_idx:06d} E_A={ea:.10f} E_B={eb:.10f} "
+            f"step={step_idx} E_A={ea:.10f} E_B={eb:.10f} "
             f"dE={energy_diff:+.6e} "
             f"pgrad_max={pgrad_max:.3e} pgrad_rms={pgrad_rms:.3e} "
             f"disp_max={disp_max:.3e} disp_rms={disp_rms:.3e} "
@@ -564,6 +600,9 @@ class GaussianMECPJob(GaussianJob):
         inv_hessian = None
         prev_eff_grad = None
         prev_positions_bfgs = None
+        self.steps_folder = os.path.join(self.folder, f"{self.label}_steps")
+        os.makedirs(self.steps_folder, exist_ok=True)
+        self._state_checkpoint_files = {}
 
         with open(self.report_file, "w") as report:
             report.write("CHEMSMART self-contained MECP optimization\n")
@@ -587,6 +626,9 @@ class GaussianMECPJob(GaussianJob):
                         projected_grad,
                         seam_correction,
                         inv_hessian,
+                        bfgs_status,
+                        bfgs_fac,
+                        bfgs_fae,
                     ) = self._bfgs_displacement(
                         ea=ea,
                         eb=eb,
@@ -618,6 +660,12 @@ class GaussianMECPJob(GaussianJob):
                     seam_correction,
                     current_step_size,
                 )
+                if self.settings.step_size_method == "harvey_bfgs":
+                    report.write(
+                        f"bfgs_status={bfgs_status} "
+                        f"delta_g_dot_delta_x={bfgs_fac:+.8e} "
+                        f"delta_g_dot_h_delta_g={bfgs_fae:+.8e}\n"
+                    )
 
                 if self._is_converged(
                     energy_diff=energy_diff,
@@ -784,8 +832,7 @@ class GaussianMECPJob(GaussianJob):
         Args:
             positions_bohr (np.ndarray): Current geometry, shape (n_atoms, 3).
             h (float): Finite-difference step size in Bohr.
-            step_prefix (int): Starting sub-job step index (to avoid
-                clashing with MECP optimisation step labels).
+            step_prefix (int): First check-specific sub-job step index.
 
         Returns:
             np.ndarray: Average symmetrised Hessian, shape (3N, 3N),
@@ -810,10 +857,18 @@ class GaussianMECPJob(GaussianJob):
             step_p = step_prefix + 2 * j
             step_m = step_prefix + 2 * j + 1
 
-            _, g_A_plus = self._run_state(pos_plus, step_p, "A")
-            _, g_B_plus = self._run_state(pos_plus, step_p, "B")
-            _, g_A_minus = self._run_state(pos_minus, step_m, "A")
-            _, g_B_minus = self._run_state(pos_minus, step_m, "B")
+            _, g_A_plus = self._run_state(
+                pos_plus, step_p, "A", checkpoint_tag="check"
+            )
+            _, g_B_plus = self._run_state(
+                pos_plus, step_p, "B", checkpoint_tag="check"
+            )
+            _, g_A_minus = self._run_state(
+                pos_minus, step_m, "A", checkpoint_tag="check"
+            )
+            _, g_B_minus = self._run_state(
+                pos_minus, step_m, "B", checkpoint_tag="check"
+            )
 
             H_A[:, j] = (g_A_plus.ravel() - g_A_minus.ravel()) / (2 * h)
             H_B[:, j] = (g_B_plus.ravel() - g_B_minus.ravel()) / (2 * h)
@@ -822,7 +877,7 @@ class GaussianMECPJob(GaussianJob):
         H_B = (H_B + H_B.T) / 2
         return (H_A + H_B) / 2
 
-    def verify_seam_minimum(self, h=None, step_prefix=900000):
+    def verify_seam_minimum(self, h=None, step_prefix=1):
         """
         Verify that the current MECP geometry is a **minimum on the crossing
         seam**, not merely a crossing point.
@@ -860,8 +915,9 @@ class GaussianMECPJob(GaussianJob):
         Args:
             h (float, optional): Finite-difference step size in Bohr.
                 Defaults to ``settings.hess_step_size`` (1 × 10⁻³ Bohr).
-            step_prefix (int, optional): Starting sub-job step index
-                (default: 900000, well above any normal MECP step).
+            step_prefix (int, optional): Starting check-specific sub-job step
+                index (default: 1). The ``check`` name component prevents
+                clashes with normal MECP steps.
 
         Returns:
             dict: Keys ``"eigenvalues"`` (1-D array, non-projected modes),
@@ -879,8 +935,12 @@ class GaussianMECPJob(GaussianJob):
         logger.info(
             f"verify_seam_minimum: computing gradient difference at {self.label}"
         )
-        ea, grad_a = self._run_state(positions_bohr, step_prefix - 1, "A")
-        eb, grad_b = self._run_state(positions_bohr, step_prefix - 1, "B")
+        ea, grad_a = self._run_state(
+            positions_bohr, step_prefix, "A", checkpoint_tag="check"
+        )
+        eb, grad_b = self._run_state(
+            positions_bohr, step_prefix, "B", checkpoint_tag="check"
+        )
         diff_grad = grad_a - grad_b
 
         logger.info(
@@ -888,7 +948,7 @@ class GaussianMECPJob(GaussianJob):
             f"(h={h} Bohr, {4 * 3 * len(self.molecule.symbols)} sub-jobs)"
         )
         H_avg = self._compute_numerical_hessian(
-            positions_bohr, h=h, step_prefix=step_prefix
+            positions_bohr, h=h, step_prefix=step_prefix + 1
         )
 
         proj_vecs = self._build_projection_vectors(positions_bohr, diff_grad)
@@ -908,7 +968,18 @@ class GaussianMECPJob(GaussianJob):
         }
 
         self._write_seam_check_log(result, h, step_prefix)
+        self._remove_checkpoint_set("check")
         return result
+
+    def _remove_checkpoint_set(self, checkpoint_tag):
+        """Remove successful verification checkpoints, preserving MECP ones."""
+        for state in ("A", "B"):
+            checkpoint_key = (checkpoint_tag, state)
+            checkpoint_file = self._state_checkpoint_files.pop(
+                checkpoint_key, None
+            )
+            if checkpoint_file and os.path.isfile(checkpoint_file):
+                os.remove(checkpoint_file)
 
     def _run_seam_minimum_check(self, positions_bohr):
         """Called at the end of ``_run()`` when ``verify_seam_minimum`` is set."""
@@ -931,7 +1002,7 @@ class GaussianMECPJob(GaussianJob):
             f.write("CHEMSMART MECP seam-minimum verification\n")
             f.write(
                 f"label={self.label} hess_step={h:.2e} Bohr "
-                f"step_prefix={step_prefix}\n"
+                f"check_step_start={step_prefix}\n"
             )
             f.write(
                 f"energy_diff={result['energy_diff']:+.6e} Hartree "

--- a/chemsmart/jobs/gaussian/mecp.py
+++ b/chemsmart/jobs/gaussian/mecp.py
@@ -304,6 +304,139 @@ class GaussianMECPJob(GaussianJob):
             )
         )
 
+    @staticmethod
+    def _update_inverse_hessian(inv_hessian, delta_x, delta_g):
+        """Return a curvature-safe inverse-BFGS update.
+
+        The rank-three form used by Harvey is algebraically equivalent to
+        the conventional inverse-BFGS formula.  If the secant pair does not
+        have positive curvature, retain the previous approximation.
+        """
+        h_del_g = inv_hessian @ delta_g
+        fac = float(np.dot(delta_g, delta_x))
+        fae = float(np.dot(delta_g, h_del_g))
+        curvature_tol = 1.0e-8 * np.linalg.norm(delta_x) * np.linalg.norm(
+            delta_g
+        )
+
+        if fac <= curvature_tol or fae <= 1.0e-30:
+            return inv_hessian
+
+        w = delta_x / fac - h_del_g / fae
+        updated = (
+            inv_hessian
+            + np.outer(delta_x, delta_x) / fac
+            - np.outer(h_del_g, h_del_g) / fae
+            + fae * np.outer(w, w)
+        )
+        return 0.5 * (updated + updated.T)
+
+    def _bfgs_displacement(
+        self,
+        ea,
+        eb,
+        grad_a,
+        grad_b,
+        prev_positions,
+        curr_positions,
+        prev_eff_grad,
+        inv_hessian,
+    ):
+        """
+        Harvey 原版 BFGS 准牛顿法位移计算。
+
+        完整实现 J. N. Harvey (2003) 的 MECP 优化算法:
+        1. 计算有效梯度 G_eff = (Ea-Eb)*facPP*PerpG + facP*ParG
+        2. 维护逆 Hessian 矩阵并用 BFGS 公式更新
+        3. 位移 = -HI @ G_eff
+        4. 应用 STPMX 位移限制
+
+        参考: easymecp 中的 MECP_FORTRAN UpdateX 子程序。
+
+        Args:
+            ea, eb: 两个态的能量
+            grad_a, grad_b: 两个态的梯度 (Hartree/Bohr)
+            prev_positions: 前一步几何 (Bohr), 第一步为 None
+            curr_positions: 当前几何 (Bohr)
+            prev_eff_grad: 前一步有效梯度 (1-D), 第一步为 None
+            inv_hessian: 当前逆 Hessian (N×N), 第一步为 None
+
+        Returns:
+            displacement: 位移 (Bohr)
+            eff_grad: 有效梯度 (用于收敛判断)
+            seam_correction: seam 修正项 (用于日志)
+            inv_hessian: 更新后的逆 Hessian
+        """
+        n = grad_a.size
+
+        # 1. 计算有效梯度 (Harvey 原版 Effective_Gradient 子程序)
+        diff_grad = grad_a - grad_b  # PerpG
+        diff_norm_sq = float(np.sum(diff_grad * diff_grad))
+        if diff_norm_sq < self.MIN_DIFF_GRAD_NORM_SQ:
+            raise RuntimeError(
+                "Difference gradient is too small; cannot continue MECP step."
+            )
+        diff_norm = np.sqrt(diff_norm_sq)
+        pp = float(np.sum(grad_a * diff_grad)) / diff_norm
+        par_grad = grad_a - diff_grad / diff_norm * pp  # ParG
+
+        # facPP=140: 经验值, 使沿 PerpG 方向逆 Hessian ≈ 1/140
+        # facP=1: ParG 方向用 BFGS 维护的逆 Hessian
+        fac_pp = 140.0
+        fac_p = 1.0
+        eff_grad = (ea - eb) * fac_pp * diff_grad + fac_p * par_grad
+        eff_grad_flat = eff_grad.ravel().copy()
+
+        # 2. BFGS 更新逆 Hessian 并计算位移
+        # Harvey 原版用 Angstrom, chemsmart 用 Bohr
+        # 初始逆 Hessian: 0.7 Å²/Hartree -> 0.7 * (1/Bohr)² Bohr²/Hartree
+        bohr_per_ang = 1.0 / units.Bohr
+        initial_hi_val = 0.7 * (bohr_per_ang ** 2)
+
+        if prev_positions is None or prev_eff_grad is None:
+            # 第一步: 用对角逆 Hessian (Harvey Initialize 子程序)
+            inv_hess = initial_hi_val * np.eye(n)
+            displacement_flat = -inv_hess @ eff_grad_flat
+        else:
+            # BFGS 更新 (Harvey UpdateX 子程序)
+            delta_x = (curr_positions - prev_positions).ravel()  # DelX
+            delta_g = (eff_grad_flat - prev_eff_grad)  # DelG
+
+            inv_hess = self._update_inverse_hessian(
+                inv_hessian, delta_x, delta_g
+            )
+
+            displacement_flat = -inv_hess @ eff_grad_flat
+
+            # A finite positive-definite inverse Hessian should always yield a
+            # descent direction.  Reset defensively if accumulated numerical
+            # error or noisy electronic gradients violate that invariant.
+            if not np.all(np.isfinite(displacement_flat)) or float(
+                np.dot(eff_grad_flat, displacement_flat)
+            ) >= 0.0:
+                inv_hess = initial_hi_val * np.eye(n)
+                displacement_flat = -inv_hess @ eff_grad_flat
+
+        # 3. 位移限制 (Harvey UpdateX 中的 STPMX 逻辑)
+        # STPMX = 0.1 Å -> 0.1 * (1/Bohr) Bohr
+        stpmx = 0.1 * bohr_per_ang
+        stpmax = stpmx * n  # 总位移向量最大范数
+
+        stpl = float(np.sqrt(np.sum(displacement_flat ** 2)))
+        if stpl > stpmax:
+            displacement_flat = displacement_flat / stpl * stpmax
+
+        lgstst = float(np.max(np.abs(displacement_flat)))
+        if lgstst > stpmx:
+            displacement_flat = displacement_flat / lgstst * stpmx
+
+        displacement = displacement_flat.reshape(grad_a.shape)
+
+        # seam_correction: 精确线性 seam 修正 (用于日志对比)
+        seam_correction = -(ea - eb) / diff_norm_sq * diff_grad
+
+        return displacement, eff_grad, seam_correction, inv_hess
+
     def _adapt_step_size(self, current_step_size, prev_merit, current_merit):
         """
         Return an updated step size based on the merit function progress.
@@ -427,6 +560,10 @@ class GaussianMECPJob(GaussianJob):
         prev_positions = None
         prev_proj_grad = None
         prev_energy_a = None
+        # BFGS state variables for harvey_bfgs method
+        inv_hessian = None
+        prev_eff_grad = None
+        prev_positions_bfgs = None
 
         with open(self.report_file, "w") as report:
             report.write("CHEMSMART self-contained MECP optimization\n")
@@ -444,14 +581,32 @@ class GaussianMECPJob(GaussianJob):
 
                 energy_diff = ea - eb
 
-                displacement, projected_grad, seam_correction = self._mecp_displacement(
-                    energy_diff=energy_diff,
-                    grad_a=grad_a,
-                    grad_b=grad_b,
-                    step_size=current_step_size,
-                )
+                if self.settings.step_size_method == "harvey_bfgs":
+                    (
+                        displacement,
+                        projected_grad,
+                        seam_correction,
+                        inv_hessian,
+                    ) = self._bfgs_displacement(
+                        ea=ea,
+                        eb=eb,
+                        grad_a=grad_a,
+                        grad_b=grad_b,
+                        prev_positions=prev_positions_bfgs,
+                        curr_positions=positions_bohr,
+                        prev_eff_grad=prev_eff_grad,
+                        inv_hessian=inv_hessian,
+                    )
+                else:
+                    displacement, projected_grad, seam_correction = self._mecp_displacement(
+                        energy_diff=energy_diff,
+                        grad_a=grad_a,
+                        grad_b=grad_b,
+                        step_size=current_step_size,
+                    )
 
-                displacement = self._apply_trust_radius(displacement)
+                if self.settings.step_size_method != "harvey_bfgs":
+                    displacement = self._apply_trust_radius(displacement)
 
                 self._log_step(
                     report,
@@ -489,6 +644,9 @@ class GaussianMECPJob(GaussianJob):
                                 current_step_size, prev_energy_a, ea
                             )
                         prev_energy_a = ea
+                    elif self.settings.step_size_method == "harvey_bfgs":
+                        # BFGS maintains its own step size via inverse Hessian
+                        pass
                     else:  # "grow_shrink"
                         current_merit = (
                             abs(energy_diff) / self.settings.energy_diff_tol
@@ -500,6 +658,10 @@ class GaussianMECPJob(GaussianJob):
                                 current_step_size, prev_merit, current_merit
                             )
                         prev_merit = current_merit
+
+                if self.settings.step_size_method == "harvey_bfgs":
+                    prev_positions_bfgs = positions_bohr.copy()
+                    prev_eff_grad = projected_grad.ravel().copy()
 
                 positions_bohr = positions_bohr + displacement
             else:

--- a/chemsmart/jobs/gaussian/mecp.py
+++ b/chemsmart/jobs/gaussian/mecp.py
@@ -1,4 +1,4 @@
-"""
+﻿"""
 Gaussian Minimum Energy Cross Point (MECP) job implementation.
 
 This module provides the GaussianMECPJob class for performing
@@ -275,6 +275,35 @@ class GaussianMECPJob(GaussianJob):
 
         return displacement, projected_grad, seam_correction
 
+    def _harvey_step_size(self, current_step_size, prev_energy_a, curr_energy_a):
+        """
+        Harvey's heuristic step-size update (1998).
+
+        Uses the *total energy of state A* (not a merit function) to decide
+        whether to grow or shrink:
+
+        * If ``E_A`` decreased -> step grew by ``step_size_grow`` (default x1.2).
+        * If ``E_A`` increased or stagnated -> step shrunk by
+          ``step_size_shrink`` (default x0.5).
+
+        This mirrors the original Fortran code's ``TSTEP`` / ``TSMIN`` / ``TSMAX``
+        logic where ``TSMAX`` is typically 0.30 Bohr (much smaller than the
+        chemsmart default of 1.0).
+
+        The result is clamped to ``[step_size_min, step_size_max]``.
+        """
+        if curr_energy_a < prev_energy_a:
+            new_step = current_step_size * self.settings.step_size_grow
+        else:
+            new_step = current_step_size * self.settings.step_size_shrink
+        return float(
+            np.clip(
+                new_step,
+                self.settings.step_size_min,
+                self.settings.step_size_max,
+            )
+        )
+
     def _adapt_step_size(self, current_step_size, prev_merit, current_merit):
         """
         Return an updated step size based on the merit function progress.
@@ -397,6 +426,7 @@ class GaussianMECPJob(GaussianJob):
         prev_merit = None
         prev_positions = None
         prev_proj_grad = None
+        prev_energy_a = None
 
         with open(self.report_file, "w") as report:
             report.write("CHEMSMART self-contained MECP optimization\n")
@@ -453,6 +483,12 @@ class GaussianMECPJob(GaussianJob):
                             )
                         prev_positions = positions_bohr.copy()
                         prev_proj_grad = projected_grad.copy()
+                    elif self.settings.step_size_method == "harvey":
+                        if prev_energy_a is not None:
+                            current_step_size = self._harvey_step_size(
+                                current_step_size, prev_energy_a, ea
+                            )
+                        prev_energy_a = ea
                     else:  # "grow_shrink"
                         current_merit = (
                             abs(energy_diff) / self.settings.energy_diff_tol

--- a/chemsmart/jobs/gaussian/mecp.py
+++ b/chemsmart/jobs/gaussian/mecp.py
@@ -1,4 +1,4 @@
-﻿"""
+"""
 Gaussian Minimum Energy Cross Point (MECP) job implementation.
 
 This module provides the GaussianMECPJob class for performing

--- a/chemsmart/jobs/gaussian/mecp.py
+++ b/chemsmart/jobs/gaussian/mecp.py
@@ -474,35 +474,45 @@ class GaussianMECPJob(GaussianJob):
         inv_hessian,
     ):
         """
-        Harvey 原版 BFGS 准牛顿法位移计算。
+        Compute the displacement using Harvey's original BFGS
+        quasi-Newton method.
 
-        完整实现 J. N. Harvey (2003) 的 MECP 优化算法:
-        1. 计算有效梯度 G_eff = (Ea-Eb)*facPP*PerpG + facP*ParG
-        2. 维护逆 Hessian 矩阵并用 BFGS 公式更新
-        3. 位移 = -HI @ G_eff
-        4. 应用 STPMX 位移限制
+        This implements the MECP optimization algorithm of J. N. Harvey
+        (2003):
 
-        参考: easymecp 中的 MECP_FORTRAN UpdateX 子程序。
+        1. Compute the effective gradient
+           ``G_eff = (Ea-Eb)*facPP*PerpG + facP*ParG``.
+        2. Maintain and update the inverse Hessian using the BFGS formula.
+        3. Compute the displacement as ``-HI @ G_eff``.
+        4. Apply the STPMX displacement limit.
+
+        The implementation follows the ``UpdateX`` subroutine in
+        ``easymecp``'s ``MECP_FORTRAN`` code.
 
         Args:
-            ea, eb: 两个态的能量
-            grad_a, grad_b: 两个态的梯度 (Hartree/Bohr)
-            prev_positions: 前一步几何 (Bohr), 第一步为 None
-            curr_positions: 当前几何 (Bohr)
-            prev_eff_grad: 前一步有效梯度 (1-D), 第一步为 None
-            inv_hessian: 当前逆 Hessian (N×N), 第一步为 None
+            ea, eb: Energies of the two states.
+            grad_a, grad_b: Gradients of the two states (Hartree/Bohr).
+            prev_positions: Previous geometry (Bohr), or ``None`` on the
+                first step.
+            curr_positions: Current geometry (Bohr).
+            prev_eff_grad: Previous effective gradient as a one-dimensional
+                array, or ``None`` on the first step.
+            inv_hessian: Current inverse Hessian (N x N), or ``None`` on the
+                first step.
 
         Returns:
-            displacement: 位移 (Bohr)
-            par_grad: seam 切向梯度 (用于收敛判断)
-            seam_correction: seam 修正项 (用于日志)
-            inv_hessian: 更新后的逆 Hessian
-            update_status, fac, fae: BFGS 更新诊断
-            eff_grad: Harvey 有效梯度 (用于 BFGS 历史更新)
+            displacement: Cartesian displacement (Bohr).
+            par_grad: Gradient tangent to the seam, used for convergence.
+            seam_correction: Seam-correction term used for logging.
+            inv_hessian: Updated inverse Hessian.
+            update_status, fac, fae: BFGS update diagnostics.
+            eff_grad: Harvey effective gradient used for the next BFGS
+                history update.
         """
         n = grad_a.size
 
-        # 1. 计算有效梯度 (Harvey 原版 Effective_Gradient 子程序)
+        # 1. Compute the effective gradient following Harvey's original
+        # Effective_Gradient subroutine.
         diff_grad = grad_a - grad_b  # PerpG
         diff_norm_sq = float(np.sum(diff_grad * diff_grad))
         if diff_norm_sq < self.MIN_DIFF_GRAD_NORM_SQ:
@@ -513,16 +523,18 @@ class GaussianMECPJob(GaussianJob):
         pp = float(np.sum(grad_a * diff_grad)) / diff_norm
         par_grad = grad_a - diff_grad / diff_norm * pp  # ParG
 
-        # facPP=140: 经验值, 使沿 PerpG 方向逆 Hessian ≈ 1/140
-        # facP=1: ParG 方向用 BFGS 维护的逆 Hessian
+        # facPP=140 is an empirical value that gives an inverse-Hessian
+        # component of approximately 1/140 along PerpG. facP=1 uses the
+        # BFGS-maintained inverse Hessian along ParG.
         fac_pp = 140.0
         fac_p = 1.0
         eff_grad = (ea - eb) * fac_pp * diff_grad + fac_p * par_grad
         eff_grad_flat = eff_grad.ravel().copy()
 
-        # 2. BFGS 更新逆 Hessian 并计算位移
-        # Harvey 原版用 Angstrom, chemsmart 用 Bohr
-        # 初始逆 Hessian: 0.7 Å²/Hartree -> 0.7 * (1/Bohr)² Bohr²/Hartree
+        # 2. Update the inverse Hessian with BFGS and compute the displacement.
+        # Harvey's original code uses Angstrom, whereas ChemSmart uses Bohr.
+        # Initial inverse Hessian: 0.7 Angstrom^2/Hartree converted to
+        # Bohr^2/Hartree.
         bohr_per_ang = 1.0 / units.Bohr
         initial_hi_val = self.settings.harvey_initial_hessian * (
             bohr_per_ang**2
@@ -530,14 +542,15 @@ class GaussianMECPJob(GaussianJob):
         initial_inv_hessian = initial_hi_val * np.eye(n)
 
         if prev_positions is None or prev_eff_grad is None:
-            # 第一步: 用对角逆 Hessian (Harvey Initialize 子程序)
+            # First step: use the diagonal inverse Hessian from Harvey's
+            # Initialize subroutine.
             inv_hess = initial_inv_hessian
             displacement_flat = -inv_hess @ eff_grad_flat
             update_status = "INITIAL"
             fac = float("nan")
             fae = float("nan")
         else:
-            # BFGS 更新 (Harvey UpdateX 子程序)
+            # Apply the BFGS update from Harvey's UpdateX subroutine.
             delta_x = (curr_positions - prev_positions).ravel()  # DelX
             delta_g = eff_grad_flat - prev_eff_grad  # DelG
 
@@ -564,7 +577,8 @@ class GaussianMECPJob(GaussianJob):
                 displacement_flat = -inv_hess @ eff_grad_flat
                 update_status = "RESET_NON_DESCENT"
 
-        # 3. 位移限制 (Harvey UpdateX 中的 STPMX 逻辑)
+        # 3. Limit the displacement using the STPMX logic from Harvey's
+        # UpdateX subroutine.
         # STPMX = 0.1 Å -> 0.1 * (1/Bohr) Bohr
         stpmx = self.settings.harvey_max_component_step * bohr_per_ang
 
@@ -574,7 +588,7 @@ class GaussianMECPJob(GaussianJob):
 
         displacement = displacement_flat.reshape(grad_a.shape)
 
-        # seam_correction: 精确线性 seam 修正 (用于日志对比)
+        # Exact linear seam correction, retained for log comparisons.
         seam_correction = -(ea - eb) / diff_norm_sq * diff_grad
 
         return (

--- a/chemsmart/jobs/gaussian/mecp.py
+++ b/chemsmart/jobs/gaussian/mecp.py
@@ -62,10 +62,21 @@ class GaussianMECPJob(GaussianJob):
             route,
             flags=re.IGNORECASE,
         )
-        route = re.sub(
-            r"\bguess\s*=\s*read\b", "", route, flags=re.IGNORECASE
-        )
+        route = re.sub(r"\bguess\s*=\s*read\b", "", route, flags=re.IGNORECASE)
         return " ".join(route.split())
+
+    @staticmethod
+    def _with_required_nosymm(route):
+        """Ensure Gaussian forces remain in the MECP Cartesian frame."""
+        route = route or ""
+        if re.search(r"\bnosymm\b", route, flags=re.IGNORECASE):
+            return route
+        if re.search(r"\bsymm(?:etry)?\b", route, flags=re.IGNORECASE):
+            raise ValueError(
+                "MECP requires nosymm so Cartesian forces remain aligned with "
+                "the optimization coordinates; remove the explicit symmetry option."
+            )
+        return f"{route} nosymm".strip()
 
     # MECP-specific attribute names that must be stripped when building
     # a GaussianLinkJobSettings for each sub-job (broken-symmetry mode).
@@ -91,10 +102,14 @@ class GaussianMECPJob(GaussianJob):
             "step_size_shrink",
             "step_size_min",
             "step_size_max",
+            "harvey_initial_hessian",
+            "harvey_max_component_step",
+            "harvey_max_condition",
             "use_link",
             "convergence_preset",
             "verify_seam_minimum",
             "hess_step_size",
+            "restart",
             # 'stable' and 'guess' are kept: they are valid GaussianLinkJobSettings
             # params and will be overridden with state-specific values anyway.
         }
@@ -128,6 +143,89 @@ class GaussianMECPJob(GaussianJob):
     @property
     def trajectory_file(self):
         return os.path.join(self.folder, f"{self.label}_traj.xyz")
+
+    @property
+    def state_file(self):
+        return os.path.join(self.folder, f"{self.label}_state.npz")
+
+    @staticmethod
+    def _optional_array(value):
+        return (
+            np.array([], dtype=float) if value is None else np.asarray(value)
+        )
+
+    @staticmethod
+    def _restore_optional_array(value):
+        return None if value.size == 0 else value
+
+    def _save_optimizer_state(self, **state):
+        """Atomically persist enough optimizer state to resume the next step."""
+        temporary_file = f"{self.state_file}.tmp.npz"
+        np.savez(
+            temporary_file,
+            version=np.array(1, dtype=int),
+            symbols=np.asarray(self.molecule.symbols, dtype="U4"),
+            step_size_method=np.array(self.settings.step_size_method),
+            next_step=np.array(state["next_step"], dtype=int),
+            positions_bohr=np.asarray(state["positions_bohr"], dtype=float),
+            current_step_size=np.array(
+                state["current_step_size"], dtype=float
+            ),
+            prev_merit=np.array(
+                np.nan if state["prev_merit"] is None else state["prev_merit"],
+                dtype=float,
+            ),
+            prev_positions=self._optional_array(state["prev_positions"]),
+            prev_proj_grad=self._optional_array(state["prev_proj_grad"]),
+            inv_hessian=self._optional_array(state["inv_hessian"]),
+            prev_eff_grad=self._optional_array(state["prev_eff_grad"]),
+            prev_positions_bfgs=self._optional_array(
+                state["prev_positions_bfgs"]
+            ),
+        )
+        os.replace(temporary_file, self.state_file)
+
+    def _load_optimizer_state(self):
+        """Load and validate a previously persisted optimizer state."""
+        with np.load(self.state_file, allow_pickle=False) as saved:
+            symbols = saved["symbols"].tolist()
+            method = str(saved["step_size_method"])
+            positions = np.asarray(saved["positions_bohr"], dtype=float)
+            if symbols != list(self.molecule.symbols):
+                raise RuntimeError(
+                    "Cannot restart MECP: atom symbols differ from saved state."
+                )
+            if method != self.settings.step_size_method:
+                raise RuntimeError(
+                    "Cannot restart MECP: optimizer method differs from saved state "
+                    f"({method!r} != {self.settings.step_size_method!r})."
+                )
+            if positions.shape != np.asarray(self.molecule.positions).shape:
+                raise RuntimeError(
+                    "Cannot restart MECP: coordinate shape differs from saved state."
+                )
+            prev_merit = float(saved["prev_merit"])
+            return {
+                "next_step": int(saved["next_step"]),
+                "positions_bohr": positions,
+                "current_step_size": float(saved["current_step_size"]),
+                "prev_merit": None if np.isnan(prev_merit) else prev_merit,
+                "prev_positions": self._restore_optional_array(
+                    saved["prev_positions"]
+                ),
+                "prev_proj_grad": self._restore_optional_array(
+                    saved["prev_proj_grad"]
+                ),
+                "inv_hessian": self._restore_optional_array(
+                    saved["inv_hessian"]
+                ),
+                "prev_eff_grad": self._restore_optional_array(
+                    saved["prev_eff_grad"]
+                ),
+                "prev_positions_bfgs": self._restore_optional_array(
+                    saved["prev_positions_bfgs"]
+                ),
+            }
 
     def _job_is_complete(self):
         """Check MECP completion by looking for a 'Converged' marker in the report file."""
@@ -190,6 +288,11 @@ class GaussianMECPJob(GaussianJob):
                     "link": True,
                 }
             )
+            link_kwargs["additional_route_parameters"] = (
+                self._with_required_nosymm(
+                    link_kwargs.get("additional_route_parameters")
+                )
+            )
             return GaussianLinkJobSettings(**link_kwargs)
 
         state_settings = self.settings.copy()
@@ -200,11 +303,14 @@ class GaussianMECPJob(GaussianJob):
         state_settings.charge = charge
         state_settings.multiplicity = multiplicity
         state_settings.title = title
+        state_settings.additional_route_parameters = (
+            self._with_required_nosymm(
+                state_settings.additional_route_parameters
+            )
+        )
         return state_settings
 
-    def _run_state(
-        self, positions_bohr, step_idx, state, checkpoint_tag=None
-    ):
+    def _run_state(self, positions_bohr, step_idx, state, checkpoint_tag=None):
         if state == "A":
             charge = self.settings.charge_a
             multiplicity = self.settings.multiplicity_a
@@ -254,9 +360,7 @@ class GaussianMECPJob(GaussianJob):
         job.set_folder(self.steps_folder)
         job.scratch_parent_folder = f"{self.label}_steps"
         checkpoint_part = f"{checkpoint_tag}_" if checkpoint_tag else ""
-        job.checkpoint_filename = (
-            f"{self.label}_{checkpoint_part}{state}.chk"
-        )
+        job.checkpoint_filename = f"{self.label}_{checkpoint_part}{state}.chk"
         job.oldchkfile = oldchkfile
         job.run()
         output = job._output()
@@ -275,6 +379,9 @@ class GaussianMECPJob(GaussianJob):
                 f"coordinate shape {np.array(mol.positions).shape}."
             )
         gradient = -forces
+        if not hasattr(self, "_last_spin_squared"):
+            self._last_spin_squared = {"A": None, "B": None}
+        self._last_spin_squared[state] = getattr(output, "spin_squared", None)
         if os.path.isfile(job.chkfile):
             self._state_checkpoint_files[checkpoint_key] = job.chkfile
         return energy, gradient
@@ -387,9 +494,11 @@ class GaussianMECPJob(GaussianJob):
 
         Returns:
             displacement: 位移 (Bohr)
-            eff_grad: 有效梯度 (用于收敛判断)
+            par_grad: seam 切向梯度 (用于收敛判断)
             seam_correction: seam 修正项 (用于日志)
             inv_hessian: 更新后的逆 Hessian
+            update_status, fac, fae: BFGS 更新诊断
+            eff_grad: Harvey 有效梯度 (用于 BFGS 历史更新)
         """
         n = grad_a.size
 
@@ -415,11 +524,14 @@ class GaussianMECPJob(GaussianJob):
         # Harvey 原版用 Angstrom, chemsmart 用 Bohr
         # 初始逆 Hessian: 0.7 Å²/Hartree -> 0.7 * (1/Bohr)² Bohr²/Hartree
         bohr_per_ang = 1.0 / units.Bohr
-        initial_hi_val = 0.7 * (bohr_per_ang ** 2)
+        initial_hi_val = self.settings.harvey_initial_hessian * (
+            bohr_per_ang**2
+        )
+        initial_inv_hessian = initial_hi_val * np.eye(n)
 
         if prev_positions is None or prev_eff_grad is None:
             # 第一步: 用对角逆 Hessian (Harvey Initialize 子程序)
-            inv_hess = initial_hi_val * np.eye(n)
+            inv_hess = initial_inv_hessian
             displacement_flat = -inv_hess @ eff_grad_flat
             update_status = "INITIAL"
             fac = float("nan")
@@ -427,7 +539,7 @@ class GaussianMECPJob(GaussianJob):
         else:
             # BFGS 更新 (Harvey UpdateX 子程序)
             delta_x = (curr_positions - prev_positions).ravel()  # DelX
-            delta_g = (eff_grad_flat - prev_eff_grad)  # DelG
+            delta_g = eff_grad_flat - prev_eff_grad  # DelG
 
             inv_hess, update_status, fac, fae = self._update_inverse_hessian(
                 inv_hessian,
@@ -436,18 +548,25 @@ class GaussianMECPJob(GaussianJob):
                 return_diagnostics=True,
             )
 
+            condition_number = float(np.linalg.cond(inv_hess))
+            if (
+                not np.isfinite(condition_number)
+                or condition_number > self.settings.harvey_max_condition
+            ):
+                inv_hess = initial_inv_hessian
+                update_status = "RESET_ILL_CONDITIONED"
+
             displacement_flat = -inv_hess @ eff_grad_flat
             if not np.all(np.isfinite(displacement_flat)):
                 raise RuntimeError("Harvey BFGS produced a non-finite step.")
+            if float(np.dot(displacement_flat, eff_grad_flat)) >= 0.0:
+                inv_hess = initial_inv_hessian
+                displacement_flat = -inv_hess @ eff_grad_flat
+                update_status = "RESET_NON_DESCENT"
 
         # 3. 位移限制 (Harvey UpdateX 中的 STPMX 逻辑)
         # STPMX = 0.1 Å -> 0.1 * (1/Bohr) Bohr
-        stpmx = 0.1 * bohr_per_ang
-        stpmax = stpmx * n  # 总位移向量最大范数
-
-        stpl = float(np.sqrt(np.sum(displacement_flat ** 2)))
-        if stpl > stpmax:
-            displacement_flat = displacement_flat / stpl * stpmax
+        stpmx = self.settings.harvey_max_component_step * bohr_per_ang
 
         lgstst = float(np.max(np.abs(displacement_flat)))
         if lgstst > stpmx:
@@ -460,27 +579,38 @@ class GaussianMECPJob(GaussianJob):
 
         return (
             displacement,
-            eff_grad,
+            par_grad,
             seam_correction,
             inv_hess,
             update_status,
             fac,
             fae,
+            eff_grad,
         )
+
+    _GROW_SHRINK_IMPROVEMENT_THRESHOLD = 0.10
+    _GROW_SHRINK_REGRESSION_THRESHOLD = 0.02
+    _BB_CURVATURE_COSINE_MIN = 1.0e-4
+    _BB_RELATIVE_STEP_MIN = 0.5
+    _BB_RELATIVE_STEP_MAX = 2.0
 
     def _adapt_step_size(self, current_step_size, prev_merit, current_merit):
         """
         Return an updated step size based on the merit function progress.
 
         The merit is dimensionless: ``|ΔE|/energy_diff_tol + RMS(g_perp)/force_rms_tol``.
-        If merit decreased (progress), the step size is grown by ``step_size_grow``.
-        If merit increased (overshoot/oscillation), it is shrunk by ``step_size_shrink``.
-        The result is clamped to ``[step_size_min, step_size_max]``.
+        A relative dead band prevents numerical noise from repeatedly growing and
+        shrinking the step. Only an improvement above 10% grows the step; a
+        regression above 2% shrinks it; otherwise the step is retained.
         """
-        if current_merit < prev_merit:
+        merit_scale = max(abs(prev_merit), np.finfo(float).tiny)
+        relative_progress = (prev_merit - current_merit) / merit_scale
+        if relative_progress > self._GROW_SHRINK_IMPROVEMENT_THRESHOLD:
             new_step = current_step_size * self.settings.step_size_grow
-        else:
+        elif relative_progress < -self._GROW_SHRINK_REGRESSION_THRESHOLD:
             new_step = current_step_size * self.settings.step_size_shrink
+        else:
+            new_step = current_step_size
         return float(
             np.clip(
                 new_step,
@@ -490,37 +620,59 @@ class GaussianMECPJob(GaussianJob):
         )
 
     def _bb_step_size(
-        self, prev_positions, curr_positions, prev_proj_grad, curr_proj_grad
+        self,
+        current_step_size,
+        prev_positions,
+        curr_positions,
+        prev_proj_grad,
+        curr_proj_grad,
+        constraint_gradient=None,
     ):
         """
-        Compute a Barzilai-Borwein (BB2) step size from the secant condition.
+        Compute a safeguarded Barzilai-Borwein step from the secant condition.
 
         Uses the formula ``α = ||Δr||² / (Δr · Δg_⊥)`` where
         ``Δr = r_n − r_{n−1}`` and ``Δg_⊥ = g_⊥,n − g_⊥,n−1``.
 
-        Falls back to the initial ``step_size`` when the denominator is
-        non-positive (negative curvature or numerically zero step).
-        The result is clamped to ``[step_size_min, step_size_max]``.
+        When supplied, ``constraint_gradient`` projects the displacement onto
+        the current seam tangent before pairing it with the projected-gradient
+        change. Unreliable curvature damps the current step instead of resetting
+        it. A relative safeguard also prevents a valid but noisy secant pair
+        from changing the step by more than a factor of two in one iteration.
         """
         delta_r = (curr_positions - prev_positions).ravel()
         delta_g = (curr_proj_grad - prev_proj_grad).ravel()
 
+        if constraint_gradient is not None:
+            normal = np.asarray(constraint_gradient, dtype=float).ravel()
+            normal_norm_sq = float(np.dot(normal, normal))
+            if normal_norm_sq > np.finfo(float).tiny:
+                delta_r = (
+                    delta_r
+                    - float(np.dot(delta_r, normal)) / normal_norm_sq * normal
+                )
+
         r_dot_r = float(np.dot(delta_r, delta_r))
         r_dot_g = float(np.dot(delta_r, delta_g))
+        g_dot_g = float(np.dot(delta_g, delta_g))
+        curvature_scale = np.sqrt(max(r_dot_r * g_dot_g, 0.0))
+        reliable_curvature = (
+            r_dot_r >= 1.0e-30
+            and g_dot_g >= 1.0e-30
+            and r_dot_g > self._BB_CURVATURE_COSINE_MIN * curvature_scale
+        )
 
-        if r_dot_r < 1e-30 or r_dot_g <= 0.0:
-            return float(
-                np.clip(
-                    self.settings.step_size,
-                    self.settings.step_size_min,
-                    self.settings.step_size_max,
-                )
-            )
+        if reliable_curvature:
+            candidate = r_dot_r / r_dot_g
+        else:
+            candidate = current_step_size * self.settings.step_size_shrink
 
-        bb_step = r_dot_r / r_dot_g
+        relative_min = current_step_size * self._BB_RELATIVE_STEP_MIN
+        relative_max = current_step_size * self._BB_RELATIVE_STEP_MAX
+        safeguarded_step = np.clip(candidate, relative_min, relative_max)
         return float(
             np.clip(
-                bb_step,
+                safeguarded_step,
                 self.settings.step_size_min,
                 self.settings.step_size_max,
             )
@@ -558,7 +710,15 @@ class GaussianMECPJob(GaussianJob):
         )
 
     def _log_step(
-        self, f, step_idx, ea, eb, projected_grad, displacement, seam_correction, step_size
+        self,
+        f,
+        step_idx,
+        ea,
+        eb,
+        projected_grad,
+        displacement,
+        seam_correction,
+        step_size,
     ):
         energy_diff = ea - eb
         pgrad_max = float(np.max(np.abs(projected_grad)))
@@ -597,17 +757,58 @@ class GaussianMECPJob(GaussianJob):
         self.steps_folder = os.path.join(self.folder, f"{self.label}_steps")
         os.makedirs(self.steps_folder, exist_ok=True)
         self._state_checkpoint_files = {}
+        self._last_spin_squared = {"A": None, "B": None}
 
-        with open(self.report_file, "w") as report:
-            report.write("CHEMSMART self-contained MECP optimization\n")
-            report.write(
-                f"max_steps={self.settings.max_steps} "
-                f"step_size={self.settings.step_size} "
-                f"trust_radius={self.settings.trust_radius} "
-                f"adaptive_step_size={self.settings.adaptive_step_size} "
-                f"step_size_method={self.settings.step_size_method}\n"
-            )
-            for step_idx in range(1, self.settings.max_steps + 1):
+        start_step = 1
+        restarting = self.settings.restart and os.path.isfile(self.state_file)
+        if restarting:
+            saved = self._load_optimizer_state()
+            start_step = saved["next_step"]
+            positions_bohr = saved["positions_bohr"]
+            current_step_size = saved["current_step_size"]
+            prev_merit = saved["prev_merit"]
+            prev_positions = saved["prev_positions"]
+            prev_proj_grad = saved["prev_proj_grad"]
+            inv_hessian = saved["inv_hessian"]
+            prev_eff_grad = saved["prev_eff_grad"]
+            prev_positions_bfgs = saved["prev_positions_bfgs"]
+            for state in ("A", "B"):
+                checkpoint_file = os.path.join(
+                    self.steps_folder, f"{self.label}_{state}.chk"
+                )
+                if os.path.isfile(checkpoint_file):
+                    self._state_checkpoint_files[(None, state)] = (
+                        checkpoint_file
+                    )
+
+        report_mode = "a" if restarting else "w"
+        converged_step = None
+        with open(self.report_file, report_mode) as report:
+            if restarting:
+                report.write(
+                    f"Restarting from saved state at step {start_step}.\n"
+                )
+            else:
+                report.write("CHEMSMART self-contained MECP optimization\n")
+            if self.settings.step_size_method == "harvey":
+                report.write(
+                    f"max_steps={self.settings.max_steps} "
+                    "step_size_method=harvey "
+                    "harvey_initial_hessian="
+                    f"{self.settings.harvey_initial_hessian} "
+                    "harvey_max_component_step="
+                    f"{self.settings.harvey_max_component_step} "
+                    f"harvey_max_condition={self.settings.harvey_max_condition}\n"
+                )
+            else:
+                report.write(
+                    f"max_steps={self.settings.max_steps} "
+                    f"step_size={self.settings.step_size} "
+                    f"trust_radius={self.settings.trust_radius} "
+                    f"adaptive_step_size={self.settings.adaptive_step_size} "
+                    f"step_size_method={self.settings.step_size_method}\n"
+                )
+            for step_idx in range(start_step, self.settings.max_steps + 1):
                 self._write_trajectory_frame(positions_bohr, step_idx)
                 ea, grad_a = self._run_state(positions_bohr, step_idx, "A")
                 eb, grad_b = self._run_state(positions_bohr, step_idx, "B")
@@ -623,6 +824,7 @@ class GaussianMECPJob(GaussianJob):
                         bfgs_status,
                         bfgs_fac,
                         bfgs_fae,
+                        optimizer_gradient,
                     ) = self._bfgs_displacement(
                         ea=ea,
                         eb=eb,
@@ -634,12 +836,15 @@ class GaussianMECPJob(GaussianJob):
                         inv_hessian=inv_hessian,
                     )
                 else:
-                    displacement, projected_grad, seam_correction = self._mecp_displacement(
-                        energy_diff=energy_diff,
-                        grad_a=grad_a,
-                        grad_b=grad_b,
-                        step_size=current_step_size,
+                    displacement, projected_grad, seam_correction = (
+                        self._mecp_displacement(
+                            energy_diff=energy_diff,
+                            grad_a=grad_a,
+                            grad_b=grad_b,
+                            step_size=current_step_size,
+                        )
                     )
+                    optimizer_gradient = projected_grad
 
                 if self.settings.step_size_method != "harvey":
                     displacement = self._apply_trust_radius(displacement)
@@ -660,30 +865,40 @@ class GaussianMECPJob(GaussianJob):
                         f"delta_g_dot_delta_x={bfgs_fac:+.8e} "
                         f"delta_g_dot_h_delta_g={bfgs_fae:+.8e}\n"
                     )
+                spin_a = self._last_spin_squared["A"]
+                spin_b = self._last_spin_squared["B"]
+                if spin_a is not None or spin_b is not None:
+                    value_a = "NA" if spin_a is None else f"{spin_a:.6f}"
+                    value_b = "NA" if spin_b is None else f"{spin_b:.6f}"
+                    report.write(
+                        f"spin_squared_A={value_a} spin_squared_B={value_b}\n"
+                    )
 
                 if self._is_converged(
                     energy_diff=energy_diff,
                     eff_grad=projected_grad,
                     displacement=displacement,
                 ):
-                    report.write(f"Converged at step {step_idx}.\n")
+                    report.write(
+                        f"Optimization converged at step {step_idx}.\n"
+                    )
+                    converged_step = step_idx
                     break
 
                 if self.settings.adaptive_step_size:
                     if self.settings.step_size_method == "bb":
                         if prev_positions is not None:
                             current_step_size = self._bb_step_size(
+                                current_step_size,
                                 prev_positions,
                                 positions_bohr,
                                 prev_proj_grad,
                                 projected_grad,
+                                grad_a - grad_b,
                             )
                         prev_positions = positions_bohr.copy()
                         prev_proj_grad = projected_grad.copy()
-                    elif self.settings.step_size_method == "harvey":
-                        # BFGS maintains its own step size via inverse Hessian
-                        pass
-                    else:  # "grow_shrink"
+                    elif self.settings.step_size_method == "grow_shrink":
                         current_merit = (
                             abs(energy_diff) / self.settings.energy_diff_tol
                             + self._rms(projected_grad)
@@ -697,9 +912,20 @@ class GaussianMECPJob(GaussianJob):
 
                 if self.settings.step_size_method == "harvey":
                     prev_positions_bfgs = positions_bohr.copy()
-                    prev_eff_grad = projected_grad.ravel().copy()
+                    prev_eff_grad = optimizer_gradient.ravel().copy()
 
                 positions_bohr = positions_bohr + displacement
+                self._save_optimizer_state(
+                    next_step=step_idx + 1,
+                    positions_bohr=positions_bohr,
+                    current_step_size=current_step_size,
+                    prev_merit=prev_merit,
+                    prev_positions=prev_positions,
+                    prev_proj_grad=prev_proj_grad,
+                    inv_hessian=inv_hessian,
+                    prev_eff_grad=prev_eff_grad,
+                    prev_positions_bfgs=prev_positions_bfgs,
+                )
             else:
                 raise RuntimeError(
                     "MECP optimization did not converge within max_steps."
@@ -709,6 +935,11 @@ class GaussianMECPJob(GaussianJob):
 
         if self.settings.verify_seam_minimum:
             self._run_seam_minimum_check(positions_bohr)
+
+        with open(self.report_file, "a", encoding="utf-8") as report:
+            report.write(f"Converged at step {converged_step}.\n")
+        if os.path.isfile(self.state_file):
+            os.remove(self.state_file)
 
     # ------------------------------------------------------------------
     # Seam-minimum verification via effective Hessian analysis
@@ -775,30 +1006,41 @@ class GaussianMECPJob(GaussianJob):
 
         return orthonormal
 
-    def _project_hessian(self, hessian, projection_vectors):
-        """
-        Apply the projector :math:`P = I - \\sum_i |v_i\\rangle\\langle v_i|`
-        to the Hessian from both sides: :math:`H_\\text{eff} = P H P`.
+    @staticmethod
+    def _reduced_hessian(hessian, projection_vectors):
+        """Return the Hessian represented in the unprojected subspace.
 
-        Args:
-            hessian (np.ndarray): Square Hessian matrix (3N × 3N),
-                Hartree/Bohr².
-            projection_vectors (list[np.ndarray]): Orthonormal vectors to
-                project out (each of length 3N).
-
-        Returns:
-            np.ndarray: Projected Hessian, same shape as input.
+        Diagonalising ``P @ H @ P`` leaves one numerical zero eigenvalue for
+        every projected vector.  Removing a fixed number of eigenvalues after
+        sorting is unsafe because genuine negative eigenvalues sort before the
+        projected zeros.  Building an explicit orthonormal complement avoids
+        that ambiguity.
         """
-        n = hessian.shape[0]
-        P = np.eye(n)
-        for v in projection_vectors:
-            P -= np.outer(v, v)
-        return P @ hessian @ P
+        if not projection_vectors:
+            return np.array(hessian, dtype=float, copy=True)
+        projected_basis = np.column_stack(projection_vectors)
+        q_full, _ = np.linalg.qr(projected_basis, mode="complete")
+        seam_basis = q_full[:, projected_basis.shape[1] :]
+        return seam_basis.T @ hessian @ seam_basis
+
+    @classmethod
+    def _lagrangian_hessian(cls, hessian_a, hessian_b, grad_a, grad_b):
+        """Return the constrained MECP Lagrangian Hessian and multiplier."""
+        diff_grad = np.asarray(grad_a).ravel() - np.asarray(grad_b).ravel()
+        diff_norm_sq = float(np.dot(diff_grad, diff_grad))
+        if diff_norm_sq < cls.MIN_DIFF_GRAD_NORM_SQ:
+            raise RuntimeError(
+                "Difference gradient is too small for seam verification."
+            )
+        multiplier = float(np.dot(np.asarray(grad_a).ravel(), diff_grad))
+        multiplier /= diff_norm_sq
+        hessian = (1.0 - multiplier) * hessian_a + multiplier * hessian_b
+        return hessian, multiplier
 
     def _compute_numerical_hessian(self, positions_bohr, h, step_prefix):
         """
-        Compute the average Hessian :math:`H = (H_A + H_B)/2` numerically
-        via central finite differences of the Cartesian forces.
+        Compute both state Hessians numerically via central finite differences
+        of the Cartesian forces.
 
         For each coordinate ``j`` (0 … 3N−1) the geometry is displaced by
         ``±h`` Bohr and both states are evaluated:
@@ -808,7 +1050,7 @@ class GaussianMECPJob(GaussianJob):
             H_{ij} \\approx \\frac{g_i(+h_j) - g_i(-h_j)}{2h}
 
         where :math:`g_i` denotes the gradient component (force negated).
-        The Hessian is symmetrised as :math:`(H + H^T)/2` before averaging.
+        Each Hessian is symmetrised as :math:`(H + H^T)/2`.
 
         .. warning::
 
@@ -823,8 +1065,8 @@ class GaussianMECPJob(GaussianJob):
             step_prefix (int): First check-specific sub-job step index.
 
         Returns:
-            np.ndarray: Average symmetrised Hessian, shape (3N, 3N),
-            Hartree/Bohr².
+            tuple[np.ndarray, np.ndarray]: Symmetrised ``(H_A, H_B)`` matrices,
+            each with shape (3N, 3N), in Hartree/Bohr².
         """
         n_atoms = len(self.molecule.symbols)
         n = 3 * n_atoms
@@ -863,32 +1105,24 @@ class GaussianMECPJob(GaussianJob):
 
         H_A = (H_A + H_A.T) / 2
         H_B = (H_B + H_B.T) / 2
-        return (H_A + H_B) / 2
+        return H_A, H_B
 
     def verify_seam_minimum(self, h=None, step_prefix=1):
         """
         Verify that the current MECP geometry is a **minimum on the crossing
         seam**, not merely a crossing point.
 
-        The method computes the average Hessian :math:`H = (H_A + H_B)/2`
-        numerically via central finite differences, then projects out
-        translational, rotational, and gradient-difference degrees of
-        freedom:
+        The method computes both state Hessians numerically and forms the
+        constrained Lagrangian Hessian. It then represents that Hessian in the
+        subspace orthogonal to translations, rotations, and the
+        gradient-difference direction:
 
         .. math::
 
-            H_\\text{eff} = P H P, \\quad
-            P = I - \\textstyle\\sum_i |v_i\\rangle\\langle v_i|
+            H_\\text{seam} = Q^T [(1-\\lambda)H_A + \\lambda H_B] Q
 
-        where :math:`\\{v_i\\}` spans translations (3), rotations (up to 3),
-        and the gradient-difference direction
-        :math:`\\mathbf{g}_\\Delta / \\|\\mathbf{g}_\\Delta\\|`.
-
-        The eigenvalues of :math:`H_\\text{eff}` are diagonalised after
-        discarding the (approximately) zero eigenvalues corresponding to
-        projected-out modes.  All remaining eigenvalues positive → confirmed
-        MECP minimum; any negative eigenvalue indicates a saddle point on the
-        seam.
+        The columns of the reduced-space basis span the seam tangent space.
+        Any negative eigenvalue indicates a saddle point on the seam.
 
         Results are written to ``<label>_seam_check.log``.
 
@@ -911,7 +1145,8 @@ class GaussianMECPJob(GaussianJob):
             dict: Keys ``"eigenvalues"`` (1-D array, non-projected modes),
             ``"n_negative"`` (int), ``"is_minimum"`` (bool),
             ``"energy_diff"`` (float, Hartree),
-            ``"n_projected"`` (int, modes removed).
+            ``"n_projected"`` (int, modes removed), and
+            ``"lagrange_multiplier"`` (float).
         """
         if h is None:
             h = self.settings.hess_step_size
@@ -935,16 +1170,18 @@ class GaussianMECPJob(GaussianJob):
             f"verify_seam_minimum: computing numerical Hessian for {self.label} "
             f"(h={h} Bohr, {4 * 3 * len(self.molecule.symbols)} sub-jobs)"
         )
-        H_avg = self._compute_numerical_hessian(
+        H_A, H_B = self._compute_numerical_hessian(
             positions_bohr, h=h, step_prefix=step_prefix + 1
         )
 
         proj_vecs = self._build_projection_vectors(positions_bohr, diff_grad)
-        H_eff = self._project_hessian(H_avg, proj_vecs)
+        H_lagrangian, lagrange_multiplier = self._lagrangian_hessian(
+            H_A, H_B, grad_a, grad_b
+        )
+        H_seam = self._reduced_hessian(H_lagrangian, proj_vecs)
 
-        eigenvalues = np.sort(np.linalg.eigvalsh(H_eff))
+        non_zero_evals = np.sort(np.linalg.eigvalsh(H_seam))
         n_proj = len(proj_vecs)
-        non_zero_evals = eigenvalues[n_proj:]
         n_negative = int(np.sum(non_zero_evals < -1.0e-6))
 
         result = {
@@ -953,6 +1190,7 @@ class GaussianMECPJob(GaussianJob):
             "is_minimum": n_negative == 0,
             "energy_diff": ea - eb,
             "n_projected": n_proj,
+            "lagrange_multiplier": lagrange_multiplier,
         }
 
         self._write_seam_check_log(result, h, step_prefix)
@@ -971,15 +1209,22 @@ class GaussianMECPJob(GaussianJob):
 
     def _run_seam_minimum_check(self, positions_bohr):
         """Called at the end of ``_run()`` when ``verify_seam_minimum`` is set."""
-        logger.info(
-            f"Starting seam-minimum verification for {self.label}"
-        )
+        logger.info(f"Starting seam-minimum verification for {self.label}")
         result = self.verify_seam_minimum()
-        status = "MINIMUM" if result["is_minimum"] else "NOT A MINIMUM (saddle point on seam)"
+        status = (
+            "MINIMUM"
+            if result["is_minimum"]
+            else "NOT A MINIMUM (saddle point on seam)"
+        )
         logger.info(
             f"Seam-minimum check for {self.label}: {status} "
             f"(n_negative={result['n_negative']})"
         )
+        if not result["is_minimum"]:
+            raise RuntimeError(
+                f"Converged crossing is not a minimum on the seam "
+                f"({result['n_negative']} negative eigenvalue(s))."
+            )
 
     def _write_seam_check_log(self, result, h, step_prefix):
         """Write the seam-minimum verification results to a log file."""
@@ -994,7 +1239,8 @@ class GaussianMECPJob(GaussianJob):
             )
             f.write(
                 f"energy_diff={result['energy_diff']:+.6e} Hartree "
-                f"n_projected={result['n_projected']}\n"
+                f"n_projected={result['n_projected']} "
+                f"lagrange_multiplier={result['lagrange_multiplier']:+.8e}\n"
             )
             n_neg = result["n_negative"]
             is_min = result["is_minimum"]

--- a/chemsmart/jobs/gaussian/mecp.py
+++ b/chemsmart/jobs/gaussian/mecp.py
@@ -18,6 +18,38 @@ from chemsmart.jobs.gaussian.settings import GaussianMECPJobSettings
 
 logger = logging.getLogger(__name__)
 
+MIN_DIFF_GRAD_NORM_SQ = 1.0e-20
+
+# Settings consumed by the MECP driver rather than Gaussian link sub-jobs.
+MECP_ONLY_KEYS = frozenset(
+    {
+        "multiplicity_a",
+        "multiplicity_b",
+        "charge_a",
+        "charge_b",
+        "title_a",
+        "title_b",
+        "max_steps",
+        "step_size",
+        "trust_radius",
+        "energy_diff_tol",
+        "force_max_tol",
+        "force_rms_tol",
+        "disp_max_tol",
+        "disp_rms_tol",
+        "adaptive_step_size",
+        "step_size_method",
+        "step_size_grow",
+        "step_size_shrink",
+        "step_size_min",
+        "step_size_max",
+        "use_link",
+        "convergence_preset",
+        "verify_seam_minimum",
+        "hess_step_size",
+    }
+)
+
 
 class GaussianMECPJob(GaussianJob):
     """
@@ -42,6 +74,7 @@ class GaussianMECPJob(GaussianJob):
     """
 
     TYPE = "g16mecp"
+<<<<<<< Updated upstream
     MIN_DIFF_GRAD_NORM_SQ = 1.0e-20
 
     @staticmethod
@@ -114,6 +147,8 @@ class GaussianMECPJob(GaussianJob):
             # params and will be overridden with state-specific values anyway.
         }
     )
+=======
+>>>>>>> Stashed changes
 
     def __init__(
         self,
@@ -271,7 +306,7 @@ class GaussianMECPJob(GaussianJob):
             link_kwargs = {
                 k: v
                 for k, v in self.settings.__dict__.items()
-                if not k.startswith("_") and k not in self._MECP_ONLY_KEYS
+                if not k.startswith("_") and k not in MECP_ONLY_KEYS
             }
             # Override with state-specific and link-specific values.
             link_kwargs.update(
@@ -406,7 +441,7 @@ class GaussianMECPJob(GaussianJob):
         diff_grad = grad_a - grad_b
         diff_norm_sq = float(np.sum(diff_grad * diff_grad))
 
-        if diff_norm_sq < self.MIN_DIFF_GRAD_NORM_SQ:
+        if diff_norm_sq < MIN_DIFF_GRAD_NORM_SQ:
             raise RuntimeError(
                 "Difference gradient is too small; cannot continue MECP step."
             )
@@ -723,7 +758,11 @@ class GaussianMECPJob(GaussianJob):
             and disp_rms <= self.settings.disp_rms_tol
         )
 
+<<<<<<< Updated upstream
     def _log_step(
+=======
+    def log_step(
+>>>>>>> Stashed changes
         self,
         f,
         step_idx,
@@ -863,7 +902,7 @@ class GaussianMECPJob(GaussianJob):
                 if self.settings.step_size_method != "harvey":
                     displacement = self._apply_trust_radius(displacement)
 
-                self._log_step(
+                self.log_step(
                     report,
                     step_idx,
                     ea,

--- a/chemsmart/jobs/gaussian/mecp.py
+++ b/chemsmart/jobs/gaussian/mecp.py
@@ -18,10 +18,21 @@ from chemsmart.jobs.gaussian.settings import GaussianMECPJobSettings
 
 logger = logging.getLogger(__name__)
 
-MIN_DIFF_GRAD_NORM_SQ = 1.0e-20
+_MIN_DIFF_GRAD_NORM_SQ = 1.0e-20
+
+_GROW_SHRINK_THRESHOLDS = {
+    "improvement": 0.10,
+    "regression": 0.02,
+}
+
+_BB_SAFEGUARDS = {
+    "curvature_cosine_min": 1.0e-4,
+    "relative_step_min": 0.5,
+    "relative_step_max": 2.0,
+}
 
 # Settings consumed by the MECP driver rather than Gaussian link sub-jobs.
-MECP_ONLY_KEYS = frozenset(
+_MECP_ONLY_KEYS = frozenset(
     {
         "multiplicity_a",
         "multiplicity_b",
@@ -43,10 +54,14 @@ MECP_ONLY_KEYS = frozenset(
         "step_size_shrink",
         "step_size_min",
         "step_size_max",
+        "harvey_initial_hessian",
+        "harvey_max_component_step",
+        "harvey_max_condition",
         "use_link",
         "convergence_preset",
         "verify_seam_minimum",
         "hess_step_size",
+        "restart",
     }
 )
 
@@ -74,11 +89,9 @@ class GaussianMECPJob(GaussianJob):
     """
 
     TYPE = "g16mecp"
-<<<<<<< Updated upstream
-    MIN_DIFF_GRAD_NORM_SQ = 1.0e-20
 
     @staticmethod
-    def _without_unavailable_guess_read(route):
+    def _route_without_guess_read(route):
         """Remove ``read`` from a Gaussian guess option for the first step."""
 
         def strip_parenthesized_read(match):
@@ -110,45 +123,6 @@ class GaussianMECPJob(GaussianJob):
                 "the optimization coordinates; remove the explicit symmetry option."
             )
         return f"{route} nosymm".strip()
-
-    # MECP-specific attribute names that must be stripped when building
-    # a GaussianLinkJobSettings for each sub-job (broken-symmetry mode).
-    _MECP_ONLY_KEYS = frozenset(
-        {
-            "multiplicity_a",
-            "multiplicity_b",
-            "charge_a",
-            "charge_b",
-            "title_a",
-            "title_b",
-            "max_steps",
-            "step_size",
-            "trust_radius",
-            "energy_diff_tol",
-            "force_max_tol",
-            "force_rms_tol",
-            "disp_max_tol",
-            "disp_rms_tol",
-            "adaptive_step_size",
-            "step_size_method",
-            "step_size_grow",
-            "step_size_shrink",
-            "step_size_min",
-            "step_size_max",
-            "harvey_initial_hessian",
-            "harvey_max_component_step",
-            "harvey_max_condition",
-            "use_link",
-            "convergence_preset",
-            "verify_seam_minimum",
-            "hess_step_size",
-            "restart",
-            # 'stable' and 'guess' are kept: they are valid GaussianLinkJobSettings
-            # params and will be overridden with state-specific values anyway.
-        }
-    )
-=======
->>>>>>> Stashed changes
 
     def __init__(
         self,
@@ -306,7 +280,7 @@ class GaussianMECPJob(GaussianJob):
             link_kwargs = {
                 k: v
                 for k, v in self.settings.__dict__.items()
-                if not k.startswith("_") and k not in MECP_ONLY_KEYS
+                if not k.startswith("_") and k not in _MECP_ONLY_KEYS
             }
             # Override with state-specific and link-specific values.
             link_kwargs.update(
@@ -371,31 +345,29 @@ class GaussianMECPJob(GaussianJob):
         if not oldchkfile and not self.settings.use_link:
             route = settings.additional_route_parameters or ""
             settings.additional_route_parameters = (
-                self._without_unavailable_guess_read(route)
+                self._route_without_guess_read(route)
             )
+
+        checkpoint_part = f"{checkpoint_tag}_" if checkpoint_tag else ""
+        job_kwargs = {
+            "molecule": mol,
+            "settings": settings,
+            "label": state_label,
+            "jobrunner": self.jobrunner,
+            "skip_completed": False,
+            "scratch_parent_folder": f"{self.label}_steps",
+            "checkpoint_filename": (
+                f"{self.label}_{checkpoint_part}{state}.chk"
+            ),
+        }
 
         if self.settings.use_link:
             from chemsmart.jobs.gaussian.link import GaussianLinkJob
 
-            job = GaussianLinkJob(
-                molecule=mol,
-                settings=settings,
-                label=state_label,
-                jobrunner=self.jobrunner,
-                skip_completed=False,
-            )
+            job = GaussianLinkJob(**job_kwargs)
         else:
-            job = GaussianGeneralJob(
-                molecule=mol,
-                settings=settings,
-                label=state_label,
-                jobrunner=self.jobrunner,
-                skip_completed=False,
-            )
+            job = GaussianGeneralJob(**job_kwargs)
         job.set_folder(self.steps_folder)
-        job.scratch_parent_folder = f"{self.label}_steps"
-        checkpoint_part = f"{checkpoint_tag}_" if checkpoint_tag else ""
-        job.checkpoint_filename = f"{self.label}_{checkpoint_part}{state}.chk"
         job.oldchkfile = oldchkfile
         job.run()
         output = job._output()
@@ -416,7 +388,7 @@ class GaussianMECPJob(GaussianJob):
         gradient = -forces
         if not hasattr(self, "_last_spin_squared"):
             self._last_spin_squared = {"A": None, "B": None}
-        self._last_spin_squared[state] = getattr(output, "spin_squared", None)
+        self._last_spin_squared[state] = output.spin_squared_after_annihilation
         if os.path.isfile(job.chkfile):
             self._state_checkpoint_files[checkpoint_key] = job.chkfile
         return energy, gradient
@@ -441,7 +413,7 @@ class GaussianMECPJob(GaussianJob):
         diff_grad = grad_a - grad_b
         diff_norm_sq = float(np.sum(diff_grad * diff_grad))
 
-        if diff_norm_sq < MIN_DIFF_GRAD_NORM_SQ:
+        if diff_norm_sq < _MIN_DIFF_GRAD_NORM_SQ:
             raise RuntimeError(
                 "Difference gradient is too small; cannot continue MECP step."
             )
@@ -550,7 +522,7 @@ class GaussianMECPJob(GaussianJob):
         # Effective_Gradient subroutine.
         diff_grad = grad_a - grad_b  # PerpG
         diff_norm_sq = float(np.sum(diff_grad * diff_grad))
-        if diff_norm_sq < self.MIN_DIFF_GRAD_NORM_SQ:
+        if diff_norm_sq < _MIN_DIFF_GRAD_NORM_SQ:
             raise RuntimeError(
                 "Difference gradient is too small; cannot continue MECP step."
             )
@@ -637,12 +609,6 @@ class GaussianMECPJob(GaussianJob):
             eff_grad,
         )
 
-    _GROW_SHRINK_IMPROVEMENT_THRESHOLD = 0.10
-    _GROW_SHRINK_REGRESSION_THRESHOLD = 0.02
-    _BB_CURVATURE_COSINE_MIN = 1.0e-4
-    _BB_RELATIVE_STEP_MIN = 0.5
-    _BB_RELATIVE_STEP_MAX = 2.0
-
     def _adapt_step_size(self, current_step_size, prev_merit, current_merit):
         """
         Return an updated step size based on the merit function progress.
@@ -654,9 +620,9 @@ class GaussianMECPJob(GaussianJob):
         """
         merit_scale = max(abs(prev_merit), np.finfo(float).tiny)
         relative_progress = (prev_merit - current_merit) / merit_scale
-        if relative_progress > self._GROW_SHRINK_IMPROVEMENT_THRESHOLD:
+        if relative_progress > _GROW_SHRINK_THRESHOLDS["improvement"]:
             new_step = current_step_size * self.settings.step_size_grow
-        elif relative_progress < -self._GROW_SHRINK_REGRESSION_THRESHOLD:
+        elif relative_progress < -_GROW_SHRINK_THRESHOLDS["regression"]:
             new_step = current_step_size * self.settings.step_size_shrink
         else:
             new_step = current_step_size
@@ -708,7 +674,8 @@ class GaussianMECPJob(GaussianJob):
         reliable_curvature = (
             r_dot_r >= 1.0e-30
             and g_dot_g >= 1.0e-30
-            and r_dot_g > self._BB_CURVATURE_COSINE_MIN * curvature_scale
+            and r_dot_g
+            > _BB_SAFEGUARDS["curvature_cosine_min"] * curvature_scale
         )
 
         if reliable_curvature:
@@ -716,8 +683,8 @@ class GaussianMECPJob(GaussianJob):
         else:
             candidate = current_step_size * self.settings.step_size_shrink
 
-        relative_min = current_step_size * self._BB_RELATIVE_STEP_MIN
-        relative_max = current_step_size * self._BB_RELATIVE_STEP_MAX
+        relative_min = current_step_size * _BB_SAFEGUARDS["relative_step_min"]
+        relative_max = current_step_size * _BB_SAFEGUARDS["relative_step_max"]
         safeguarded_step = np.clip(candidate, relative_min, relative_max)
         return float(
             np.clip(
@@ -758,11 +725,7 @@ class GaussianMECPJob(GaussianJob):
             and disp_rms <= self.settings.disp_rms_tol
         )
 
-<<<<<<< Updated upstream
-    def _log_step(
-=======
     def log_step(
->>>>>>> Stashed changes
         self,
         f,
         step_idx,
@@ -1081,7 +1044,7 @@ class GaussianMECPJob(GaussianJob):
         """Return the constrained MECP Lagrangian Hessian and multiplier."""
         diff_grad = np.asarray(grad_a).ravel() - np.asarray(grad_b).ravel()
         diff_norm_sq = float(np.dot(diff_grad, diff_grad))
-        if diff_norm_sq < cls.MIN_DIFF_GRAD_NORM_SQ:
+        if diff_norm_sq < _MIN_DIFF_GRAD_NORM_SQ:
             raise RuntimeError(
                 "Difference gradient is too small for seam verification."
             )

--- a/chemsmart/jobs/gaussian/mecp.py
+++ b/chemsmart/jobs/gaussian/mecp.py
@@ -318,35 +318,6 @@ class GaussianMECPJob(GaussianJob):
 
         return displacement, projected_grad, seam_correction
 
-    def _harvey_step_size(self, current_step_size, prev_energy_a, curr_energy_a):
-        """
-        Harvey's heuristic step-size update (1998).
-
-        Uses the *total energy of state A* (not a merit function) to decide
-        whether to grow or shrink:
-
-        * If ``E_A`` decreased -> step grew by ``step_size_grow`` (default x1.2).
-        * If ``E_A`` increased or stagnated -> step shrunk by
-          ``step_size_shrink`` (default x0.5).
-
-        This mirrors the original Fortran code's ``TSTEP`` / ``TSMIN`` / ``TSMAX``
-        logic where ``TSMAX`` is typically 0.30 Bohr (much smaller than the
-        chemsmart default of 1.0).
-
-        The result is clamped to ``[step_size_min, step_size_max]``.
-        """
-        if curr_energy_a < prev_energy_a:
-            new_step = current_step_size * self.settings.step_size_grow
-        else:
-            new_step = current_step_size * self.settings.step_size_shrink
-        return float(
-            np.clip(
-                new_step,
-                self.settings.step_size_min,
-                self.settings.step_size_max,
-            )
-        )
-
     @staticmethod
     def _update_inverse_hessian(
         inv_hessian, delta_x, delta_g, return_diagnostics=False
@@ -619,8 +590,7 @@ class GaussianMECPJob(GaussianJob):
         prev_merit = None
         prev_positions = None
         prev_proj_grad = None
-        prev_energy_a = None
-        # BFGS state variables for harvey_bfgs method
+        # BFGS state variables for the Harvey method
         inv_hessian = None
         prev_eff_grad = None
         prev_positions_bfgs = None
@@ -644,7 +614,7 @@ class GaussianMECPJob(GaussianJob):
 
                 energy_diff = ea - eb
 
-                if self.settings.step_size_method == "harvey_bfgs":
+                if self.settings.step_size_method == "harvey":
                     (
                         displacement,
                         projected_grad,
@@ -671,7 +641,7 @@ class GaussianMECPJob(GaussianJob):
                         step_size=current_step_size,
                     )
 
-                if self.settings.step_size_method != "harvey_bfgs":
+                if self.settings.step_size_method != "harvey":
                     displacement = self._apply_trust_radius(displacement)
 
                 self._log_step(
@@ -684,7 +654,7 @@ class GaussianMECPJob(GaussianJob):
                     seam_correction,
                     current_step_size,
                 )
-                if self.settings.step_size_method == "harvey_bfgs":
+                if self.settings.step_size_method == "harvey":
                     report.write(
                         f"bfgs_status={bfgs_status} "
                         f"delta_g_dot_delta_x={bfgs_fac:+.8e} "
@@ -711,12 +681,6 @@ class GaussianMECPJob(GaussianJob):
                         prev_positions = positions_bohr.copy()
                         prev_proj_grad = projected_grad.copy()
                     elif self.settings.step_size_method == "harvey":
-                        if prev_energy_a is not None:
-                            current_step_size = self._harvey_step_size(
-                                current_step_size, prev_energy_a, ea
-                            )
-                        prev_energy_a = ea
-                    elif self.settings.step_size_method == "harvey_bfgs":
                         # BFGS maintains its own step size via inverse Hessian
                         pass
                     else:  # "grow_shrink"
@@ -731,7 +695,7 @@ class GaussianMECPJob(GaussianJob):
                             )
                         prev_merit = current_merit
 
-                if self.settings.step_size_method == "harvey_bfgs":
+                if self.settings.step_size_method == "harvey":
                     prev_positions_bfgs = positions_bohr.copy()
                     prev_eff_grad = projected_grad.ravel().copy()
 

--- a/chemsmart/jobs/gaussian/runner.py
+++ b/chemsmart/jobs/gaussian/runner.py
@@ -98,6 +98,17 @@ class GaussianJobRunner(JobRunner):
     # of instance attribute so it needs not be set at
     # instance level - set during initialization (__init__).
 
+    def _scratch_job_directory(self, job):
+        """Return the scratch directory, optionally grouped by a job folder."""
+        scratch_parent = getattr(job, "scratch_parent_folder", None)
+        if scratch_parent:
+            return os.path.join(
+                self.scratch_dir,
+                os.path.basename(scratch_parent),
+                job.label,
+            )
+        return os.path.join(self.scratch_dir, job.label)
+
     def __init__(
         self, server, scratch=None, fake=False, scratch_dir=None, **kwargs
     ):
@@ -210,7 +221,7 @@ class GaussianJobRunner(JobRunner):
         Args:
             job: Job object to configure scratch paths for.
         """
-        scratch_job_dir = os.path.join(self.scratch_dir, job.label)
+        scratch_job_dir = self._scratch_job_directory(job)
         if not os.path.exists(scratch_job_dir):
             with suppress(FileExistsError):
                 os.makedirs(scratch_job_dir)
@@ -459,7 +470,7 @@ class FakeGaussianJobRunner(GaussianJobRunner):
         Args:
             job: Job object to configure fake scratch paths for.
         """
-        scratch_job_dir = os.path.join(self.scratch_dir, job.label)
+        scratch_job_dir = self._scratch_job_directory(job)
         if not os.path.exists(scratch_job_dir):
             with suppress(FileExistsError):
                 os.makedirs(scratch_job_dir)

--- a/chemsmart/jobs/gaussian/runner.py
+++ b/chemsmart/jobs/gaussian/runner.py
@@ -100,7 +100,11 @@ class GaussianJobRunner(JobRunner):
 
     def _scratch_job_directory(self, job):
         """Return the scratch directory, optionally grouped by a job folder."""
-        scratch_parent = getattr(job, "scratch_parent_folder", None)
+        if self.scratch_dir is None:
+            raise ValueError(
+                "A scratch directory is required for scratch jobs."
+            )
+        scratch_parent = job.scratch_parent_folder
         if scratch_parent:
             return os.path.join(
                 self.scratch_dir,

--- a/chemsmart/jobs/gaussian/runner.py
+++ b/chemsmart/jobs/gaussian/runner.py
@@ -222,7 +222,7 @@ class GaussianJobRunner(JobRunner):
         scratch_job_inputfile = os.path.join(scratch_job_dir, job_inputfile)
         self.job_inputfile = os.path.abspath(scratch_job_inputfile)
 
-        job_chkfile = job.label + ".chk"
+        job_chkfile = os.path.basename(job.chkfile)
         scratch_job_chkfile = os.path.join(scratch_job_dir, job_chkfile)
         self.job_chkfile = os.path.abspath(scratch_job_chkfile)
 
@@ -265,6 +265,14 @@ class GaussianJobRunner(JobRunner):
 
         input_writer = GaussianInputWriter(job=job)
         input_writer.write(target_directory=self.running_directory)
+
+        oldchkfile = getattr(job, "oldchkfile", None)
+        if oldchkfile and self.scratch and self.running_directory:
+            oldchk_target = os.path.join(
+                self.running_directory, os.path.basename(oldchkfile)
+            )
+            if os.path.abspath(oldchkfile) != os.path.abspath(oldchk_target):
+                copy(oldchkfile, oldchk_target)
 
     def _get_command(self, job):
         """
@@ -356,6 +364,14 @@ class GaussianJobRunner(JobRunner):
                             f"File {file} cannot be copied to job folder "
                             f"{job.folder}: {e}"
                         )
+            if os.path.isfile(self.job_chkfile):
+                checkpoint_target = os.path.join(
+                    job.folder, os.path.basename(self.job_chkfile)
+                )
+                if os.path.abspath(self.job_chkfile) != os.path.abspath(
+                    checkpoint_target
+                ):
+                    copy(self.job_chkfile, checkpoint_target)
 
 
 class FakeGaussianJobRunner(GaussianJobRunner):
@@ -458,7 +474,7 @@ class FakeGaussianJobRunner(GaussianJobRunner):
         scratch_job_inputfile = os.path.join(scratch_job_dir, job_inputfile)
         self.job_inputfile = os.path.abspath(scratch_job_inputfile)
 
-        job_chkfile = job.label + ".chk"
+        job_chkfile = os.path.basename(job.chkfile)
         scratch_job_chkfile = os.path.join(scratch_job_dir, job_chkfile)
         self.job_chkfile = os.path.abspath(scratch_job_chkfile)
 

--- a/chemsmart/jobs/gaussian/settings.py
+++ b/chemsmart/jobs/gaussian/settings.py
@@ -1180,7 +1180,7 @@ class GaussianMECPJobSettings(GaussianJobSettings):
         disp_rms_tol=None,  # Bohr
         trust_radius=None,  # Bohr
         adaptive_step_size=True,
-        step_size_method="bb",  # "bb", "grow_shrink", "harvey", or "harvey_bfgs"
+        step_size_method="harvey",  # "harvey", "bb", or "grow_shrink"
         step_size_grow=1.2,  # dimensionless multiplier; grow × shrink = 0.84 (mild damping per cycle)
         step_size_shrink=0.7,  # dimensionless multiplier; stronger than 1/grow to damp oscillations
         step_size_min=1.0e-4,  # Bohr^2/Hartree
@@ -1221,6 +1221,12 @@ class GaussianMECPJobSettings(GaussianJobSettings):
         self.trust_radius = trust_radius if trust_radius is not None else preset["trust_radius"]
 
         self.adaptive_step_size = adaptive_step_size
+        valid_step_size_methods = {"harvey", "bb", "grow_shrink"}
+        if step_size_method not in valid_step_size_methods:
+            raise ValueError(
+                f"Unknown MECP step_size_method {step_size_method!r}; expected one of "
+                f"{sorted(valid_step_size_methods)}."
+            )
         self.step_size_method = step_size_method
         self.step_size_grow = step_size_grow
         self.step_size_shrink = step_size_shrink

--- a/chemsmart/jobs/gaussian/settings.py
+++ b/chemsmart/jobs/gaussian/settings.py
@@ -1180,7 +1180,7 @@ class GaussianMECPJobSettings(GaussianJobSettings):
         disp_rms_tol=None,  # Bohr
         trust_radius=None,  # Bohr
         adaptive_step_size=True,
-        step_size_method="bb",  # algorithm: "bb" (Barzilai-Borwein), "grow_shrink" (merit-based), or "harvey" (energy-based, Harvey 1998)
+        step_size_method="bb",  # algorithm: "bb" (Barzilai-Borwein), "grow_shrink" (merit-based), "harvey" (energy-based, Harvey 1998), or "harvey_bfgs" (BFGS quasi-Newton, Harvey 2003)
         step_size_grow=1.2,  # dimensionless multiplier; grow × shrink = 0.84 (mild damping per cycle)
         step_size_shrink=0.7,  # dimensionless multiplier; stronger than 1/grow to damp oscillations
         step_size_min=1.0e-4,  # Bohr^2/Hartree

--- a/chemsmart/jobs/gaussian/settings.py
+++ b/chemsmart/jobs/gaussian/settings.py
@@ -1,4 +1,4 @@
-﻿"""
+"""
 Gaussian job configuration and settings management.
 
 This module provides the GaussianJobSettings class for configuring
@@ -1180,7 +1180,7 @@ class GaussianMECPJobSettings(GaussianJobSettings):
         disp_rms_tol=None,  # Bohr
         trust_radius=None,  # Bohr
         adaptive_step_size=True,
-        step_size_method="bb",  # algorithm: "bb" (Barzilai-Borwein), "grow_shrink" (merit-based), "harvey" (energy-based, Harvey 1998), or "harvey_bfgs" (BFGS quasi-Newton, Harvey 2003)
+        step_size_method="bb",  # "bb", "grow_shrink", "harvey", or "harvey_bfgs"
         step_size_grow=1.2,  # dimensionless multiplier; grow × shrink = 0.84 (mild damping per cycle)
         step_size_shrink=0.7,  # dimensionless multiplier; stronger than 1/grow to damp oscillations
         step_size_min=1.0e-4,  # Bohr^2/Hartree

--- a/chemsmart/jobs/gaussian/settings.py
+++ b/chemsmart/jobs/gaussian/settings.py
@@ -1217,12 +1217,36 @@ class GaussianMECPJobSettings(GaussianJobSettings):
         self.convergence_preset = convergence_preset
         preset = self.CONVERGENCE_PRESETS[convergence_preset]
 
-        self.energy_diff_tol = energy_diff_tol if energy_diff_tol is not None else preset["energy_diff_tol"]
-        self.force_max_tol = force_max_tol if force_max_tol is not None else preset["force_max_tol"]
-        self.force_rms_tol = force_rms_tol if force_rms_tol is not None else preset["force_rms_tol"]
-        self.disp_max_tol = disp_max_tol if disp_max_tol is not None else preset["disp_max_tol"]
-        self.disp_rms_tol = disp_rms_tol if disp_rms_tol is not None else preset["disp_rms_tol"]
-        self.trust_radius = trust_radius if trust_radius is not None else preset["trust_radius"]
+        self.energy_diff_tol = (
+            energy_diff_tol
+            if energy_diff_tol is not None
+            else preset["energy_diff_tol"]
+        )
+        self.force_max_tol = (
+            force_max_tol
+            if force_max_tol is not None
+            else preset["force_max_tol"]
+        )
+        self.force_rms_tol = (
+            force_rms_tol
+            if force_rms_tol is not None
+            else preset["force_rms_tol"]
+        )
+        self.disp_max_tol = (
+            disp_max_tol
+            if disp_max_tol is not None
+            else preset["disp_max_tol"]
+        )
+        self.disp_rms_tol = (
+            disp_rms_tol
+            if disp_rms_tol is not None
+            else preset["disp_rms_tol"]
+        )
+        self.trust_radius = (
+            trust_radius
+            if trust_radius is not None
+            else preset["trust_radius"]
+        )
 
         self.adaptive_step_size = adaptive_step_size
         valid_step_size_methods = {"harvey", "bb", "grow_shrink"}

--- a/chemsmart/jobs/gaussian/settings.py
+++ b/chemsmart/jobs/gaussian/settings.py
@@ -1185,6 +1185,9 @@ class GaussianMECPJobSettings(GaussianJobSettings):
         step_size_shrink=0.7,  # dimensionless multiplier; stronger than 1/grow to damp oscillations
         step_size_min=1.0e-4,  # Bohr^2/Hartree
         step_size_max=1.0,  # Bohr^2/Hartree
+        harvey_initial_hessian=0.7,  # Angstrom^2/Hartree
+        harvey_max_component_step=0.1,  # Angstrom
+        harvey_max_condition=1.0e12,
         # broken-symmetry link-job mode
         use_link=False,
         stable="opt",  # stability analysis for link mode
@@ -1192,6 +1195,7 @@ class GaussianMECPJobSettings(GaussianJobSettings):
         # seam-minimum verification via effective Hessian analysis
         verify_seam_minimum=False,
         hess_step_size=1.0e-3,  # Bohr; finite-difference displacement for numerical Hessian
+        restart=True,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -1232,11 +1236,43 @@ class GaussianMECPJobSettings(GaussianJobSettings):
         self.step_size_shrink = step_size_shrink
         self.step_size_min = step_size_min
         self.step_size_max = step_size_max
+        self.harvey_initial_hessian = harvey_initial_hessian
+        self.harvey_max_component_step = harvey_max_component_step
+        self.harvey_max_condition = harvey_max_condition
         self.use_link = use_link
         self.stable = stable
         self.guess = guess
         self.verify_seam_minimum = verify_seam_minimum
         self.hess_step_size = hess_step_size
+        self.restart = restart
+
+        positive_values = {
+            "max_steps": max_steps,
+            "step_size": step_size,
+            "energy_diff_tol": self.energy_diff_tol,
+            "force_max_tol": self.force_max_tol,
+            "force_rms_tol": self.force_rms_tol,
+            "disp_max_tol": self.disp_max_tol,
+            "disp_rms_tol": self.disp_rms_tol,
+            "trust_radius": self.trust_radius,
+            "step_size_min": step_size_min,
+            "step_size_max": step_size_max,
+            "harvey_initial_hessian": harvey_initial_hessian,
+            "harvey_max_component_step": harvey_max_component_step,
+            "harvey_max_condition": harvey_max_condition,
+            "hess_step_size": hess_step_size,
+        }
+        invalid = [name for name, value in positive_values.items() if value <= 0]
+        if invalid:
+            raise ValueError(
+                "MECP settings must be positive: " + ", ".join(invalid)
+            )
+        if step_size_min > step_size_max:
+            raise ValueError("step_size_min cannot exceed step_size_max.")
+        if multiplicity_a < 1 or multiplicity_b < 1:
+            raise ValueError("MECP multiplicities must be positive integers.")
+        if charge_a == charge_b and multiplicity_a == multiplicity_b:
+            raise ValueError("MECP states A and B must not be identical.")
 
     @classmethod
     def from_settings(cls, settings):

--- a/chemsmart/jobs/gaussian/settings.py
+++ b/chemsmart/jobs/gaussian/settings.py
@@ -1,4 +1,4 @@
-"""
+﻿"""
 Gaussian job configuration and settings management.
 
 This module provides the GaussianJobSettings class for configuring
@@ -1180,7 +1180,7 @@ class GaussianMECPJobSettings(GaussianJobSettings):
         disp_rms_tol=None,  # Bohr
         trust_radius=None,  # Bohr
         adaptive_step_size=True,
-        step_size_method="bb",  # algorithm: "bb" (Barzilai-Borwein) or "grow_shrink"
+        step_size_method="bb",  # algorithm: "bb" (Barzilai-Borwein), "grow_shrink" (merit-based), or "harvey" (energy-based, Harvey 1998)
         step_size_grow=1.2,  # dimensionless multiplier; grow × shrink = 0.84 (mild damping per cycle)
         step_size_shrink=0.7,  # dimensionless multiplier; stronger than 1/grow to damp oscillations
         step_size_min=1.0e-4,  # Bohr^2/Hartree

--- a/chemsmart/jobs/gaussian/writer.py
+++ b/chemsmart/jobs/gaussian/writer.py
@@ -147,9 +147,15 @@ class GaussianInputWriter(InputWriter):
             f (file): Open file object to write to.
         """
         logger.debug("Writing Gaussian header.")
+        oldchkfile = getattr(self.job, "oldchkfile", None)
+        chk_name = os.path.basename(self.job.chkfile)
+        if oldchkfile and os.path.basename(oldchkfile) != chk_name:
+            oldchk_name = os.path.basename(oldchkfile)
+            logger.debug(f"Reading previous chk file: {oldchk_name}")
+            f.write(f"%oldchk={oldchk_name}\n")
         if self.settings.chk:
-            logger.debug(f"Writing chk file: {self.job.label}.chk")
-            f.write(f"%chk={self.job.label}.chk\n")
+            logger.debug(f"Writing chk file: {chk_name}")
+            f.write(f"%chk={chk_name}\n")
 
         # Set default values if jobrunner resources are not specified
         num_cores = self.jobrunner.num_cores if not None else 12

--- a/chemsmart/utils/repattern.py
+++ b/chemsmart/utils/repattern.py
@@ -34,8 +34,8 @@ frozen_coordinates_pattern = (
 )
 scf_energy_pattern = r"SCF Done:\s+E\([^)]*\)\s*=\s*([-.\d]+)"
 spin_squared_pattern = (
-    r"S\*\*2 before annihilation\s+([+-]?\d+(?:\.\d+)?),"
-    r"\s+after\s+([+-]?\d+(?:\.\d+)?)"
+    r"S\*\*2 before annihilation\s+([-+0-9.DEde]+),"
+    r"\s+after\s+([-+0-9.DEde]+)"
 )
 mp2_energy_pattern = r"EUMP2\s*=\s*(.*)"
 oniom_gridpoint_pattern = r"ONIOM:\s+gridpoint\s+(\d+)\s+method:\s+(\w+)\s+system:\s+(\w+)\s+energy:\s+([+-]?\d*\.\d+|\d+)"

--- a/chemsmart/utils/repattern.py
+++ b/chemsmart/utils/repattern.py
@@ -33,6 +33,10 @@ frozen_coordinates_pattern = (
     r"\s*([A-Z][a-z]?)\s+(-1|0)\s+(-?\d+\.\d*)\s+(-?\d+\.\d*)\s+(-?\d+\.\d*)"
 )
 scf_energy_pattern = r"SCF Done:\s+E\([^)]*\)\s*=\s*([-.\d]+)"
+spin_squared_pattern = (
+    r"S\*\*2 before annihilation\s+([+-]?\d+(?:\.\d+)?),"
+    r"\s+after\s+([+-]?\d+(?:\.\d+)?)"
+)
 mp2_energy_pattern = r"EUMP2\s*=\s*(.*)"
 oniom_gridpoint_pattern = r"ONIOM:\s+gridpoint\s+(\d+)\s+method:\s+(\w+)\s+system:\s+(\w+)\s+energy:\s+([+-]?\d*\.\d+|\d+)"
 oniom_energy_pattern = r"ONIOM:\s+extrapolated energy\s*=\s*(.*)"

--- a/docs/source/gaussian-other-jobs.rst
+++ b/docs/source/gaussian-other-jobs.rst
@@ -329,13 +329,19 @@ inverse Hessian from successive effective-gradient and Cartesian-displacement
 pairs, including negative-curvature updates, and limits the total Cartesian
 step using Harvey's ``STPMX`` rule. Numerically singular updates are skipped.
 
-For non-Link calculations, each state also reads the checkpoint from its own
-previous MECP step. This preserves orbital continuity in the same way as
-``%chk`` with ``guess=read``. Like easyMECP, ChemSmart maintains one rolling
-checkpoint per state (``<label>_A.chk`` and ``<label>_B.chk``) instead of one
-checkpoint per iteration. Iteration ``.com`` and ``.log`` files and the two
-rolling checkpoints are kept in ``<label>_steps``; the report and trajectory
-remain in the main job directory.
+Like easyMECP, ChemSmart maintains one rolling checkpoint per state
+(``<label>_A.chk`` and ``<label>_B.chk``) instead of one checkpoint per
+iteration. It does not add ``guess=read`` automatically: checkpoint orbitals
+are read only when that option is explicitly present in the Gaussian route.
+If the first step requests ``guess=read`` but its checkpoint does not yet
+exist, ``read`` is removed for that first step and retained thereafter.
+Iteration ``.com`` and ``.log`` files and the two rolling checkpoints are kept
+in ``<label>_steps``; the report and trajectory remain in the main job
+directory.
+
+When Gaussian scratch storage is enabled, MECP scratch job directories are
+also grouped below ``<label>_steps`` instead of being created directly in the
+scratch root.
 
 Seam-minimum verification uses a separate pair of temporary rolling
 checkpoints. They are deleted after a successful verification, so the final

--- a/docs/source/gaussian-other-jobs.rst
+++ b/docs/source/gaussian-other-jobs.rst
@@ -109,9 +109,8 @@ MECP Options
    -  -  ``--convergence``
       -  string
       -  ``"standard"``
-      -  Convergence preset: ``"standard"`` (default, general-purpose) or ``"tight"``
-         (publication-quality). See the :ref:`convergence-presets` section below.
-         Individual tolerance options override the preset.
+      -  Convergence preset: ``"standard"`` (default, general-purpose) or ``"tight"`` (publication-quality). See the
+         :ref:`convergence-presets` section below. Individual tolerance options override the preset.
 
    -  -  ``--trust-radius``
       -  float
@@ -181,11 +180,14 @@ MECP Options
       -  Resume an interrupted MECP optimization from ``<label>_state.npz``.
 
    -  -  ``--verify-seam-minimum / --no-verify-seam-minimum``
+
       -  bool
+
       -  False
-      -  After convergence, verify the MECP is a true minimum on the crossing seam via effective Hessian
-         analysis. Requires ~4×3N additional Gaussian sub-jobs.  Results are written to
-         ``<label>_seam_check.log``. See the :ref:`seam-minimum-verification` section below.
+
+      -  After convergence, verify the MECP is a true minimum on the crossing seam via effective Hessian analysis.
+         Requires ~4×3N additional Gaussian sub-jobs. Results are written to ``<label>_seam_check.log``. See the
+         :ref:`seam-minimum-verification` section below.
 
    -  -  ``--hess-step-size``
       -  float
@@ -283,8 +285,7 @@ Two built-in convergence presets are available via ``--convergence``:
          -  0.1
          -  Bohr/atom
 
-Individual options (``--energy-diff-tol``, ``--force-max-tol``, etc.) always override
-the preset values when provided.
+Individual options (``--energy-diff-tol``, ``--force-max-tol``, etc.) always override the preset values when provided.
 
 Convergence is declared when **all** five criteria are simultaneously satisfied.
 
@@ -387,9 +388,14 @@ MECP geometry. Temporary checkpoints are retained if verification fails.
 Output Files
 ============
 
+<<<<<<< Updated upstream
 Three output files are produced in the main job directory; Gaussian sub-job input/output files are stored in
 ``<label>_steps``. The
 third (``<label>_seam_check.log``) is written only when ``--verify-seam-minimum`` is requested:
+=======
+Three output files are produced alongside the Gaussian sub-job input/output files; the third
+(``<label>_seam_check.log``) is written only when ``--verify-seam-minimum`` is requested:
+>>>>>>> Stashed changes
 
 ``<label>_report.log``
    Step-by-step optimization log. The file header records the run settings; each subsequent line reports one step, using
@@ -406,14 +412,12 @@ third (``<label>_seam_check.log``) is written only when ``--verify-seam-minimum`
    where:
 
    -  ``dE`` = :math:`E_A - E_B` — energy difference (drives toward the seam).
-   -  ``pgrad_max`` / ``pgrad_rms`` — max and RMS of the seam-tangent gradient
-      :math:`\mathbf{g}_\perp` (projection of :math:`\nabla E_A` onto the seam; drives
-      geometry to the minimum on the seam).
-   -  ``disp_max`` / ``disp_rms`` — max and RMS of the total Cartesian displacement
-      :math:`\mathbf{d} = \mathbf{d}_\text{seam} + \mathbf{d}_\text{seam-min}` after trust-radius scaling.
-   -  ``seam_max`` / ``seam_rms`` — max and RMS of the seam-correction component
-      :math:`\mathbf{d}_\text{seam} = -(\Delta E / \|\mathbf{g}_\Delta\|^2)\,\mathbf{g}_\Delta` that
-      moves the geometry toward the crossing surface.
+   -  ``pgrad_max`` / ``pgrad_rms`` — max and RMS of the seam-tangent gradient :math:`\mathbf{g}_\perp` (projection of
+      :math:`\nabla E_A` onto the seam; drives geometry to the minimum on the seam).
+   -  ``disp_max`` / ``disp_rms`` — max and RMS of the total Cartesian displacement :math:`\mathbf{d} =
+      \mathbf{d}_\text{seam} + \mathbf{d}_\text{seam-min}` after trust-radius scaling.
+   -  ``seam_max`` / ``seam_rms`` — max and RMS of the seam-correction component :math:`\mathbf{d}_\text{seam} =
+      -(\Delta E / \|\mathbf{g}_\Delta\|^2)\,\mathbf{g}_\Delta` that moves the geometry toward the crossing surface.
 
    The final line reads ``Converged at step N.`` on successful convergence. The presence of this ``Converged``
    marker is used by ``skip_completed`` to avoid re-running a finished job.
@@ -422,26 +426,26 @@ third (``<label>_seam_check.log``) is written only when ``--verify-seam-minimum`
    Multi-frame XYZ trajectory of the MECP geometry at every optimization step (coordinates in Ångström).
 
 ``<label>_seam_check.log``
-   Written only when ``--verify-seam-minimum`` is requested. Reports the eigenvalues of the effective projected
-   Hessian :math:`H_\text{eff}` (translations, rotations, and gradient-difference direction removed) and whether
-   the MECP is a true minimum on the seam. See the :ref:`seam-minimum-verification` section below.
+   Written only when ``--verify-seam-minimum`` is requested. Reports the eigenvalues of the effective projected Hessian
+   :math:`H_\text{eff}` (translations, rotations, and gradient-difference direction removed) and whether the MECP is a
+   true minimum on the seam. See the :ref:`seam-minimum-verification` section below.
 
 .. _seam-minimum-verification:
 
 Seam Minimum Verification
-==========================
+=========================
 
-A converged MECP may be a crossing point anywhere on the crossing seam, not necessarily the **minimum energy**
-point on it.  To confirm that the MECP is a true minimum on the seam (analogous to verifying a transition state has
-exactly one imaginary frequency), ChemSmart implements an effective Hessian analysis.
+A converged MECP may be a crossing point anywhere on the crossing seam, not necessarily the **minimum energy** point on
+it. To confirm that the MECP is a true minimum on the seam (analogous to verifying a transition state has exactly one
+imaginary frequency), ChemSmart implements an effective Hessian analysis.
 
 Theory
 ------
 
-At the MECP the crossing seam is a :math:`(3N-1)`-dimensional hypersurface.  Motions along the gradient-difference
-direction :math:`\mathbf{g}_\Delta = \nabla E_A - \nabla E_B` take the molecule off the seam.  The remaining
-:math:`3N-1` directions span the seam tangent space; after further removal of translations (3) and rotations (up to 3)
-there are :math:`3N - 7` (or :math:`3N - 6` for linear molecules) internal seam degrees of freedom.
+At the MECP the crossing seam is a :math:`(3N-1)`-dimensional hypersurface. Motions along the gradient-difference
+direction :math:`\mathbf{g}_\Delta = \nabla E_A - \nabla E_B` take the molecule off the seam. The remaining :math:`3N-1`
+directions span the seam tangent space; after further removal of translations (3) and rotations (up to 3) there are
+:math:`3N - 7` (or :math:`3N - 6` for linear molecules) internal seam degrees of freedom.
 
 ChemSmart constructs a projector that removes these constrained directions:
 
@@ -450,21 +454,21 @@ ChemSmart constructs a projector that removes these constrained directions:
    P = I - \sum_i |\mathbf{v}_i\rangle\langle\mathbf{v}_i|
 
 where :math:`\{\mathbf{v}_i\}` is an orthonormal set spanning translations, rotations, and
-:math:`\hat{\mathbf{g}}_\Delta`.  The **effective Hessian** is
+:math:`\hat{\mathbf{g}}_\Delta`. The **effective Hessian** is
 
 .. math::
 
    H_\text{eff} = P\,\bar{H}\,P, \qquad \bar{H} = \tfrac{1}{2}(H_A + H_B)
 
-where :math:`H_A` and :math:`H_B` are the numerical Hessians of the two states, averaged to give a balanced
-description.  If all non-zero eigenvalues of :math:`H_\text{eff}` are positive, the point is confirmed as a seam
-minimum; any negative eigenvalue indicates a lower-energy MECP elsewhere on the seam.
+where :math:`H_A` and :math:`H_B` are the numerical Hessians of the two states, averaged to give a balanced description.
+If all non-zero eigenvalues of :math:`H_\text{eff}` are positive, the point is confirmed as a seam minimum; any negative
+eigenvalue indicates a lower-energy MECP elsewhere on the seam.
 
 .. note::
 
    A **standard Gaussian frequency analysis** at the MECP geometry is **not sufficient** for this check: it does not
-   project out the gradient-difference direction, so it will always show one near-zero or spurious mode whose sign
-   is ambiguous.  The effective Hessian analysis described here is the correct diagnostic (cf. ORCA manual, §9.40).
+   project out the gradient-difference direction, so it will always show one near-zero or spurious mode whose sign is
+   ambiguous. The effective Hessian analysis described here is the correct diagnostic (cf. ORCA manual, §9.40).
 
 Usage
 -----
@@ -476,10 +480,16 @@ Add ``--verify-seam-minimum`` to the MECP command after the optimization converg
    chemsmart sub gaussian -p project -f structure.log -c 0 -m 1 mecp \
        --convergence tight --verify-seam-minimum
 
+<<<<<<< Updated upstream
 The verification requires **4 × 3N** additional Gaussian sub-jobs (2 displaced geometries × 2 spin states
 × 3N Cartesian coordinates), labelled ``<label>_check_step1_A``, ``<label>_check_step2_A``, etc. For a 10-atom molecule this is 120
 additional Gaussian calculations.  The finite-difference step size (default 1×10⁻³ Bohr) can be adjusted with
 ``--hess-step-size``.
+=======
+The verification requires **4 × 3N** additional Gaussian sub-jobs (2 displaced geometries × 2 spin states × 3N Cartesian
+coordinates), each labelled ``<label>_step900000_A`` etc. For a 10-atom molecule this is 120 additional Gaussian
+calculations. The finite-difference step size (default 1×10⁻³ Bohr) can be adjusted with ``--hess-step-size``.
+>>>>>>> Stashed changes
 
 Results are written to ``<label>_seam_check.log``:
 

--- a/docs/source/gaussian-other-jobs.rst
+++ b/docs/source/gaussian-other-jobs.rst
@@ -66,24 +66,24 @@ MECP Options
       -  Default
       -  Description
 
-   -  -  ``--multiplicity-a``
+   -  -  ``--multiplicity-1`` / ``-m1``
       -  int
       -  1 (singlet)
       -  Spin multiplicity of state A. Falls back to ``-m`` if not set.
 
-   -  -  ``--multiplicity-b``
+   -  -  ``--multiplicity-2`` / ``-m2``
       -  int
-      -  multiplicity-a + 2
+      -  multiplicity-1 + 2
       -  Spin multiplicity of state B.
 
-   -  -  ``--charge-a``
+   -  -  ``--charge-1`` / ``-c1``
       -  int
       -  0
       -  Charge of state A. Falls back to ``-c`` if not set.
 
-   -  -  ``--charge-b``
+   -  -  ``--charge-2`` / ``-c2``
       -  int
-      -  charge-a
+      -  charge-1
       -  Charge of state B.
 
    -  -  ``--title-a``
@@ -507,13 +507,13 @@ Set spin states explicitly (singlet ↔ triplet):
 
 .. code:: bash
 
-   chemsmart sub gaussian -p project -f structure.log -c 0 -m 1 mecp --multiplicity-a 1 --multiplicity-b 3
+   chemsmart sub gaussian -p project -f structure.log -c 0 -m 1 mecp --multiplicity-1 1 --multiplicity-2 3
 
 Doublet/quartet MECP for an open-shell cation:
 
 .. code:: bash
 
-   chemsmart sub gaussian -p project -f radical.log -c 1 -m 2 mecp --multiplicity-a 2 --multiplicity-b 4
+   chemsmart sub gaussian -p project -f radical.log -c 1 -m 2 mecp --multiplicity-1 2 --multiplicity-2 4
 
 Use tight convergence (publication quality):
 

--- a/docs/source/gaussian-other-jobs.rst
+++ b/docs/source/gaussian-other-jobs.rst
@@ -388,14 +388,9 @@ MECP geometry. Temporary checkpoints are retained if verification fails.
 Output Files
 ============
 
-<<<<<<< Updated upstream
 Three output files are produced in the main job directory; Gaussian sub-job input/output files are stored in
 ``<label>_steps``. The
 third (``<label>_seam_check.log``) is written only when ``--verify-seam-minimum`` is requested:
-=======
-Three output files are produced alongside the Gaussian sub-job input/output files; the third
-(``<label>_seam_check.log``) is written only when ``--verify-seam-minimum`` is requested:
->>>>>>> Stashed changes
 
 ``<label>_report.log``
    Step-by-step optimization log. The file header records the run settings; each subsequent line reports one step, using
@@ -480,16 +475,10 @@ Add ``--verify-seam-minimum`` to the MECP command after the optimization converg
    chemsmart sub gaussian -p project -f structure.log -c 0 -m 1 mecp \
        --convergence tight --verify-seam-minimum
 
-<<<<<<< Updated upstream
 The verification requires **4 × 3N** additional Gaussian sub-jobs (2 displaced geometries × 2 spin states
 × 3N Cartesian coordinates), labelled ``<label>_check_step1_A``, ``<label>_check_step2_A``, etc. For a 10-atom molecule this is 120
 additional Gaussian calculations.  The finite-difference step size (default 1×10⁻³ Bohr) can be adjusted with
 ``--hess-step-size``.
-=======
-The verification requires **4 × 3N** additional Gaussian sub-jobs (2 displaced geometries × 2 spin states × 3N Cartesian
-coordinates), each labelled ``<label>_step900000_A`` etc. For a 10-atom molecule this is 120 additional Gaussian
-calculations. The finite-difference step size (default 1×10⁻³ Bohr) can be adjusted with ``--hess-step-size``.
->>>>>>> Stashed changes
 
 Results are written to ``<label>_seam_check.log``:
 

--- a/docs/source/gaussian-other-jobs.rst
+++ b/docs/source/gaussian-other-jobs.rst
@@ -168,12 +168,17 @@ MECP Options
    -  -  ``--step-size-min``
       -  float
       -  1.0×10⁻⁴ Bohr²/Hartree
-      -  Floor for the adaptive step size (both methods).
+      -  Floor for the adaptive step size (``bb`` and ``grow_shrink``).
 
    -  -  ``--step-size-max``
       -  float
       -  1.0 Bohr²/Hartree
-      -  Ceiling for the adaptive step size (both methods).
+      -  Ceiling for the adaptive step size (``bb`` and ``grow_shrink``).
+
+   -  -  ``--restart / --no-restart``
+      -  bool
+      -  True
+      -  Resume an interrupted MECP optimization from ``<label>_state.npz``.
 
    -  -  ``--verify-seam-minimum / --no-verify-seam-minimum``
       -  bool
@@ -288,11 +293,14 @@ Adaptive Step Size
 
 When ``--adaptive-step-size`` is enabled (the default), the step size :math:`\alpha` is updated at the end of each
 iteration. The available algorithms are selected via ``--step-size-method``.
+For the default ``harvey`` optimizer, the inverse Hessian controls the step;
+``--adaptive-step-size`` and the scalar ``step-size-*`` controls apply only to
+``bb`` and ``grow_shrink``.
 
 Barzilai-Borwein (``"bb"``)
 -----------------------------
 
-The BB2 step size is derived from the secant condition and provides near-quadratic convergence near the MECP:
+The BB step size is derived from the secant condition and accelerates convergence near the MECP:
 
 .. math::
 
@@ -301,9 +309,14 @@ The BB2 step size is derived from the secant condition and provides near-quadrat
 where :math:`\Delta\mathbf{r} = \mathbf{r}_n - \mathbf{r}_{n-1}` and :math:`\Delta\mathbf{g}_\perp =
 \mathbf{g}_{\perp,n} - \mathbf{g}_{\perp,n-1}`.
 
-The denominator is the inner product of the position change and the seam-tangent gradient change; it approximates the
-local curvature. If the curvature is non-positive (negative-curvature region or first step), the algorithm falls back to
-the initial ``step_size``. The result is clamped to ``[step_size_min, step_size_max]``.
+Before applying the secant formula, the position change is projected onto the
+current seam tangent so that it is paired consistently with the seam-tangent
+gradient change. Curvature is accepted only when its normalized magnitude is
+reliably positive. An unreliable pair damps the current step by
+``step_size_shrink`` instead of resetting it. Even a valid BB estimate is limited
+to between 0.5 and 2 times the current step before the configured
+``[step_size_min, step_size_max]`` bounds are applied. These safeguards prevent
+small secant denominators from causing abrupt jumps to ``step_size_max``.
 
 Grow-Shrink (``"grow_shrink"``)
 -------------------------------
@@ -314,10 +327,15 @@ A dimensionless merit function tracks progress:
 
    M_n = \frac{|\Delta E_n|}{\epsilon_{\Delta E}} + \frac{\text{RMS}(\mathbf{g}_{\perp,n})}{\epsilon_{\text{rms}}}
 
--  If :math:`M_n < M_{n-1}` (progress): :math:`\alpha_{n+1} = \min(\alpha_n \times \texttt{step\_size\_grow},\,
-   \texttt{step\_size\_max})`
--  If :math:`M_n \geq M_{n-1}` (stall/overshoot): :math:`\alpha_{n+1} = \max(\alpha_n \times
-   \texttt{step\_size\_shrink},\, \texttt{step\_size\_min})`
+The update uses relative merit progress rather than reacting to every numerical
+change:
+
+-  Improvement greater than 10%: grow by ``step_size_grow``.
+-  Change between a 2% regression and a 10% improvement: keep the step.
+-  Regression greater than 2%: shrink by ``step_size_shrink``.
+
+The dead band prevents small SCF and gradient fluctuations from making the step
+size oscillate.
 
 The current step size is recorded on every line of ``<label>_report.log``.
 
@@ -326,8 +344,26 @@ Harvey inverse-BFGS (``"harvey"``, default)
 
 This method follows the inverse-BFGS update used by easyMECP: it builds a full
 inverse Hessian from successive effective-gradient and Cartesian-displacement
-pairs, including negative-curvature updates, and limits the total Cartesian
-step using Harvey's ``STPMX`` rule. Numerically singular updates are skipped.
+pairs, including negative-curvature updates, and limits the largest Cartesian
+component using Harvey's ``STPMX`` rule. Numerically singular updates are skipped.
+Ill-conditioned inverse Hessians and non-descent directions are reset to the
+configured diagonal initial inverse Hessian. The corresponding
+``bfgs_status=RESET_*`` reason is recorded in the report.
+
+Restarting interrupted calculations
+====================================
+
+MECP optimization state is written atomically after every completed step to
+``<label>_state.npz``. It contains the next geometry, inverse Hessian, previous
+effective gradient, and adaptive-step history. Re-running the same job resumes
+from that state by default. The saved atom sequence and optimizer method must
+match the new invocation; otherwise ChemSmart stops with an explicit error.
+Use ``--no-restart`` to deliberately start from the supplied input geometry.
+The state file is removed after successful convergence.
+
+MECP force calculations always include ``nosymm`` so that Gaussian Cartesian
+forces remain aligned with the optimizer coordinate frame. An explicit
+conflicting ``symmetry`` route option is rejected.
 
 Like easyMECP, ChemSmart maintains one rolling checkpoint per state
 (``<label>_A.chk`` and ``<label>_B.chk``) instead of one checkpoint per

--- a/docs/source/gaussian-other-jobs.rst
+++ b/docs/source/gaussian-other-jobs.rst
@@ -287,7 +287,7 @@ Adaptive Step Size
 ==================
 
 When ``--adaptive-step-size`` is enabled (the default), the step size :math:`\alpha` is updated at the end of each
-iteration. Two algorithms are available via ``--step-size-method``.
+iteration. The available algorithms are selected via ``--step-size-method``.
 
 Barzilai-Borwein (``"bb"``, default)
 ------------------------------------
@@ -321,19 +321,41 @@ A dimensionless merit function tracks progress:
 
 The current step size is recorded on every line of ``<label>_report.log``.
 
+Harvey BFGS (``"harvey_bfgs"``)
+--------------------------------
+
+This method follows the inverse-BFGS update used by easyMECP: it builds a full
+inverse Hessian from successive effective-gradient and Cartesian-displacement
+pairs, including negative-curvature updates, and limits the total Cartesian
+step using Harvey's ``STPMX`` rule. Numerically singular updates are skipped.
+
+For non-Link calculations, each state also reads the checkpoint from its own
+previous MECP step. This preserves orbital continuity in the same way as
+``%chk`` with ``guess=read``. Like easyMECP, ChemSmart maintains one rolling
+checkpoint per state (``<label>_A.chk`` and ``<label>_B.chk``) instead of one
+checkpoint per iteration. Iteration ``.com`` and ``.log`` files and the two
+rolling checkpoints are kept in ``<label>_steps``; the report and trajectory
+remain in the main job directory.
+
+Seam-minimum verification uses a separate pair of temporary rolling
+checkpoints. They are deleted after a successful verification, so the final
+``<label>_A.chk`` and ``<label>_B.chk`` continue to represent the converged
+MECP geometry. Temporary checkpoints are retained if verification fails.
+
 Output Files
 ============
 
-Three output files are produced alongside the Gaussian sub-job input/output files; the
+Three output files are produced in the main job directory; Gaussian sub-job input/output files are stored in
+``<label>_steps``. The
 third (``<label>_seam_check.log``) is written only when ``--verify-seam-minimum`` is requested:
 
 ``<label>_report.log``
    Step-by-step optimization log. The file header records the run settings; each subsequent line reports one step, using
-   a **1-indexed** six-digit zero-padded step counter (``000001`` = first step):
+   a **1-indexed** step counter (``1`` = first step):
 
    .. code::
 
-      step=NNNNNN E_A=<Hartree> E_B=<Hartree> dE=<±Hartree>
+      step=N E_A=<Hartree> E_B=<Hartree> dE=<±Hartree>
       pgrad_max=<H/Bohr> pgrad_rms=<H/Bohr>
       disp_max=<Bohr> disp_rms=<Bohr>
       seam_max=<Bohr> seam_rms=<Bohr>
@@ -351,7 +373,7 @@ third (``<label>_seam_check.log``) is written only when ``--verify-seam-minimum`
       :math:`\mathbf{d}_\text{seam} = -(\Delta E / \|\mathbf{g}_\Delta\|^2)\,\mathbf{g}_\Delta` that
       moves the geometry toward the crossing surface.
 
-   The final line reads ``Converged at step NNNNNN.`` on successful convergence. The presence of this ``Converged``
+   The final line reads ``Converged at step N.`` on successful convergence. The presence of this ``Converged``
    marker is used by ``skip_completed`` to avoid re-running a finished job.
 
 ``<label>_traj.xyz``
@@ -413,7 +435,7 @@ Add ``--verify-seam-minimum`` to the MECP command after the optimization converg
        --convergence tight --verify-seam-minimum
 
 The verification requires **4 × 3N** additional Gaussian sub-jobs (2 displaced geometries × 2 spin states
-× 3N Cartesian coordinates), each labelled ``<label>_step900000_A`` etc.  For a 10-atom molecule this is 120
+× 3N Cartesian coordinates), labelled ``<label>_check_step1_A``, ``<label>_check_step2_A``, etc. For a 10-atom molecule this is 120
 additional Gaussian calculations.  The finite-difference step size (default 1×10⁻³ Bohr) can be adjusted with
 ``--hess-step-size``.
 
@@ -422,7 +444,7 @@ Results are written to ``<label>_seam_check.log``:
 .. code::
 
    CHEMSMART MECP seam-minimum verification
-   label=... hess_step=1.00e-03 Bohr step_prefix=900000
+   label=... hess_step=1.00e-03 Bohr check_step_start=1
    energy_diff=+1.234567e-06 Hartree n_projected=7
    n_negative_eigenvalues=0  MECP MINIMUM
 
@@ -488,10 +510,10 @@ Use the grow/shrink adaptive method instead of the default Barzilai-Borwein:
 
 .. note::
 
-   Each MECP step generates two Gaussian sub-jobs named ``<label>_step<NNNNNN>_A`` and ``<label>_step<NNNNNN>_B``
-   (single-point energy + forces), where ``<NNNNNN>`` is the **1-indexed** six-digit zero-padded step number (e.g.
-   ``000001`` for the first step, ``000010`` for the tenth). Steps are numbered starting from 1 up to ``max_steps`` (up
-   to 999 999). These sub-jobs are always re-run (``skip_completed=False``), while the outer MECP job itself honours
+   Each MECP step generates two Gaussian sub-jobs in ``<label>_steps``, named
+   ``<label>_step<N>_A`` and ``<label>_step<N>_B``
+   (single-point energy + forces), where ``<N>`` is the **1-indexed** step number (for example, ``step1`` and
+   ``step10``). These sub-jobs are always re-run (``skip_completed=False``), while the outer MECP job itself honours
    ``skip_completed`` via the ``Converged`` marker in the report file.
 
 ***********

--- a/docs/source/gaussian-other-jobs.rst
+++ b/docs/source/gaussian-other-jobs.rst
@@ -13,7 +13,7 @@ A Minimum Energy Crossing Point (MECP) is a geometry where two potential energy 
 are degenerate. It is the spin-forbidden analogue of a transition state and is relevant to intersystem crossing,
 spin-state reactivity, and organometallic reaction mechanisms.
 
-ChemSmart provides a **self-contained MECP optimizer** that drives the search entirely in Python, calling Gaussian only
+CHEMSMART provides a **self-contained MECP optimizer** that drives the search entirely in Python, calling Gaussian only
 for single-point energies and Cartesian forces at each step. No external MECP code (e.g. MECP2, Harvey's code) is
 required.
 
@@ -358,7 +358,7 @@ MECP optimization state is written atomically after every completed step to
 ``<label>_state.npz``. It contains the next geometry, inverse Hessian, previous
 effective gradient, and adaptive-step history. Re-running the same job resumes
 from that state by default. The saved atom sequence and optimizer method must
-match the new invocation; otherwise ChemSmart stops with an explicit error.
+match the new invocation; otherwise CHEMSMART stops with an explicit error.
 Use ``--no-restart`` to deliberately start from the supplied input geometry.
 The state file is removed after successful convergence.
 
@@ -366,7 +366,7 @@ MECP force calculations always include ``nosymm`` so that Gaussian Cartesian
 forces remain aligned with the optimizer coordinate frame. An explicit
 conflicting ``symmetry`` route option is rejected.
 
-Like easyMECP, ChemSmart maintains one rolling checkpoint per state
+Like easyMECP, CHEMSMART maintains one rolling checkpoint per state
 (``<label>_A.chk`` and ``<label>_B.chk``) instead of one checkpoint per
 iteration. It does not add ``guess=read`` automatically: checkpoint orbitals
 are read only when that option is explicitly present in the Gaussian route.
@@ -432,7 +432,7 @@ Seam Minimum Verification
 
 A converged MECP may be a crossing point anywhere on the crossing seam, not necessarily the **minimum energy** point on
 it. To confirm that the MECP is a true minimum on the seam (analogous to verifying a transition state has exactly one
-imaginary frequency), ChemSmart implements an effective Hessian analysis.
+imaginary frequency), CHEMSMART implements an effective Hessian analysis.
 
 Theory
 ------
@@ -442,7 +442,7 @@ direction :math:`\mathbf{g}_\Delta = \nabla E_A - \nabla E_B` take the molecule 
 directions span the seam tangent space; after further removal of translations (3) and rotations (up to 3) there are
 :math:`3N - 7` (or :math:`3N - 6` for linear molecules) internal seam degrees of freedom.
 
-ChemSmart constructs a projector that removes these constrained directions:
+CHEMSMART constructs a projector that removes these constrained directions:
 
 .. math::
 
@@ -648,7 +648,7 @@ This sets ``guess=(mix,always)`` in the route string:
  Custom User Jobs
 ******************
 
-Run custom calculations not built into Chemsmart.
+Run custom calculations not built into CHEMSMART.
 
 .. code:: bash
 

--- a/docs/source/gaussian-other-jobs.rst
+++ b/docs/source/gaussian-other-jobs.rst
@@ -66,24 +66,43 @@ MECP Options
       -  Default
       -  Description
 
+<<<<<<< Updated upstream
    -  -  ``--multiplicity-1`` / ``-m1``
+=======
+   -  -  ``--multiplicity1``
+>>>>>>> Stashed changes
       -  int
       -  1 (singlet)
       -  Spin multiplicity of state A. Falls back to ``-m`` if not set.
 
+<<<<<<< Updated upstream
    -  -  ``--multiplicity-2`` / ``-m2``
       -  int
       -  multiplicity-1 + 2
       -  Spin multiplicity of state B.
 
    -  -  ``--charge-1`` / ``-c1``
+=======
+   -  -  ``--multiplicity2``
+      -  int
+      -  multiplicity1 + 2
+      -  Spin multiplicity of state B.
+
+   -  -  ``--charge1``
+>>>>>>> Stashed changes
       -  int
       -  0
       -  Charge of state A. Falls back to ``-c`` if not set.
 
+<<<<<<< Updated upstream
    -  -  ``--charge-2`` / ``-c2``
       -  int
       -  charge-1
+=======
+   -  -  ``--charge2``
+      -  int
+      -  charge1
+>>>>>>> Stashed changes
       -  Charge of state B.
 
    -  -  ``--title-a``
@@ -507,13 +526,21 @@ Set spin states explicitly (singlet ↔ triplet):
 
 .. code:: bash
 
+<<<<<<< Updated upstream
    chemsmart sub gaussian -p project -f structure.log -c 0 -m 1 mecp --multiplicity-1 1 --multiplicity-2 3
+=======
+   chemsmart sub gaussian -p project -f structure.log -c 0 -m 1 mecp --multiplicity1 1 --multiplicity2 3
+>>>>>>> Stashed changes
 
 Doublet/quartet MECP for an open-shell cation:
 
 .. code:: bash
 
+<<<<<<< Updated upstream
    chemsmart sub gaussian -p project -f radical.log -c 1 -m 2 mecp --multiplicity-1 2 --multiplicity-2 4
+=======
+   chemsmart sub gaussian -p project -f radical.log -c 1 -m 2 mecp --multiplicity1 2 --multiplicity2 4
+>>>>>>> Stashed changes
 
 Use tight convergence (publication quality):
 

--- a/docs/source/gaussian-other-jobs.rst
+++ b/docs/source/gaussian-other-jobs.rst
@@ -66,43 +66,24 @@ MECP Options
       -  Default
       -  Description
 
-<<<<<<< Updated upstream
-   -  -  ``--multiplicity-1`` / ``-m1``
-=======
    -  -  ``--multiplicity1``
->>>>>>> Stashed changes
       -  int
       -  1 (singlet)
       -  Spin multiplicity of state A. Falls back to ``-m`` if not set.
 
-<<<<<<< Updated upstream
-   -  -  ``--multiplicity-2`` / ``-m2``
-      -  int
-      -  multiplicity-1 + 2
-      -  Spin multiplicity of state B.
-
-   -  -  ``--charge-1`` / ``-c1``
-=======
    -  -  ``--multiplicity2``
       -  int
       -  multiplicity1 + 2
       -  Spin multiplicity of state B.
 
    -  -  ``--charge1``
->>>>>>> Stashed changes
       -  int
       -  0
       -  Charge of state A. Falls back to ``-c`` if not set.
 
-<<<<<<< Updated upstream
-   -  -  ``--charge-2`` / ``-c2``
-      -  int
-      -  charge-1
-=======
    -  -  ``--charge2``
       -  int
       -  charge1
->>>>>>> Stashed changes
       -  Charge of state B.
 
    -  -  ``--title-a``
@@ -312,13 +293,12 @@ Adaptive Step Size
 ==================
 
 When ``--adaptive-step-size`` is enabled (the default), the step size :math:`\alpha` is updated at the end of each
-iteration. The available algorithms are selected via ``--step-size-method``.
-For the default ``harvey`` optimizer, the inverse Hessian controls the step;
-``--adaptive-step-size`` and the scalar ``step-size-*`` controls apply only to
-``bb`` and ``grow_shrink``.
+iteration. The available algorithms are selected via ``--step-size-method``. For the default ``harvey`` optimizer, the
+inverse Hessian controls the step; ``--adaptive-step-size`` and the scalar ``step-size-*`` controls apply only to ``bb``
+and ``grow_shrink``.
 
 Barzilai-Borwein (``"bb"``)
------------------------------
+---------------------------
 
 The BB step size is derived from the secant condition and accelerates convergence near the MECP:
 
@@ -329,14 +309,11 @@ The BB step size is derived from the secant condition and accelerates convergenc
 where :math:`\Delta\mathbf{r} = \mathbf{r}_n - \mathbf{r}_{n-1}` and :math:`\Delta\mathbf{g}_\perp =
 \mathbf{g}_{\perp,n} - \mathbf{g}_{\perp,n-1}`.
 
-Before applying the secant formula, the position change is projected onto the
-current seam tangent so that it is paired consistently with the seam-tangent
-gradient change. Curvature is accepted only when its normalized magnitude is
-reliably positive. An unreliable pair damps the current step by
-``step_size_shrink`` instead of resetting it. Even a valid BB estimate is limited
-to between 0.5 and 2 times the current step before the configured
-``[step_size_min, step_size_max]`` bounds are applied. These safeguards prevent
-small secant denominators from causing abrupt jumps to ``step_size_max``.
+Before applying the secant formula, the position change is projected onto the current seam tangent so that it is paired
+consistently with the seam-tangent gradient change. Curvature is accepted only when its normalized magnitude is reliably
+positive. An unreliable pair damps the current step by ``step_size_shrink`` instead of resetting it. Even a valid BB
+estimate is limited to between 0.5 and 2 times the current step before the configured ``[step_size_min, step_size_max]``
+bounds are applied. These safeguards prevent small secant denominators from causing abrupt jumps to ``step_size_max``.
 
 Grow-Shrink (``"grow_shrink"``)
 -------------------------------
@@ -347,69 +324,56 @@ A dimensionless merit function tracks progress:
 
    M_n = \frac{|\Delta E_n|}{\epsilon_{\Delta E}} + \frac{\text{RMS}(\mathbf{g}_{\perp,n})}{\epsilon_{\text{rms}}}
 
-The update uses relative merit progress rather than reacting to every numerical
-change:
+The update uses relative merit progress rather than reacting to every numerical change:
 
 -  Improvement greater than 10%: grow by ``step_size_grow``.
 -  Change between a 2% regression and a 10% improvement: keep the step.
 -  Regression greater than 2%: shrink by ``step_size_shrink``.
 
-The dead band prevents small SCF and gradient fluctuations from making the step
-size oscillate.
+The dead band prevents small SCF and gradient fluctuations from making the step size oscillate.
 
 The current step size is recorded on every line of ``<label>_report.log``.
 
 Harvey inverse-BFGS (``"harvey"``, default)
---------------------------------------------
+-------------------------------------------
 
-This method follows the inverse-BFGS update used by easyMECP: it builds a full
-inverse Hessian from successive effective-gradient and Cartesian-displacement
-pairs, including negative-curvature updates, and limits the largest Cartesian
-component using Harvey's ``STPMX`` rule. Numerically singular updates are skipped.
-Ill-conditioned inverse Hessians and non-descent directions are reset to the
-configured diagonal initial inverse Hessian. The corresponding
+This method follows the inverse-BFGS update used by easyMECP: it builds a full inverse Hessian from successive
+effective-gradient and Cartesian-displacement pairs, including negative-curvature updates, and limits the largest
+Cartesian component using Harvey's ``STPMX`` rule. Numerically singular updates are skipped. Ill-conditioned inverse
+Hessians and non-descent directions are reset to the configured diagonal initial inverse Hessian. The corresponding
 ``bfgs_status=RESET_*`` reason is recorded in the report.
 
 Restarting interrupted calculations
-====================================
+===================================
 
-MECP optimization state is written atomically after every completed step to
-``<label>_state.npz``. It contains the next geometry, inverse Hessian, previous
-effective gradient, and adaptive-step history. Re-running the same job resumes
-from that state by default. The saved atom sequence and optimizer method must
-match the new invocation; otherwise CHEMSMART stops with an explicit error.
-Use ``--no-restart`` to deliberately start from the supplied input geometry.
-The state file is removed after successful convergence.
+MECP optimization state is written atomically after every completed step to ``<label>_state.npz``. It contains the next
+geometry, inverse Hessian, previous effective gradient, and adaptive-step history. Re-running the same job resumes from
+that state by default. The saved atom sequence and optimizer method must match the new invocation; otherwise CHEMSMART
+stops with an explicit error. Use ``--no-restart`` to deliberately start from the supplied input geometry. The state
+file is removed after successful convergence.
 
-MECP force calculations always include ``nosymm`` so that Gaussian Cartesian
-forces remain aligned with the optimizer coordinate frame. An explicit
-conflicting ``symmetry`` route option is rejected.
+MECP force calculations always include ``nosymm`` so that Gaussian Cartesian forces remain aligned with the optimizer
+coordinate frame. An explicit conflicting ``symmetry`` route option is rejected.
 
-Like easyMECP, CHEMSMART maintains one rolling checkpoint per state
-(``<label>_A.chk`` and ``<label>_B.chk``) instead of one checkpoint per
-iteration. It does not add ``guess=read`` automatically: checkpoint orbitals
-are read only when that option is explicitly present in the Gaussian route.
-If the first step requests ``guess=read`` but its checkpoint does not yet
-exist, ``read`` is removed for that first step and retained thereafter.
-Iteration ``.com`` and ``.log`` files and the two rolling checkpoints are kept
-in ``<label>_steps``; the report and trajectory remain in the main job
+Like easyMECP, CHEMSMART maintains one rolling checkpoint per state (``<label>_A.chk`` and ``<label>_B.chk``) instead of
+one checkpoint per iteration. It does not add ``guess=read`` automatically: checkpoint orbitals are read only when that
+option is explicitly present in the Gaussian route. If the first step requests ``guess=read`` but its checkpoint does
+not yet exist, ``read`` is removed for that first step and retained thereafter. Iteration ``.com`` and ``.log`` files
+and the two rolling checkpoints are kept in ``<label>_steps``; the report and trajectory remain in the main job
 directory.
 
-When Gaussian scratch storage is enabled, MECP scratch job directories are
-also grouped below ``<label>_steps`` instead of being created directly in the
-scratch root.
+When Gaussian scratch storage is enabled, MECP scratch job directories are also grouped below ``<label>_steps`` instead
+of being created directly in the scratch root.
 
-Seam-minimum verification uses a separate pair of temporary rolling
-checkpoints. They are deleted after a successful verification, so the final
-``<label>_A.chk`` and ``<label>_B.chk`` continue to represent the converged
-MECP geometry. Temporary checkpoints are retained if verification fails.
+Seam-minimum verification uses a separate pair of temporary rolling checkpoints. They are deleted after a successful
+verification, so the final ``<label>_A.chk`` and ``<label>_B.chk`` continue to represent the converged MECP geometry.
+Temporary checkpoints are retained if verification fails.
 
 Output Files
 ============
 
 Three output files are produced in the main job directory; Gaussian sub-job input/output files are stored in
-``<label>_steps``. The
-third (``<label>_seam_check.log``) is written only when ``--verify-seam-minimum`` is requested:
+``<label>_steps``. The third (``<label>_seam_check.log``) is written only when ``--verify-seam-minimum`` is requested:
 
 ``<label>_report.log``
    Step-by-step optimization log. The file header records the run settings; each subsequent line reports one step, using
@@ -433,8 +397,8 @@ third (``<label>_seam_check.log``) is written only when ``--verify-seam-minimum`
    -  ``seam_max`` / ``seam_rms`` — max and RMS of the seam-correction component :math:`\mathbf{d}_\text{seam} =
       -(\Delta E / \|\mathbf{g}_\Delta\|^2)\,\mathbf{g}_\Delta` that moves the geometry toward the crossing surface.
 
-   The final line reads ``Converged at step N.`` on successful convergence. The presence of this ``Converged``
-   marker is used by ``skip_completed`` to avoid re-running a finished job.
+   The final line reads ``Converged at step N.`` on successful convergence. The presence of this ``Converged`` marker is
+   used by ``skip_completed`` to avoid re-running a finished job.
 
 ``<label>_traj.xyz``
    Multi-frame XYZ trajectory of the MECP geometry at every optimization step (coordinates in Ångström).
@@ -494,9 +458,9 @@ Add ``--verify-seam-minimum`` to the MECP command after the optimization converg
    chemsmart sub gaussian -p project -f structure.log -c 0 -m 1 mecp \
        --convergence tight --verify-seam-minimum
 
-The verification requires **4 × 3N** additional Gaussian sub-jobs (2 displaced geometries × 2 spin states
-× 3N Cartesian coordinates), labelled ``<label>_check_step1_A``, ``<label>_check_step2_A``, etc. For a 10-atom molecule this is 120
-additional Gaussian calculations.  The finite-difference step size (default 1×10⁻³ Bohr) can be adjusted with
+The verification requires **4 × 3N** additional Gaussian sub-jobs (2 displaced geometries × 2 spin states × 3N Cartesian
+coordinates), labelled ``<label>_check_step1_A``, ``<label>_check_step2_A``, etc. For a 10-atom molecule this is 120
+additional Gaussian calculations. The finite-difference step size (default 1×10⁻³ Bohr) can be adjusted with
 ``--hess-step-size``.
 
 Results are written to ``<label>_seam_check.log``:
@@ -526,21 +490,13 @@ Set spin states explicitly (singlet ↔ triplet):
 
 .. code:: bash
 
-<<<<<<< Updated upstream
-   chemsmart sub gaussian -p project -f structure.log -c 0 -m 1 mecp --multiplicity-1 1 --multiplicity-2 3
-=======
    chemsmart sub gaussian -p project -f structure.log -c 0 -m 1 mecp --multiplicity1 1 --multiplicity2 3
->>>>>>> Stashed changes
 
 Doublet/quartet MECP for an open-shell cation:
 
 .. code:: bash
 
-<<<<<<< Updated upstream
-   chemsmart sub gaussian -p project -f radical.log -c 1 -m 2 mecp --multiplicity-1 2 --multiplicity-2 4
-=======
    chemsmart sub gaussian -p project -f radical.log -c 1 -m 2 mecp --multiplicity1 2 --multiplicity2 4
->>>>>>> Stashed changes
 
 Use tight convergence (publication quality):
 
@@ -578,11 +534,10 @@ Use the grow/shrink adaptive method instead of the default Barzilai-Borwein:
 
 .. note::
 
-   Each MECP step generates two Gaussian sub-jobs in ``<label>_steps``, named
-   ``<label>_step<N>_A`` and ``<label>_step<N>_B``
-   (single-point energy + forces), where ``<N>`` is the **1-indexed** step number (for example, ``step1`` and
-   ``step10``). These sub-jobs are always re-run (``skip_completed=False``), while the outer MECP job itself honours
-   ``skip_completed`` via the ``Converged`` marker in the report file.
+   Each MECP step generates two Gaussian sub-jobs in ``<label>_steps``, named ``<label>_step<N>_A`` and
+   ``<label>_step<N>_B`` (single-point energy + forces), where ``<N>`` is the **1-indexed** step number (for example,
+   ``step1`` and ``step10``). These sub-jobs are always re-run (``skip_completed=False``), while the outer MECP job
+   itself honours ``skip_completed`` via the ``Converged`` marker in the report file.
 
 ***********
  Link Jobs

--- a/docs/source/gaussian-other-jobs.rst
+++ b/docs/source/gaussian-other-jobs.rst
@@ -150,9 +150,9 @@ MECP Options
 
    -  -  ``--step-size-method``
       -  string
-      -  ``"bb"``
-      -  Step size adaptation algorithm: ``"bb"`` (Barzilai-Borwein, default) or ``"grow_shrink"`` (merit-based
-         grow/shrink).
+      -  ``"harvey"``
+      -  MECP optimizer: ``"harvey"`` (inverse-BFGS, default), ``"bb"`` (Barzilai-Borwein), or ``"grow_shrink"``
+         (merit-based grow/shrink).
 
    -  -  ``--step-size-grow``
       -  float
@@ -289,8 +289,8 @@ Adaptive Step Size
 When ``--adaptive-step-size`` is enabled (the default), the step size :math:`\alpha` is updated at the end of each
 iteration. The available algorithms are selected via ``--step-size-method``.
 
-Barzilai-Borwein (``"bb"``, default)
-------------------------------------
+Barzilai-Borwein (``"bb"``)
+-----------------------------
 
 The BB2 step size is derived from the secant condition and provides near-quadratic convergence near the MECP:
 
@@ -321,8 +321,8 @@ A dimensionless merit function tracks progress:
 
 The current step size is recorded on every line of ``<label>_report.log``.
 
-Harvey BFGS (``"harvey_bfgs"``)
---------------------------------
+Harvey inverse-BFGS (``"harvey"``, default)
+--------------------------------------------
 
 This method follows the inverse-BFGS update used by easyMECP: it builds a full
 inverse Hessian from successive effective-gradient and Cartesian-displacement

--- a/tests/test_GaussianIO.py
+++ b/tests/test_GaussianIO.py
@@ -951,6 +951,8 @@ class TestGaussian16Output:
         )
         assert g16_link_sp.is_link
         assert g16_link_sp.jobtype == "sp"
+        assert g16_link_sp.spin_squared_before_annihilation == 1.005
+        assert g16_link_sp.spin_squared_after_annihilation == 0.0404
         assert len(g16_link_sp.vibrational_frequencies) == 0
         assert (
             g16_link_sp.num_vib_modes == g16_link_sp.num_vib_frequencies == 0

--- a/tests/test_gaussian_cli.py
+++ b/tests/test_gaussian_cli.py
@@ -1026,6 +1026,7 @@ class TestGaussianCLIMecpCommand:
                 "-m",
                 "2",
                 "mecp",
+<<<<<<< Updated upstream
                 "-m1",
                 "2",
                 "-m2",
@@ -1033,6 +1034,15 @@ class TestGaussianCLIMecpCommand:
                 "-c1",
                 "1",
                 "-c2",
+=======
+                "--multiplicity1",
+                "2",
+                "--multiplicity2",
+                "4",
+                "--charge1",
+                "1",
+                "--charge2",
+>>>>>>> Stashed changes
                 "1",
                 "--max-steps",
                 "120",
@@ -1253,9 +1263,15 @@ class TestGaussianCLILinkMecpCommand:
                 "link",
                 "-j",
                 "mecp",
+<<<<<<< Updated upstream
                 "--multiplicity-1",
                 "1",
                 "--multiplicity-2",
+=======
+                "--multiplicity1",
+                "1",
+                "--multiplicity2",
+>>>>>>> Stashed changes
                 "3",
             ],
             make_cli_ctx_obj(gaussian_jobrunner_no_scratch),
@@ -1273,7 +1289,11 @@ class TestGaussianCLILinkMecpCommand:
         make_cli_ctx_obj,
         run_gaussian_and_capture_settings,
     ):
+<<<<<<< Updated upstream
         """Without ``--multiplicity-2``, state 2 defaults to state 1 + 2."""
+=======
+        """Without ``--multiplicity2``, state 2 defaults to state 1 + 2."""
+>>>>>>> Stashed changes
         result, settings = run_gaussian_and_capture_settings(
             "chemsmart.jobs.gaussian.mecp.GaussianMECPJob",
             [
@@ -1288,7 +1308,11 @@ class TestGaussianCLILinkMecpCommand:
                 "link",
                 "-j",
                 "mecp",
+<<<<<<< Updated upstream
                 "--multiplicity-1",
+=======
+                "--multiplicity1",
+>>>>>>> Stashed changes
                 "1",
             ],
             make_cli_ctx_obj(gaussian_jobrunner_no_scratch),
@@ -1320,7 +1344,11 @@ class TestGaussianCLILinkMecpCommand:
                 "link",
                 "-j",
                 "mecp",
+<<<<<<< Updated upstream
                 "-m1",
+=======
+                "--multiplicity1",
+>>>>>>> Stashed changes
                 "1",
                 "--stable",
                 "qrhf",
@@ -1356,7 +1384,11 @@ class TestGaussianCLILinkMecpCommand:
                 "link",
                 "-j",
                 "mecp",
+<<<<<<< Updated upstream
                 "-m1",
+=======
+                "--multiplicity1",
+>>>>>>> Stashed changes
                 "1",
             ],
             make_cli_ctx_obj(gaussian_jobrunner_no_scratch),

--- a/tests/test_gaussian_cli.py
+++ b/tests/test_gaussian_cli.py
@@ -1134,7 +1134,7 @@ class TestGaussianCLIMecpCommand:
 
         assert result.exit_code == 0, result.output
         assert settings.adaptive_step_size is True
-        assert settings.step_size_method == "bb"
+        assert settings.step_size_method == "harvey"
         assert settings.step_size_grow == 1.2
         assert settings.step_size_shrink == 0.7
         assert settings.step_size_min == 1e-4
@@ -1168,6 +1168,64 @@ class TestGaussianCLIMecpCommand:
 
         assert result.exit_code == 0, result.output
         assert settings.step_size_method == "grow_shrink"
+
+    def test_mecp_harvey_selects_inverse_bfgs_optimizer(
+        self,
+        single_molecule_xyz_file,
+        gaussian_jobrunner_no_scratch,
+        make_cli_ctx_obj,
+        run_gaussian_and_capture_settings,
+    ):
+        """The public ``harvey`` name selects the inverse-BFGS optimizer."""
+        result, settings = run_gaussian_and_capture_settings(
+            "chemsmart.jobs.gaussian.mecp.GaussianMECPJob",
+            [
+                "-p",
+                "gas_solv",
+                "-f",
+                str(single_molecule_xyz_file),
+                "-c",
+                "0",
+                "-m",
+                "1",
+                "mecp",
+                "--step-size-method",
+                "harvey",
+            ],
+            make_cli_ctx_obj(gaussian_jobrunner_no_scratch),
+        )
+
+        assert result.exit_code == 0, result.output
+        assert settings.step_size_method == "harvey"
+
+    def test_mecp_harvey_bfgs_old_name_is_rejected(
+        self,
+        single_molecule_xyz_file,
+        gaussian_jobrunner_no_scratch,
+        make_cli_ctx_obj,
+        run_gaussian_and_capture_settings,
+    ):
+        """The removed implementation name is no longer part of the CLI."""
+        result, _ = run_gaussian_and_capture_settings(
+            "chemsmart.jobs.gaussian.mecp.GaussianMECPJob",
+            [
+                "-p",
+                "gas_solv",
+                "-f",
+                str(single_molecule_xyz_file),
+                "-c",
+                "0",
+                "-m",
+                "1",
+                "mecp",
+                "--step-size-method",
+                "harvey_bfgs",
+            ],
+            make_cli_ctx_obj(gaussian_jobrunner_no_scratch),
+        )
+
+        assert result.exit_code != 0
+        assert "Invalid value for '--step-size-method'" in result.output
 
 
 class TestGaussianCLILinkMecpCommand:

--- a/tests/test_gaussian_cli.py
+++ b/tests/test_gaussian_cli.py
@@ -983,7 +983,7 @@ class TestGaussianCLIMecpCommand:
         make_cli_ctx_obj,
         run_gaussian_and_capture_settings,
     ):
-        """Default ``multiplicity-2`` is inferred as ``multiplicity-1 + 2``."""
+        """Default ``multiplicity2`` is inferred as ``multiplicity1 + 2``."""
         result, settings = run_gaussian_and_capture_settings(
             "chemsmart.jobs.gaussian.mecp.GaussianMECPJob",
             [
@@ -1026,15 +1026,6 @@ class TestGaussianCLIMecpCommand:
                 "-m",
                 "2",
                 "mecp",
-<<<<<<< Updated upstream
-                "-m1",
-                "2",
-                "-m2",
-                "4",
-                "-c1",
-                "1",
-                "-c2",
-=======
                 "--multiplicity1",
                 "2",
                 "--multiplicity2",
@@ -1042,7 +1033,6 @@ class TestGaussianCLIMecpCommand:
                 "--charge1",
                 "1",
                 "--charge2",
->>>>>>> Stashed changes
                 "1",
                 "--max-steps",
                 "120",
@@ -1263,15 +1253,9 @@ class TestGaussianCLILinkMecpCommand:
                 "link",
                 "-j",
                 "mecp",
-<<<<<<< Updated upstream
-                "--multiplicity-1",
-                "1",
-                "--multiplicity-2",
-=======
                 "--multiplicity1",
                 "1",
                 "--multiplicity2",
->>>>>>> Stashed changes
                 "3",
             ],
             make_cli_ctx_obj(gaussian_jobrunner_no_scratch),
@@ -1289,11 +1273,7 @@ class TestGaussianCLILinkMecpCommand:
         make_cli_ctx_obj,
         run_gaussian_and_capture_settings,
     ):
-<<<<<<< Updated upstream
-        """Without ``--multiplicity-2``, state 2 defaults to state 1 + 2."""
-=======
         """Without ``--multiplicity2``, state 2 defaults to state 1 + 2."""
->>>>>>> Stashed changes
         result, settings = run_gaussian_and_capture_settings(
             "chemsmart.jobs.gaussian.mecp.GaussianMECPJob",
             [
@@ -1308,11 +1288,7 @@ class TestGaussianCLILinkMecpCommand:
                 "link",
                 "-j",
                 "mecp",
-<<<<<<< Updated upstream
-                "--multiplicity-1",
-=======
                 "--multiplicity1",
->>>>>>> Stashed changes
                 "1",
             ],
             make_cli_ctx_obj(gaussian_jobrunner_no_scratch),
@@ -1344,11 +1320,7 @@ class TestGaussianCLILinkMecpCommand:
                 "link",
                 "-j",
                 "mecp",
-<<<<<<< Updated upstream
-                "-m1",
-=======
                 "--multiplicity1",
->>>>>>> Stashed changes
                 "1",
                 "--stable",
                 "qrhf",
@@ -1384,11 +1356,7 @@ class TestGaussianCLILinkMecpCommand:
                 "link",
                 "-j",
                 "mecp",
-<<<<<<< Updated upstream
-                "-m1",
-=======
                 "--multiplicity1",
->>>>>>> Stashed changes
                 "1",
             ],
             make_cli_ctx_obj(gaussian_jobrunner_no_scratch),

--- a/tests/test_gaussian_cli.py
+++ b/tests/test_gaussian_cli.py
@@ -983,7 +983,7 @@ class TestGaussianCLIMecpCommand:
         make_cli_ctx_obj,
         run_gaussian_and_capture_settings,
     ):
-        """Default ``multiplicity-b`` is inferred as ``multiplicity-a + 2``."""
+        """Default ``multiplicity2`` is inferred as ``multiplicity1 + 2``."""
         result, settings = run_gaussian_and_capture_settings(
             "chemsmart.jobs.gaussian.mecp.GaussianMECPJob",
             [
@@ -1026,13 +1026,13 @@ class TestGaussianCLIMecpCommand:
                 "-m",
                 "2",
                 "mecp",
-                "--multiplicity-a",
+                "--m1",
                 "2",
-                "--multiplicity-b",
+                "--m2",
                 "4",
-                "--charge-a",
+                "--c1",
                 "1",
-                "--charge-b",
+                "--c2",
                 "1",
                 "--max-steps",
                 "120",
@@ -1253,9 +1253,9 @@ class TestGaussianCLILinkMecpCommand:
                 "link",
                 "-j",
                 "mecp",
-                "--multiplicity-a",
+                "--multiplicity1",
                 "1",
-                "--multiplicity-b",
+                "--multiplicity2",
                 "3",
             ],
             make_cli_ctx_obj(gaussian_jobrunner_no_scratch),
@@ -1273,7 +1273,7 @@ class TestGaussianCLILinkMecpCommand:
         make_cli_ctx_obj,
         run_gaussian_and_capture_settings,
     ):
-        """Without ``--multiplicity-b``, state B defaults to state A + 2."""
+        """Without ``--multiplicity2``, state 2 defaults to state 1 + 2."""
         result, settings = run_gaussian_and_capture_settings(
             "chemsmart.jobs.gaussian.mecp.GaussianMECPJob",
             [
@@ -1288,7 +1288,7 @@ class TestGaussianCLILinkMecpCommand:
                 "link",
                 "-j",
                 "mecp",
-                "--multiplicity-a",
+                "--multiplicity1",
                 "1",
             ],
             make_cli_ctx_obj(gaussian_jobrunner_no_scratch),
@@ -1320,7 +1320,7 @@ class TestGaussianCLILinkMecpCommand:
                 "link",
                 "-j",
                 "mecp",
-                "--multiplicity-a",
+                "--m1",
                 "1",
                 "--stable",
                 "qrhf",
@@ -1356,7 +1356,7 @@ class TestGaussianCLILinkMecpCommand:
                 "link",
                 "-j",
                 "mecp",
-                "--multiplicity-a",
+                "--m1",
                 "1",
             ],
             make_cli_ctx_obj(gaussian_jobrunner_no_scratch),

--- a/tests/test_gaussian_cli.py
+++ b/tests/test_gaussian_cli.py
@@ -983,7 +983,7 @@ class TestGaussianCLIMecpCommand:
         make_cli_ctx_obj,
         run_gaussian_and_capture_settings,
     ):
-        """Default ``multiplicity2`` is inferred as ``multiplicity1 + 2``."""
+        """Default ``multiplicity-2`` is inferred as ``multiplicity-1 + 2``."""
         result, settings = run_gaussian_and_capture_settings(
             "chemsmart.jobs.gaussian.mecp.GaussianMECPJob",
             [
@@ -1026,13 +1026,13 @@ class TestGaussianCLIMecpCommand:
                 "-m",
                 "2",
                 "mecp",
-                "--m1",
+                "-m1",
                 "2",
-                "--m2",
+                "-m2",
                 "4",
-                "--c1",
+                "-c1",
                 "1",
-                "--c2",
+                "-c2",
                 "1",
                 "--max-steps",
                 "120",
@@ -1253,9 +1253,9 @@ class TestGaussianCLILinkMecpCommand:
                 "link",
                 "-j",
                 "mecp",
-                "--multiplicity1",
+                "--multiplicity-1",
                 "1",
-                "--multiplicity2",
+                "--multiplicity-2",
                 "3",
             ],
             make_cli_ctx_obj(gaussian_jobrunner_no_scratch),
@@ -1273,7 +1273,7 @@ class TestGaussianCLILinkMecpCommand:
         make_cli_ctx_obj,
         run_gaussian_and_capture_settings,
     ):
-        """Without ``--multiplicity2``, state 2 defaults to state 1 + 2."""
+        """Without ``--multiplicity-2``, state 2 defaults to state 1 + 2."""
         result, settings = run_gaussian_and_capture_settings(
             "chemsmart.jobs.gaussian.mecp.GaussianMECPJob",
             [
@@ -1288,7 +1288,7 @@ class TestGaussianCLILinkMecpCommand:
                 "link",
                 "-j",
                 "mecp",
-                "--multiplicity1",
+                "--multiplicity-1",
                 "1",
             ],
             make_cli_ctx_obj(gaussian_jobrunner_no_scratch),
@@ -1320,7 +1320,7 @@ class TestGaussianCLILinkMecpCommand:
                 "link",
                 "-j",
                 "mecp",
-                "--m1",
+                "-m1",
                 "1",
                 "--stable",
                 "qrhf",
@@ -1356,7 +1356,7 @@ class TestGaussianCLILinkMecpCommand:
                 "link",
                 "-j",
                 "mecp",
-                "--m1",
+                "-m1",
                 "1",
             ],
             make_cli_ctx_obj(gaussian_jobrunner_no_scratch),

--- a/tests/test_mecp_bfgs.py
+++ b/tests/test_mecp_bfgs.py
@@ -1,0 +1,29 @@
+import numpy as np
+
+from chemsmart.jobs.gaussian.mecp import GaussianMECPJob
+
+
+def test_inverse_bfgs_update_satisfies_secant_condition():
+    inv_hessian = np.diag([0.7, 1.1, 1.6])
+    delta_x = np.array([0.12, -0.04, 0.08])
+    delta_g = np.array([0.20, -0.03, 0.10])
+
+    updated = GaussianMECPJob._update_inverse_hessian(
+        inv_hessian, delta_x, delta_g
+    )
+
+    np.testing.assert_allclose(updated @ delta_g, delta_x, atol=1.0e-12)
+    np.testing.assert_allclose(updated, updated.T, atol=1.0e-14)
+    assert np.all(np.linalg.eigvalsh(updated) > 0.0)
+
+
+def test_inverse_bfgs_update_skips_negative_curvature():
+    inv_hessian = np.eye(3)
+    delta_x = np.array([1.0, 0.0, 0.0])
+    delta_g = np.array([-1.0, 0.0, 0.0])
+
+    updated = GaussianMECPJob._update_inverse_hessian(
+        inv_hessian, delta_x, delta_g
+    )
+
+    np.testing.assert_array_equal(updated, inv_hessian)

--- a/tests/test_mecp_bfgs.py
+++ b/tests/test_mecp_bfgs.py
@@ -1,6 +1,49 @@
+from io import StringIO
+from types import SimpleNamespace
+
 import numpy as np
 
 from chemsmart.jobs.gaussian.mecp import GaussianMECPJob
+from chemsmart.jobs.gaussian.writer import GaussianInputWriter
+
+
+def test_gaussian_header_reuses_rolling_checkpoint():
+    job = SimpleNamespace(
+        label="mecp_step2_A",
+        chkfile="steps/mecp_A.chk",
+        oldchkfile="steps/mecp_A.chk",
+        settings=SimpleNamespace(chk=True),
+        jobrunner=SimpleNamespace(num_cores=4, mem_gb=8),
+    )
+    output = StringIO()
+
+    GaussianInputWriter(job)._write_gaussian_header(output)
+
+    assert output.getvalue().splitlines()[0] == "%chk=mecp_A.chk"
+    assert "%oldchk" not in output.getvalue().lower()
+
+
+def test_seam_checkpoint_cleanup_preserves_final_mecp_checkpoints(
+    monkeypatch,
+):
+    job = object.__new__(GaussianMECPJob)
+    job._state_checkpoint_files = {
+        (None, "A"): "mecp_A.chk",
+        (None, "B"): "mecp_B.chk",
+        ("check", "A"): "mecp_check_A.chk",
+        ("check", "B"): "mecp_check_B.chk",
+    }
+    removed = []
+    monkeypatch.setattr("os.path.isfile", lambda path: True)
+    monkeypatch.setattr("os.remove", removed.append)
+
+    job._remove_checkpoint_set("check")
+
+    assert removed == ["mecp_check_A.chk", "mecp_check_B.chk"]
+    assert job._state_checkpoint_files == {
+        (None, "A"): "mecp_A.chk",
+        (None, "B"): "mecp_B.chk",
+    }
 
 
 def test_inverse_bfgs_update_satisfies_secant_condition():
@@ -17,10 +60,23 @@ def test_inverse_bfgs_update_satisfies_secant_condition():
     assert np.all(np.linalg.eigvalsh(updated) > 0.0)
 
 
-def test_inverse_bfgs_update_skips_negative_curvature():
+def test_inverse_bfgs_update_accepts_negative_curvature_like_easymecp():
     inv_hessian = np.eye(3)
     delta_x = np.array([1.0, 0.0, 0.0])
     delta_g = np.array([-1.0, 0.0, 0.0])
+
+    updated = GaussianMECPJob._update_inverse_hessian(
+        inv_hessian, delta_x, delta_g
+    )
+
+    np.testing.assert_allclose(updated @ delta_g, delta_x)
+    assert np.linalg.eigvalsh(updated).min() < 0.0
+
+
+def test_inverse_bfgs_update_skips_singular_secant_pair():
+    inv_hessian = np.eye(3)
+    delta_x = np.zeros(3)
+    delta_g = np.ones(3)
 
     updated = GaussianMECPJob._update_inverse_hessian(
         inv_hessian, delta_x, delta_g

--- a/tests/test_mecp_bfgs.py
+++ b/tests/test_mecp_bfgs.py
@@ -297,6 +297,80 @@ def test_harvey_optimizer_converges_on_analytic_crossing(swap_states):
     np.testing.assert_allclose(positions, np.zeros((1, 3)), atol=1.0e-5)
 
 
+def _adaptive_step_job():
+    job = object.__new__(GaussianMECPJob)
+    job.settings = SimpleNamespace(
+        step_size=0.1,
+        step_size_grow=1.2,
+        step_size_shrink=0.5,
+        step_size_min=1.0e-4,
+        step_size_max=1.0,
+    )
+    return job
+
+
+@pytest.mark.parametrize(
+    ("previous_merit", "current_merit", "expected"),
+    [
+        (100.0, 80.0, 0.12),
+        (100.0, 95.0, 0.10),
+        (100.0, 101.0, 0.10),
+        (100.0, 103.0, 0.05),
+    ],
+)
+def test_grow_shrink_uses_relative_dead_band(
+    previous_merit, current_merit, expected
+):
+    job = _adaptive_step_job()
+
+    step = job._adapt_step_size(0.1, previous_merit, current_merit)
+
+    assert step == pytest.approx(expected)
+
+
+def test_bb_step_limits_abrupt_growth():
+    job = _adaptive_step_job()
+
+    step = job._bb_step_size(
+        0.1,
+        np.array([[0.0, 0.0, 0.0]]),
+        np.array([[1.0, 0.0, 0.0]]),
+        np.array([[0.0, 0.0, 0.0]]),
+        np.array([[0.1, 0.0, 0.0]]),
+    )
+
+    assert step == pytest.approx(0.2)
+
+
+def test_bb_step_damps_unreliable_curvature():
+    job = _adaptive_step_job()
+
+    step = job._bb_step_size(
+        0.1,
+        np.array([[0.0, 0.0, 0.0]]),
+        np.array([[1.0, 0.0, 0.0]]),
+        np.array([[0.0, 0.0, 0.0]]),
+        np.array([[-1.0, 0.0, 0.0]]),
+    )
+
+    assert step == pytest.approx(0.05)
+
+
+def test_bb_step_uses_only_seam_tangent_displacement():
+    job = _adaptive_step_job()
+
+    step = job._bb_step_size(
+        0.4,
+        np.array([[0.0, 0.0, 0.0]]),
+        np.array([[10.0, 1.0, 0.0]]),
+        np.array([[0.0, 0.0, 0.0]]),
+        np.array([[0.0, 2.0, 0.0]]),
+        np.array([[1.0, 0.0, 0.0]]),
+    )
+
+    assert step == pytest.approx(0.5)
+
+
 @pytest.mark.parametrize(
     ("label", "method", "expected"),
     [

--- a/tests/test_mecp_bfgs.py
+++ b/tests/test_mecp_bfgs.py
@@ -3,8 +3,10 @@ import os
 from types import SimpleNamespace
 
 import numpy as np
+import pytest
 
 from chemsmart.jobs.gaussian.mecp import GaussianMECPJob
+from chemsmart.jobs.gaussian.settings import GaussianMECPJobSettings
 from chemsmart.jobs.gaussian.runner import GaussianJobRunner
 from chemsmart.jobs.gaussian.writer import GaussianInputWriter
 
@@ -107,3 +109,8 @@ def test_inverse_bfgs_update_skips_singular_secant_pair():
     )
 
     np.testing.assert_array_equal(updated, inv_hessian)
+
+
+def test_removed_harvey_bfgs_setting_is_rejected():
+    with pytest.raises(ValueError, match="Unknown MECP step_size_method"):
+        GaussianMECPJobSettings(step_size_method="harvey_bfgs")

--- a/tests/test_mecp_bfgs.py
+++ b/tests/test_mecp_bfgs.py
@@ -1,10 +1,20 @@
 from io import StringIO
+import os
 from types import SimpleNamespace
 
 import numpy as np
 
 from chemsmart.jobs.gaussian.mecp import GaussianMECPJob
+from chemsmart.jobs.gaussian.runner import GaussianJobRunner
 from chemsmart.jobs.gaussian.writer import GaussianInputWriter
+
+
+def test_first_mecp_step_removes_unavailable_guess_read():
+    remove_read = GaussianMECPJob._without_unavailable_guess_read
+
+    assert remove_read("scf=xqc guess=read nosymm") == "scf=xqc nosymm"
+    assert remove_read("guess=(mix,read) nosymm") == "guess=(mix) nosymm"
+    assert remove_read("scf=xqc nosymm") == "scf=xqc nosymm"
 
 
 def test_gaussian_header_reuses_rolling_checkpoint():
@@ -44,6 +54,20 @@ def test_seam_checkpoint_cleanup_preserves_final_mecp_checkpoints(
         (None, "A"): "mecp_A.chk",
         (None, "B"): "mecp_B.chk",
     }
+
+
+def test_mecp_scratch_jobs_are_grouped_in_steps_folder():
+    runner = object.__new__(GaussianJobRunner)
+    runner._scratch_dir = "/scratch/project"
+    job = SimpleNamespace(
+        label="mecp_step2_A", scratch_parent_folder="mecp_steps"
+    )
+
+    scratch_directory = runner._scratch_job_directory(job)
+
+    assert scratch_directory == os.path.join(
+        "/scratch/project", "mecp_steps", "mecp_step2_A"
+    )
 
 
 def test_inverse_bfgs_update_satisfies_secant_condition():

--- a/tests/test_mecp_bfgs.py
+++ b/tests/test_mecp_bfgs.py
@@ -1,13 +1,17 @@
-from io import StringIO
 import os
+from io import StringIO
+from pathlib import Path
 from types import SimpleNamespace
 
 import numpy as np
 import pytest
 
+from chemsmart.cli.gaussian.mecp_options import add_mecp_method_suffix
+
+from chemsmart.io.gaussian.output import Gaussian16Output
 from chemsmart.jobs.gaussian.mecp import GaussianMECPJob
-from chemsmart.jobs.gaussian.settings import GaussianMECPJobSettings
 from chemsmart.jobs.gaussian.runner import GaussianJobRunner
+from chemsmart.jobs.gaussian.settings import GaussianMECPJobSettings
 from chemsmart.jobs.gaussian.writer import GaussianInputWriter
 
 
@@ -17,6 +21,25 @@ def test_first_mecp_step_removes_unavailable_guess_read():
     assert remove_read("scf=xqc guess=read nosymm") == "scf=xqc nosymm"
     assert remove_read("guess=(mix,read) nosymm") == "guess=(mix) nosymm"
     assert remove_read("scf=xqc nosymm") == "scf=xqc nosymm"
+
+
+def test_mecp_requires_nosymm_for_force_alignment():
+    ensure_nosymm = GaussianMECPJob._with_required_nosymm
+
+    assert ensure_nosymm("scf=xqc") == "scf=xqc nosymm"
+    assert ensure_nosymm("NoSymm scf=xqc") == "NoSymm scf=xqc"
+    with pytest.raises(ValueError, match="requires nosymm"):
+        ensure_nosymm("symmetry=loose")
+
+
+def test_gaussian_spin_squared_parser_returns_final_annihilated_value():
+    output = object.__new__(Gaussian16Output)
+    output.__dict__["contents"] = [
+        "S**2 before annihilation     2.1040, after     2.0060",
+        "S**2 before annihilation     2.0550, after     2.0015",
+    ]
+
+    assert output.spin_squared == pytest.approx(2.0015)
 
 
 def test_gaussian_header_reuses_rolling_checkpoint():
@@ -114,3 +137,173 @@ def test_inverse_bfgs_update_skips_singular_secant_pair():
 def test_removed_harvey_bfgs_setting_is_rejected():
     with pytest.raises(ValueError, match="Unknown MECP step_size_method"):
         GaussianMECPJobSettings(step_size_method="harvey_bfgs")
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"max_steps": 0},
+        {"hess_step_size": 0.0},
+        {"step_size_min": 2.0, "step_size_max": 1.0},
+        {"multiplicity_a": 0},
+        {"multiplicity_a": 1, "multiplicity_b": 1},
+    ],
+)
+def test_invalid_mecp_settings_are_rejected(kwargs):
+    with pytest.raises(ValueError):
+        GaussianMECPJobSettings(**kwargs)
+
+
+def test_reduced_hessian_preserves_negative_seam_curvature():
+    hessian = np.diag([-2.0, 0.0, 3.0])
+    projected = [np.array([0.0, 1.0, 0.0])]
+
+    reduced = GaussianMECPJob._reduced_hessian(hessian, projected)
+    eigenvalues = np.linalg.eigvalsh(reduced)
+
+    np.testing.assert_allclose(eigenvalues, [-2.0, 3.0], atol=1.0e-12)
+
+
+def test_lagrangian_hessian_weight_is_not_forced_to_average():
+    grad_a = np.array([2.0, 0.0])
+    grad_b = np.array([-1.0, 0.0])
+    hessian_a = np.diag([1.0, 2.0])
+    hessian_b = np.diag([4.0, 8.0])
+    hessian, multiplier = GaussianMECPJob._lagrangian_hessian(
+        hessian_a, hessian_b, grad_a, grad_b
+    )
+
+    assert multiplier == pytest.approx(2.0 / 3.0)
+    np.testing.assert_allclose(
+        hessian, (1.0 / 3.0) * hessian_a + (2.0 / 3.0) * hessian_b
+    )
+
+
+def test_optimizer_state_round_trip(tmp_path):
+    job = object.__new__(GaussianMECPJob)
+    job.folder = str(tmp_path)
+    job.label = "restartable"
+    job.molecule = SimpleNamespace(
+        symbols=["H", "H"], positions=np.zeros((2, 3))
+    )
+    job.settings = SimpleNamespace(step_size_method="harvey")
+    positions = np.arange(6, dtype=float).reshape(2, 3)
+    inverse_hessian = np.eye(6)
+
+    job._save_optimizer_state(
+        next_step=12,
+        positions_bohr=positions,
+        current_step_size=0.1,
+        prev_merit=None,
+        prev_positions=None,
+        prev_proj_grad=None,
+        inv_hessian=inverse_hessian,
+        prev_eff_grad=np.ones(6),
+        prev_positions_bfgs=positions - 0.1,
+    )
+    restored = job._load_optimizer_state()
+
+    assert restored["next_step"] == 12
+    assert restored["prev_merit"] is None
+    assert restored["prev_positions"] is None
+    np.testing.assert_array_equal(restored["positions_bohr"], positions)
+    np.testing.assert_array_equal(restored["inv_hessian"], inverse_hessian)
+
+
+def test_optimizer_state_rejects_method_change(tmp_path):
+    job = object.__new__(GaussianMECPJob)
+    job.folder = str(tmp_path)
+    job.label = "restartable"
+    job.molecule = SimpleNamespace(symbols=["H"], positions=np.zeros((1, 3)))
+    job.settings = SimpleNamespace(step_size_method="harvey")
+    job._save_optimizer_state(
+        next_step=2,
+        positions_bohr=np.zeros((1, 3)),
+        current_step_size=0.1,
+        prev_merit=None,
+        prev_positions=None,
+        prev_proj_grad=None,
+        inv_hessian=np.eye(3),
+        prev_eff_grad=np.zeros(3),
+        prev_positions_bfgs=np.zeros((1, 3)),
+    )
+    job.settings.step_size_method = "bb"
+
+    with pytest.raises(RuntimeError, match="optimizer method differs"):
+        job._load_optimizer_state()
+
+
+def test_job_is_complete_requires_post_verification_marker(tmp_path):
+    job = object.__new__(GaussianMECPJob)
+    job.folder = str(tmp_path)
+    job.label = "verified"
+    report = Path(job.report_file)
+    report.write_text("Optimization converged at step 8.\n", encoding="utf-8")
+
+    assert job._job_is_complete() is False
+
+    report.write_text("Converged at step 8.\n", encoding="utf-8")
+    assert job._job_is_complete() is True
+
+
+@pytest.mark.parametrize("swap_states", [False, True])
+def test_harvey_optimizer_converges_on_analytic_crossing(swap_states):
+    job = object.__new__(GaussianMECPJob)
+    job.settings = GaussianMECPJobSettings()
+    positions = np.array([[0.7, 1.0, 0.0]])
+    prev_positions = None
+    prev_gradient = None
+    inverse_hessian = None
+
+    for _ in range(100):
+        x, y, _ = positions[0]
+        energy_a = 0.5 * ((x - 1.0) ** 2 + y**2)
+        energy_b = 0.5 * ((x + 1.0) ** 2 + y**2)
+        gradient_a = np.array([[x - 1.0, y, 0.0]])
+        gradient_b = np.array([[x + 1.0, y, 0.0]])
+        if swap_states:
+            energy_a, energy_b = energy_b, energy_a
+            gradient_a, gradient_b = gradient_b, gradient_a
+
+        (
+            displacement,
+            effective_gradient,
+            _,
+            inverse_hessian,
+            _,
+            _,
+            _,
+            optimizer_gradient,
+        ) = job._bfgs_displacement(
+            energy_a,
+            energy_b,
+            gradient_a,
+            gradient_b,
+            prev_positions,
+            positions,
+            prev_gradient,
+            inverse_hessian,
+        )
+        if job._is_converged(
+            energy_a - energy_b, effective_gradient, displacement
+        ):
+            break
+        prev_positions = positions.copy()
+        prev_gradient = optimizer_gradient.ravel().copy()
+        positions = positions + displacement
+    else:
+        pytest.fail("Harvey optimizer did not converge on analytic surfaces")
+
+    np.testing.assert_allclose(positions, np.zeros((1, 3)), atol=1.0e-5)
+
+
+@pytest.mark.parametrize(
+    ("label", "method", "expected"),
+    [
+        ("sample", "bb", "sample_bb_mecp"),
+        ("sample_mecp", "grow_shrink", "sample_grow_shrink_mecp"),
+        ("sample_harvey_mecp", "harvey", "sample_harvey_mecp"),
+    ],
+)
+def test_add_mecp_method_suffix(label, method, expected):
+    assert add_mecp_method_suffix(label, method) == expected

--- a/tests/test_mecp_bfgs.py
+++ b/tests/test_mecp_bfgs.py
@@ -7,7 +7,6 @@ import numpy as np
 import pytest
 
 from chemsmart.cli.gaussian.mecp_options import add_mecp_method_suffix
-
 from chemsmart.io.gaussian.output import Gaussian16Output
 from chemsmart.jobs.gaussian.mecp import GaussianMECPJob
 from chemsmart.jobs.gaussian.runner import GaussianJobRunner
@@ -16,7 +15,7 @@ from chemsmart.jobs.gaussian.writer import GaussianInputWriter
 
 
 def test_first_mecp_step_removes_unavailable_guess_read():
-    remove_read = GaussianMECPJob._without_unavailable_guess_read
+    remove_read = GaussianMECPJob._route_without_guess_read
 
     assert remove_read("scf=xqc guess=read nosymm") == "scf=xqc nosymm"
     assert remove_read("guess=(mix,read) nosymm") == "guess=(mix) nosymm"
@@ -32,14 +31,15 @@ def test_mecp_requires_nosymm_for_force_alignment():
         ensure_nosymm("symmetry=loose")
 
 
-def test_gaussian_spin_squared_parser_returns_final_annihilated_value():
+def test_gaussian_spin_squared_parser_returns_final_values():
     output = object.__new__(Gaussian16Output)
     output.__dict__["contents"] = [
         "S**2 before annihilation     2.1040, after     2.0060",
         "S**2 before annihilation     2.0550, after     2.0015",
     ]
 
-    assert output.spin_squared == pytest.approx(2.0015)
+    assert output.spin_squared_before_annihilation == pytest.approx(2.0550)
+    assert output.spin_squared_after_annihilation == pytest.approx(2.0015)
 
 
 def test_gaussian_header_reuses_rolling_checkpoint():


### PR DESCRIPTION
This PR improves the Gaussian MECP workflow with a more robust optimization implementation, restart support, safer checkpoint handling, clearer CLI options, and expanded tests and documentation.

The Harvey inverse-BFGS optimizer is now the default MECP optimization method. The existing Barzilai–Borwein and grow/shrink methods remain available for comparison and fallback use.

